### PR TITLE
Enhanced match deduplication with fallback lookup

### DIFF
--- a/backend/celery_tasks/match_tasks.py
+++ b/backend/celery_tasks/match_tasks.py
@@ -194,11 +194,43 @@ def process_match_data(self: DatabaseTask, match_data: Dict[str, Any]) -> Dict[s
             logger.warning(f"Away team not found: {away_team_name}. Creating placeholder.")
             raise ValueError(f"Team not found: {away_team_name}")
 
-        # Step 3: Check if match already exists (by external ID)
+        # Step 3: Check if match already exists
         external_match_id = match_data.get('external_match_id')
         existing_match = None
+
+        # First try: Look up by external ID (fast path for previously scraped matches)
         if external_match_id:
             existing_match = self.dao.get_match_by_external_id(external_match_id)
+            logger.debug(f"Lookup by external_match_id '{external_match_id}': {'found' if existing_match else 'not found'}")
+
+        # Second try: Fallback to lookup by teams + date (for manually-entered matches)
+        if not existing_match:
+            existing_match = self.dao.get_match_by_teams_and_date(
+                home_team_id=home_team['id'],
+                away_team_id=away_team['id'],
+                match_date=match_data['match_date']
+            )
+
+            if existing_match:
+                logger.info(
+                    f"Found manually-entered match via fallback lookup: "
+                    f"{home_team_name} vs {away_team_name} on {match_data['match_date']}"
+                )
+
+                # If found a match without external_match_id, populate it
+                if external_match_id and not existing_match.get('match_id'):
+                    logger.info(f"Populating match_id '{external_match_id}' on existing match {existing_match['id']}")
+                    success = self.dao.update_match_external_id(
+                        match_id=existing_match['id'],
+                        external_match_id=external_match_id
+                    )
+                    if success:
+                        # Update the existing_match dict to reflect the new match_id
+                        existing_match['match_id'] = external_match_id
+                        existing_match['source'] = 'match-scraper'
+                        logger.info(f"Successfully populated match_id on match {existing_match['id']}")
+                    else:
+                        logger.warning(f"Failed to populate match_id on match {existing_match['id']}")
 
         # Step 4: Insert or update match
         if existing_match:


### PR DESCRIPTION
## Summary

This PR enhances the match deduplication logic to handle manually-entered matches that don't have an external `match_id` populated from the match-scraper.

## Problem

When admins manually enter matches in the UI, they don't have an external `match_id` field populated. When the match-scraper later scrapes the same match:
- Worker looks up by `external_match_id` only
- Manual match is not found (has NULL `match_id`)
- Worker creates a **duplicate match** ❌

## Solution

Implemented a **two-tier lookup strategy**:

1. **Fast Path**: Lookup by `external_match_id` (for previously scraped matches)
2. **Fallback**: Lookup by `home_team_id + away_team_id + match_date` (for manual entries)

When a manual match is found via fallback:
- Worker populates the `match_id` field with the external ID
- Updates `source` field to `"match-scraper"` 
- Future scrapes use the fast path (no duplicate created)

## Changes

### New DAO Methods (`backend/dao/enhanced_data_access_fixed.py`)

**`get_match_by_teams_and_date()`**
- Looks up matches by home team, away team, and date
- Used as fallback when external_match_id lookup fails
- Returns same flattened structure as other match lookup methods

**`update_match_external_id()`**
- Updates only the `match_id` and `source` fields
- Used to populate external match ID on manually-entered matches
- Preserves all other match data

### Enhanced Worker Logic (`backend/celery_tasks/match_tasks.py`)

Updated `process_match_data` task with two-tier lookup:
- Lines 201-204: Fast path lookup by external_match_id
- Lines 207-233: Fallback lookup by teams + date with automatic match_id population

## Use Case Example

**Before (Broken):**
```
1. Admin manually enters: "Bayside FC vs IFA on 10/17/2025" (match_id: NULL)
2. Scraper finds same match with external_match_id "98966"
3. Worker only looks up by external_match_id → Not found
4. Worker creates NEW match → DUPLICATE ❌
```

**After (Fixed):**
```
1. Admin manually enters: "Bayside FC vs IFA on 10/17/2025" (match_id: NULL)
2. Scraper finds same match with external_match_id "98966"
3. Worker looks up by external_match_id → Not found
4. Worker falls back to teams + date lookup → Found!
5. Worker populates match_id="98966" and source="match-scraper"
6. Worker updates scores if needed → Single match ✅
```

**Future Scrapes (Optimized):**
```
1. Scraper runs again for same match
2. Worker looks up by external_match_id "98966" → Found immediately
3. Worker updates scores → Fast, efficient ✅
```

## Testing

- ✅ Code deployed to GKE (`missing-table-celery-worker` with 2 replicas)
- ✅ New methods added to DAO
- ✅ Worker logic enhanced with fallback lookup
- ✅ Ready for integration testing with manually-entered matches

## Related Issues

Fixes the issue where manually-entered matches cause duplicates when the match-scraper processes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds fallback match detection by home/away teams and date when an external ID isn’t available.
  * Automatically links detected matches to external IDs for future synchronization and updates.

* **Bug Fixes**
  * Reduces duplicate or orphaned matches by reliably matching existing games without an external ID.
  * Ensures updates (scores, status, details) apply to the correct match, improving data consistency across sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->