### PR TITLE
fix: Add CORS origins for all domains after infrastructure consolidation

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -306,6 +306,8 @@ jobs:
               logLevel: "info"
               disableLogfire: "true"
               disableSecurity: "true"
+              extra:
+                CORS_ORIGINS: "${{ inputs.cors_origins }}"
             resources:
               requests:
                 memory: "${{ inputs.backend_resources_requests_memory }}"
@@ -371,15 +373,6 @@ jobs:
               - missingtable.com
               - www.missingtable.com
           EOF
-
-          # Add CORS origins if provided
-          if [ -n "${{ inputs.cors_origins }}" ]; then
-            cat >> helm/missing-table/values-${{ inputs.environment }}.yaml << EOF
-
-          cors:
-            origins: "${{ inputs.cors_origins }}"
-          EOF
-          fi
 
           echo "✅ Helm values file created"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,7 @@ jobs:
       enable_git_tag: ${{ github.ref == 'refs/heads/main' && github.event.inputs.create_git_tag != 'false' }}  # Only tag main branch
       enable_pr_comment: true  # Comment on PRs
       skip_tests: ${{ github.event.inputs.skip_tests == 'true' }}
+      cors_origins: 'https://dev.missingtable.com,https://missingtable.com,https://www.missingtable.com'
       backend_resources_requests_cpu: '250m'
       backend_resources_requests_memory: '256Mi'
       backend_resources_limits_cpu: '500m'

--- a/helm/missing-table/values-dev.yaml.example
+++ b/helm/missing-table/values-dev.yaml.example
@@ -41,7 +41,8 @@ backend:
     disableSecurity: "true"
     extra:
       # CORS configuration (non-sensitive)
-      CORS_ORIGINS: "http://34.133.125.204:8080,https://dev.missingtable.com"
+      # All domains point to missing-table-dev namespace after infrastructure consolidation
+      CORS_ORIGINS: "http://34.133.125.204:8080,https://dev.missingtable.com,https://missingtable.com,https://www.missingtable.com"
 
   resources:
     requests:


### PR DESCRIPTION
## Problem
After infrastructure consolidation (#66), all domains point to the same backend in `missing-table-dev` namespace:
- ✅ dev.missingtable.com
- ❌ missingtable.com  
- ❌ www.missingtable.com

Login works on dev.missingtable.com but fails on missingtable.com and www.missingtable.com due to CORS rejection.

## Root Cause
The backend CORS configuration only allowed `dev.missingtable.com` because:
1. GitHub Actions workflow wasn't passing `CORS_ORIGINS` env var
2. Backend defaulted to development mode CORS (only dev domain)
3. Production domains (missingtable.com, www.missingtable.com) were rejected

## Solution
This PR fixes the CORS configuration in three places:

### 1. `.github/workflows/deploy.yml`
Added `cors_origins` parameter with all three domains

### 2. `.github/workflows/deploy-reusable.yml`
Fixed Helm values generation to properly set `backend.env.extra.CORS_ORIGINS`

### 3. `helm/missing-table/values-dev.yaml.example`
Updated documentation to show all three domains in CORS config.

## Testing Plan
After merge:
1. GitHub Actions will automatically deploy with new CORS configuration
2. Backend will receive `CORS_ORIGINS` env var with all three domains
3. Test login on all three domains

## Verification Commands
```bash
# After deployment, verify CORS_ORIGINS is set
kubectl get deployment missing-table-backend -n missing-table-dev -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CORS_ORIGINS")].value}'

# Test health endpoints
curl -I https://dev.missingtable.com/health
curl -I https://missingtable.com/health  
curl -I https://www.missingtable.com/health
```

## Files Changed
- `.github/workflows/deploy.yml` - Added cors_origins parameter
- `.github/workflows/deploy-reusable.yml` - Fixed backend.env.extra.CORS_ORIGINS
- `helm/missing-table/values-dev.yaml.example` - Updated CORS documentation

## Related Issues
- Fixes login issues on missingtable.com and www.missingtable.com
- Related to infrastructure consolidation (#66)
