### PR TITLE
feat: Add invite request backend with honeypot protection

### DIFF
--- a/backend/api/invite_requests.py
+++ b/backend/api/invite_requests.py
@@ -1,0 +1,314 @@
+"""
+Invite Request API endpoints for Missing Table
+
+Handles public invite request submissions and admin management.
+"""
+
+import os
+import sys
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, EmailStr, Field
+from supabase import create_client
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from auth import get_current_user_required
+from dao.enhanced_data_access_fixed import SupabaseConnection as DbConnectionHolder
+
+# Initialize database connection with service role for admin operations
+supabase_url = os.getenv('SUPABASE_URL', '')
+service_key = os.getenv('SUPABASE_SERVICE_KEY')
+
+# Create service role client for operations that bypass RLS
+if service_key:
+    service_client = create_client(supabase_url, service_key)
+else:
+    # Fallback to regular connection if service key not available
+    db_conn_holder_obj = DbConnectionHolder()
+    service_client = db_conn_holder_obj.client
+
+router = APIRouter(prefix="/api/invite-requests", tags=["invite-requests"])
+
+
+# Pydantic models
+class InviteRequestCreate(BaseModel):
+    """Model for creating a new invite request"""
+    email: EmailStr = Field(..., description="Email address of the requester")
+    name: str = Field(..., min_length=1, max_length=255, description="Name of the requester")
+    team: Optional[str] = Field(None, max_length=255, description="Team or club affiliation")
+    reason: Optional[str] = Field(None, description="Reason for wanting to join")
+    website: Optional[str] = Field(None, description="Honeypot field - should be empty")
+
+
+class InviteRequestResponse(BaseModel):
+    """Model for invite request response"""
+    id: str
+    email: str
+    name: str
+    team: Optional[str]
+    reason: Optional[str]
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    reviewed_by: Optional[str]
+    reviewed_at: Optional[datetime]
+    admin_notes: Optional[str]
+
+
+class InviteRequestStatusUpdate(BaseModel):
+    """Model for updating invite request status"""
+    status: str = Field(..., pattern="^(pending|approved|rejected)$")
+    admin_notes: Optional[str] = Field(None, description="Admin notes about the decision")
+
+
+class InviteRequestStats(BaseModel):
+    """Statistics about invite requests"""
+    total: int
+    pending: int
+    approved: int
+    rejected: int
+
+
+# Public endpoint - no auth required
+@router.post("", status_code=201)
+async def create_invite_request(request: InviteRequestCreate):
+    """
+    Submit a new invite request (public endpoint).
+
+    Anyone can submit an invite request without authentication.
+    Duplicate email submissions are allowed (users can re-submit).
+    """
+    try:
+        # Honeypot check - if filled, it's a bot
+        if request.website:
+            # Return fake success to not alert the bot
+            return {
+                "success": True,
+                "message": "Thank you for your interest! We'll review your request and reach out soon."
+            }
+
+        # Check for existing pending request with same email
+        existing = service_client.table('invite_requests').select('id, status').eq(
+            'email', request.email
+        ).eq('status', 'pending').execute()
+
+        if existing.data:
+            # Return success anyway - we don't want to reveal if email exists
+            return {
+                "success": True,
+                "message": "Thank you for your interest! We'll review your request and reach out soon."
+            }
+
+        # Insert new invite request
+        result = service_client.table('invite_requests').insert({
+            'email': request.email,
+            'name': request.name,
+            'team': request.team,
+            'reason': request.reason,
+            'status': 'pending'
+        }).execute()
+
+        if result.data:
+            return {
+                "success": True,
+                "message": "Thank you for your interest! We'll review your request and reach out soon."
+            }
+        else:
+            raise HTTPException(status_code=500, detail="Failed to submit invite request")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error creating invite request: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred while submitting your request")
+
+
+# Admin endpoints
+@router.get("", response_model=List[InviteRequestResponse])
+async def list_invite_requests(
+    current_user=Depends(get_current_user_required),
+    status: Optional[str] = Query(None, pattern="^(pending|approved|rejected)$"),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0)
+):
+    """
+    List all invite requests (admin only).
+
+    Supports filtering by status and pagination.
+    """
+    if current_user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail="Only admins can view invite requests")
+
+    try:
+        query = service_client.table('invite_requests').select('*').order(
+            'created_at', desc=True
+        ).range(offset, offset + limit - 1)
+
+        if status:
+            query = query.eq('status', status)
+
+        result = query.execute()
+
+        return result.data or []
+
+    except Exception as e:
+        print(f"Error listing invite requests: {e}")
+        raise HTTPException(status_code=500, detail="Failed to retrieve invite requests")
+
+
+@router.get("/stats", response_model=InviteRequestStats)
+async def get_invite_request_stats(current_user=Depends(get_current_user_required)):
+    """
+    Get statistics about invite requests (admin only).
+    """
+    if current_user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail="Only admins can view invite request stats")
+
+    try:
+        # Get counts by status
+        all_requests = service_client.table('invite_requests').select('status').execute()
+
+        stats = {
+            'total': 0,
+            'pending': 0,
+            'approved': 0,
+            'rejected': 0
+        }
+
+        if all_requests.data:
+            stats['total'] = len(all_requests.data)
+            for req in all_requests.data:
+                status = req.get('status', 'pending')
+                if status in stats:
+                    stats[status] += 1
+
+        return stats
+
+    except Exception as e:
+        print(f"Error getting invite request stats: {e}")
+        raise HTTPException(status_code=500, detail="Failed to retrieve statistics")
+
+
+@router.get("/{request_id}", response_model=InviteRequestResponse)
+async def get_invite_request(
+    request_id: str,
+    current_user=Depends(get_current_user_required)
+):
+    """
+    Get a specific invite request by ID (admin only).
+    """
+    if current_user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail="Only admins can view invite requests")
+
+    try:
+        result = service_client.table('invite_requests').select('*').eq(
+            'id', request_id
+        ).execute()
+
+        if not result.data:
+            raise HTTPException(status_code=404, detail="Invite request not found")
+
+        return result.data[0]
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error getting invite request: {e}")
+        raise HTTPException(status_code=500, detail="Failed to retrieve invite request")
+
+
+@router.put("/{request_id}/status")
+async def update_invite_request_status(
+    request_id: str,
+    status_update: InviteRequestStatusUpdate,
+    current_user=Depends(get_current_user_required)
+):
+    """
+    Update the status of an invite request (admin only).
+
+    Used to approve or reject invite requests.
+    """
+    if current_user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail="Only admins can update invite requests")
+
+    try:
+        # Get current request
+        existing = service_client.table('invite_requests').select('*').eq(
+            'id', request_id
+        ).execute()
+
+        if not existing.data:
+            raise HTTPException(status_code=404, detail="Invite request not found")
+
+        # Get user ID
+        user_id = current_user.get('id') or current_user.get('user_id') or current_user.get('sub')
+
+        # Update the request
+        update_data = {
+            'status': status_update.status,
+            'reviewed_by': user_id,
+            'reviewed_at': datetime.utcnow().isoformat(),
+        }
+
+        if status_update.admin_notes:
+            update_data['admin_notes'] = status_update.admin_notes
+
+        result = service_client.table('invite_requests').update(
+            update_data
+        ).eq('id', request_id).execute()
+
+        if result.data:
+            return {
+                "success": True,
+                "message": f"Invite request {status_update.status}",
+                "request": result.data[0]
+            }
+        else:
+            raise HTTPException(status_code=500, detail="Failed to update invite request")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error updating invite request: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update invite request")
+
+
+@router.delete("/{request_id}")
+async def delete_invite_request(
+    request_id: str,
+    current_user=Depends(get_current_user_required)
+):
+    """
+    Delete an invite request (admin only).
+
+    Use with caution - this permanently removes the request.
+    """
+    if current_user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail="Only admins can delete invite requests")
+
+    try:
+        # Check if request exists
+        existing = service_client.table('invite_requests').select('id').eq(
+            'id', request_id
+        ).execute()
+
+        if not existing.data:
+            raise HTTPException(status_code=404, detail="Invite request not found")
+
+        # Delete the request
+        service_client.table('invite_requests').delete().eq('id', request_id).execute()
+
+        return {
+            "success": True,
+            "message": "Invite request deleted successfully"
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error deleting invite request: {e}")
+        raise HTTPException(status_code=500, detail="Failed to delete invite request")

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, field_validator, model_validator
 
 from api.invites import router as invites_router
+from api.invite_requests import router as invite_requests_router
 from auth import (
     AuthManager,
     get_current_user_required,
@@ -340,6 +341,7 @@ class RefreshTokenRequest(BaseModel):
 
 # === Include API Routers ===
 app.include_router(invites_router)
+app.include_router(invite_requests_router)
 
 # Version endpoint
 from endpoints.version import router as version_router

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "pytest-playwright>=0.7.1",
     "pytest-html>=4.1.1",
     "pillow>=12.0.0",
+    "email-validator>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -777,6 +777,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +813,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1950,6 +1972,7 @@ dependencies = [
     { name = "celery" },
     { name = "crewai" },
     { name = "cryptography" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "flask" },
     { name = "flask-cors" },
@@ -2036,6 +2059,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.6.4" },
     { name = "crewai", specifier = ">=0.28.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
+    { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.115.4" },
     { name = "flask", specifier = ">=3.0.3" },
     { name = "flask-cors", specifier = ">=5.0.0" },

--- a/supabase-local/migrations/20251120000001_create_invite_requests.sql
+++ b/supabase-local/migrations/20251120000001_create_invite_requests.sql
@@ -1,0 +1,84 @@
+-- Migration: Create invite_requests table
+-- Purpose: Store invite requests from potential users
+
+-- Create enum for invite request status
+DO $$ BEGIN
+    CREATE TYPE invite_request_status AS ENUM ('pending', 'approved', 'rejected');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- Create invite_requests table
+CREATE TABLE IF NOT EXISTS invite_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    team VARCHAR(255),
+    reason TEXT,
+    status invite_request_status DEFAULT 'pending' NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    reviewed_by UUID REFERENCES auth.users(id),
+    reviewed_at TIMESTAMPTZ,
+    admin_notes TEXT
+);
+
+-- Create index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_invite_requests_email ON invite_requests(email);
+CREATE INDEX IF NOT EXISTS idx_invite_requests_status ON invite_requests(status);
+CREATE INDEX IF NOT EXISTS idx_invite_requests_created_at ON invite_requests(created_at DESC);
+
+-- Enable RLS
+ALTER TABLE invite_requests ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Anyone can insert (public endpoint for submissions)
+CREATE POLICY "Anyone can submit invite requests"
+    ON invite_requests
+    FOR INSERT
+    WITH CHECK (true);
+
+-- Policy: Only admins can view invite requests
+CREATE POLICY "Admins can view all invite requests"
+    ON invite_requests
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM user_profiles
+            WHERE user_profiles.id = auth.uid()
+            AND user_profiles.role = 'admin'
+        )
+    );
+
+-- Policy: Only admins can update invite requests
+CREATE POLICY "Admins can update invite requests"
+    ON invite_requests
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM user_profiles
+            WHERE user_profiles.id = auth.uid()
+            AND user_profiles.role = 'admin'
+        )
+    );
+
+-- Create trigger to update updated_at
+CREATE OR REPLACE FUNCTION update_invite_requests_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_invite_requests_updated_at
+    BEFORE UPDATE ON invite_requests
+    FOR EACH ROW
+    EXECUTE FUNCTION update_invite_requests_updated_at();
+
+-- Add schema version
+SELECT add_schema_version('1.2.0', 'create_invite_requests', 'Add invite_requests table for managing user invite requests');
+
+COMMENT ON TABLE invite_requests IS 'Stores invite requests from potential users wanting to join the platform';
+COMMENT ON COLUMN invite_requests.status IS 'Request status: pending, approved, or rejected';
+COMMENT ON COLUMN invite_requests.reviewed_by IS 'Admin user who reviewed the request';
+COMMENT ON COLUMN invite_requests.admin_notes IS 'Internal notes from admin about the request';


### PR DESCRIPTION
## Summary
- Add `invite_requests` table for storing user invite requests
- Create API endpoints for submitting and managing requests
- Implement honeypot field for bot protection
- Update frontend to call real API endpoint
- Migration applied to dev database

## API Endpoints
| Endpoint | Auth | Description |
|----------|------|-------------|
| `POST /api/invite-requests` | Public | Submit invite request |
| `GET /api/invite-requests` | Admin | List all requests |
| `GET /api/invite-requests/stats` | Admin | Get statistics |
| `PUT /api/invite-requests/{id}/status` | Admin | Approve/reject |
| `DELETE /api/invite-requests/{id}` | Admin | Delete request |

## Security Features
- **Honeypot field** - Hidden form field catches bots
- **RLS policies** - Admin-only read/update access
- **Email validation** - Pydantic EmailStr validation
- **Silent rejection** - Bots get fake success response

## Database
- Created `invite_requests` table with enum status
- Added indexes for email, status, created_at
- Automatic `updated_at` trigger

## Test plan
- [x] API endpoint accepts submissions
- [x] Honeypot rejects bot submissions silently
- [x] Admin endpoints require authentication
- [x] Migration applied to dev database
- [ ] Test frontend form in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)