### PR TITLE
Fix: Filter age groups to show only those with teams

### DIFF
--- a/frontend/src/components/ScoresSchedule.vue
+++ b/frontend/src/components/ScoresSchedule.vue
@@ -67,7 +67,7 @@
               class="grid grid-cols-2 sm:grid-cols-3 lg:flex lg:flex-wrap gap-2"
             >
               <button
-                v-for="ageGroup in ageGroups"
+                v-for="ageGroup in filteredAgeGroups"
                 :key="ageGroup.id"
                 @click="selectedAgeGroupId = ageGroup.id"
                 :class="[
@@ -689,6 +689,20 @@ export default {
       return 'grid-cols-1 md:grid-cols-3';
     };
 
+    // Filter age groups to only show those that have teams
+    const filteredAgeGroups = computed(() => {
+      // Get unique age group IDs from teams
+      const teamAgeGroupIds = new Set();
+      teams.value.forEach(team => {
+        if (team.age_groups && Array.isArray(team.age_groups)) {
+          team.age_groups.forEach(ag => teamAgeGroupIds.add(ag.id));
+        }
+      });
+
+      // Filter age groups to only those with teams
+      return ageGroups.value.filter(ag => teamAgeGroupIds.has(ag.id));
+    });
+
     // Filter teams based on selected age group
     const filteredTeams = computed(() => {
       return teams.value.filter(team => {
@@ -943,6 +957,7 @@ export default {
       games,
       sortedGames,
       ageGroups,
+      filteredAgeGroups,
       seasons,
       gameTypes,
       selectedTeam,


### PR DESCRIPTION
## Problem

The age group filter was showing all 6 age groups (U13, U14, U15, U16, U17, U19) even when only one had teams. For example, IFA only has U14 teams, but all 6 buttons were displayed.

![image](https://github.com/user-attachments/assets/...)

## Solution

Created `filteredAgeGroups` computed property that:
- Scans all teams to find which age groups have teams
- Filters the age groups list to only show relevant ones
- Uses same pattern as existing `filteredTeams` functionality

## Result

✅ IFA team now shows only "U14" button
✅ Cleaner, more intuitive UI  
✅ Consistent with team filtering behavior

## Testing

- Tested with IFA team (U14 only)
- Verified only U14 button appears
- Tested team switching still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Age-group filter now shows only groups with at least one team, reducing clutter and avoiding empty selections in Scores & Schedule.
  - Improved filtering logic ensures users see relevant options, streamlining navigation and selection.

- Bug Fixes
  - Prevents display of age groups that produce no results, reducing confusion and dead ends in the filter UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->