### PR TITLE
fix: Frontend environment detection and API URL configuration

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -200,15 +200,17 @@ build_service() {
         # Add service-specific build arguments
         if [ "$service" = "frontend" ]; then
             # Set API URL based on environment
-            if [ "$env" = "dev" ]; then
-                API_URL="https://dev.missingtable.com"
-            elif [ "$env" = "prod" ]; then
-                API_URL="https://missingtable.com"
+            # For cloud deployments (dev/prod), use empty string for relative URLs
+            # Ingress routes /api to backend on same domain
+            if [ "$env" = "dev" ] || [ "$env" = "prod" ]; then
+                API_URL=""
+                print_info "Setting VUE_APP_API_URL='' (relative URLs for ingress routing)"
             else
+                # Local development uses localhost backend
                 API_URL="http://localhost:8000"
+                print_info "Setting VUE_APP_API_URL=${API_URL}"
             fi
 
-            print_info "Setting VUE_APP_API_URL=${API_URL}"
             build_args+=" --build-arg VUE_APP_API_URL=${API_URL}"
             build_args+=" --build-arg VUE_APP_VERSION=${APP_VERSION}"
         fi


### PR DESCRIPTION
## Problem
The footer was showing incorrect information on all domains:
- 🔴 "Unknown" version and "Error" status
- 🔴 "DEV" environment badge on missingtable.com (should show "PROD")
- 🔴 Cross-origin API call failures

## Root Cause
**1. Hardcoded API URLs in build-and-push.sh:**
- Dev builds → `https://dev.missingtable.com`
- Prod builds → `https://missingtable.com`
- When accessing missingtable.com, frontend tried to call dev.missingtable.com API (cross-origin)

**2. Environment from API response:**
- All domains point to same backend with `ENVIRONMENT=dev`
- VersionFooter showed "dev" for all domains, including missingtable.com

## Solution

### 1. VersionFooter.vue - Hostname-based Environment Detection
Determines environment from current domain instead of API:
- `localhost` / `127.0.0.1` → **"local"**
- `dev.missingtable.com` → **"dev"**
- `missingtable.com` / `www.missingtable.com` → **"production"**
- Uses relative URL `/api/version` (no more cross-origin calls)

### 2. build-and-push.sh - Relative API URLs
```bash
# Cloud deployments (dev/prod)
VUE_APP_API_URL=""  # Empty = relative URLs via ingress

# Local development
VUE_APP_API_URL="http://localhost:8000"
```

## Benefits
- ✅ Correct environment badge per domain
- ✅ Version and status display correctly
- ✅ Single Docker image works for all domains
- ✅ No CORS issues
- ✅ Simpler architecture (ingress-based routing)

## Testing Plan
After merge, verify footer shows:
- **dev.missingtable.com** → Version number, "DEV" badge, green status
- **missingtable.com** → Version number, no badge (production), green status
- **www.missingtable.com** → Version number, no badge (production), green status
- **localhost:8080** → Version number, "LOCAL" badge, green status

## Files Changed
- `frontend/src/components/VersionFooter.vue` - Environment from hostname
- `build-and-push.sh` - Relative URLs for cloud builds

## Related Issues
- Fixes "Unknown" and "Error" in footer
- Fixes incorrect "DEV" badge on production domain
- Related to infrastructure consolidation (#66, #70)
