### PR TITLE
feat: Make standings table mobile-responsive

### DIFF
--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -121,52 +121,52 @@
         <thead class="bg-gray-50">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               Pos
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               Team
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               GP
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               W
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               D
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               L
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               GF
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               GA
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               GD
             </th>
             <th
-              class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
             >
               Pts
             </th>
@@ -181,51 +181,53 @@
             :key="team.team"
             data-testid="standings-row"
           >
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-gray-500"
+            >
               {{ index + 1 }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm font-medium text-gray-900"
             >
               {{ getTeamDisplayName(team.team) }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.played }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.wins }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.draws }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.losses }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.goals_for }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.goals_against }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
             >
               {{ team.goal_difference }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center font-medium text-gray-900"
             >
               {{ team.points }}
             </td>


### PR DESCRIPTION
## Summary
- Hide GF, GA, GD columns on mobile portrait (< 768px)
- Show all columns when rotated to landscape or on tablet/desktop (md: 768px+)
- Reduce cell padding for tighter mobile layout
- Emphasize Points column with bold styling

## Responsive Breakpoints
- **Mobile portrait** (< 768px): Pos, Team, GP, W, D, L, Pts (7 columns)
- **Landscape/Tablet** (768px+): All 10 columns visible

## Visual Changes
- Desktop: No visible change
- Mobile: Cleaner, more readable table without horizontal scrolling

## Test Plan
- [ ] View standings on desktop browser - should look the same
- [ ] Resize browser to mobile width - GF, GA, GD columns should hide
- [ ] Rotate phone to landscape - all columns should appear
- [ ] Test on actual mobile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)