### PR TITLE
feat: Add Club Manager role with team creation support

### DIFF
--- a/backend/api/invite_requests.py
+++ b/backend/api/invite_requests.py
@@ -140,7 +140,7 @@ async def list_invite_requests(
 
     Supports filtering by status and pagination.
     """
-    if current_user.get('role') != 'admin':
+    if current_user.get('role') not in ['admin', 'club_manager']:
         raise HTTPException(status_code=403, detail="Only admins can view invite requests")
 
     try:
@@ -165,7 +165,7 @@ async def get_invite_request_stats(current_user=Depends(get_current_user_require
     """
     Get statistics about invite requests (admin only).
     """
-    if current_user.get('role') != 'admin':
+    if current_user.get('role') not in ['admin', 'club_manager']:
         raise HTTPException(status_code=403, detail="Only admins can view invite request stats")
 
     try:
@@ -201,7 +201,7 @@ async def get_invite_request(
     """
     Get a specific invite request by ID (admin only).
     """
-    if current_user.get('role') != 'admin':
+    if current_user.get('role') not in ['admin', 'club_manager']:
         raise HTTPException(status_code=403, detail="Only admins can view invite requests")
 
     try:
@@ -232,7 +232,7 @@ async def update_invite_request_status(
 
     Used to approve or reject invite requests.
     """
-    if current_user.get('role') != 'admin':
+    if current_user.get('role') not in ['admin', 'club_manager']:
         raise HTTPException(status_code=403, detail="Only admins can update invite requests")
 
     try:
@@ -287,7 +287,7 @@ async def delete_invite_request(
 
     Use with caution - this permanently removes the request.
     """
-    if current_user.get('role') != 'admin':
+    if current_user.get('role') not in ['admin', 'club_manager']:
         raise HTTPException(status_code=403, detail="Only admins can delete invite requests")
 
     try:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -311,14 +311,14 @@ export default {
         id: 'add-match',
         name: 'Add Match',
         requiresAuth: true,
-        requiresRole: ['admin', 'team-manager'],
+        requiresRole: ['admin', 'club_manager', 'team-manager'],
       },
       { id: 'profile', name: 'Profile', requiresAuth: true },
       {
         id: 'admin',
         name: 'Admin',
         requiresAuth: true,
-        requiresRole: ['admin'],
+        requiresRole: ['admin', 'club_manager'],
       },
     ];
 

--- a/frontend/src/components/AdminPanel.vue
+++ b/frontend/src/components/AdminPanel.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="admin-panel">
     <!-- Admin Access Check -->
-    <div v-if="!authStore.isAdmin.value" class="text-center py-12">
+    <div
+      v-if="!authStore.isAdmin.value && !authStore.isClubManager.value"
+      class="text-center py-12"
+    >
       <div class="max-w-md mx-auto">
         <div class="text-red-600 text-6xl mb-4">🚫</div>
         <h2 class="text-2xl font-bold text-gray-900 mb-2">Access Denied</h2>
@@ -92,7 +95,7 @@
 </template>
 
 <script>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import AdminAgeGroups from './admin/AdminAgeGroups.vue';
 import AdminSeasons from './admin/AdminSeasons.vue';
@@ -121,17 +124,35 @@ export default {
     const authStore = useAuthStore();
     const currentSection = ref('invite-requests');
 
-    const adminSections = [
-      { id: 'invite-requests', name: 'Requests' },
-      { id: 'age-groups', name: 'Age Groups' },
-      { id: 'seasons', name: 'Seasons' },
-      { id: 'leagues', name: 'Leagues' },
-      { id: 'divisions', name: 'Divisions' },
-      { id: 'clubs', name: 'Clubs' },
-      { id: 'teams', name: 'Teams' },
-      { id: 'matches', name: 'Matches' },
-      { id: 'invites', name: 'Invites' },
+    // Define all sections with role requirements
+    const allAdminSections = [
+      { id: 'invite-requests', name: 'Requests', adminOnly: true },
+      { id: 'age-groups', name: 'Age Groups', adminOnly: true },
+      { id: 'seasons', name: 'Seasons', adminOnly: true },
+      { id: 'leagues', name: 'Leagues', adminOnly: true },
+      { id: 'divisions', name: 'Divisions', adminOnly: true },
+      { id: 'clubs', name: 'Clubs', adminOnly: true },
+      { id: 'teams', name: 'Teams', adminOnly: false },
+      { id: 'matches', name: 'Matches', adminOnly: false },
+      { id: 'invites', name: 'Invites', adminOnly: false },
     ];
+
+    // Filter sections based on user role
+    const adminSections = computed(() => {
+      if (authStore.isAdmin.value) {
+        return allAdminSections;
+      }
+      // Club managers only see Teams, Matches, Invites
+      return allAdminSections.filter(section => !section.adminOnly);
+    });
+
+    // Update current section when role changes
+    if (
+      !authStore.isAdmin.value &&
+      currentSection.value === 'invite-requests'
+    ) {
+      currentSection.value = 'teams';
+    }
 
     return {
       authStore,

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -17,10 +17,19 @@ export const useAuthStore = () => {
   // Computed properties
   const isAuthenticated = computed(() => !!state.session);
   const isAdmin = computed(() => state.profile?.role === 'admin');
-  const isTeamManager = computed(() => state.profile?.role === 'team-manager');
-  const canManageTeam = computed(() => isAdmin.value || isTeamManager.value);
+  const isClubManager = computed(() => state.profile?.role === 'club_manager');
+  const isTeamManager = computed(
+    () =>
+      state.profile?.role === 'team-manager' ||
+      state.profile?.role === 'team_manager'
+  );
+  const canManageTeam = computed(
+    () => isAdmin.value || isClubManager.value || isTeamManager.value
+  );
+  const canManageClub = computed(() => isAdmin.value || isClubManager.value);
   const userRole = computed(() => state.profile?.role || 'team-fan');
   const userTeamId = computed(() => state.profile?.team_id);
+  const userClubId = computed(() => state.profile?.club_id);
 
   // Actions
   const setLoading = loading => {
@@ -512,10 +521,13 @@ export const useAuthStore = () => {
     // Computed
     isAuthenticated,
     isAdmin,
+    isClubManager,
     isTeamManager,
     canManageTeam,
+    canManageClub,
     userRole,
     userTeamId,
+    userClubId,
 
     // Actions
     signup,

--- a/supabase/migrations/20251120155152_add_club_manager_role.sql
+++ b/supabase/migrations/20251120155152_add_club_manager_role.sql
@@ -1,0 +1,34 @@
+-- Migration: Add club_manager role and remove unused user role
+-- This migration updates the role system to support club-level management
+
+-- Drop the existing role check constraint
+ALTER TABLE user_profiles
+DROP CONSTRAINT IF EXISTS user_profiles_role_check;
+
+-- Add new constraint with club_manager role and without user role
+-- Keeping both hyphenated and underscored versions for backwards compatibility
+ALTER TABLE user_profiles
+ADD CONSTRAINT user_profiles_role_check
+CHECK (role IN (
+    'admin',
+    'club_manager',
+    'team-manager',
+    'team_manager',
+    'team-player',
+    'team_player',
+    'team-fan',
+    'team_fan'
+));
+
+-- Add comment documenting the role hierarchy
+COMMENT ON COLUMN user_profiles.role IS 'User role: admin > club_manager > team-manager > team-player/team-fan. Club managers can manage all teams in their assigned club.';
+
+-- Add club_id column to invitations table for club_manager invites
+ALTER TABLE invitations
+ADD COLUMN IF NOT EXISTS club_id INTEGER REFERENCES clubs(id);
+
+-- Add comment for club_id
+COMMENT ON COLUMN invitations.club_id IS 'Club ID for club_manager invites (mutually exclusive with team_id)';
+
+-- Update schema version
+SELECT add_schema_version('1.2.0', 'add_club_manager_role', 'Add club_manager role for club-level management, remove unused user role, add club_id to invitations');

--- a/supabase/migrations/20251121000001_club_manager_teams_rls.sql
+++ b/supabase/migrations/20251121000001_club_manager_teams_rls.sql
@@ -1,0 +1,33 @@
+-- Migration: Add RLS policies for club managers to manage teams
+-- This allows club managers to create and update teams within their assigned club
+
+-- Drop the existing admin-only policy for teams
+DROP POLICY IF EXISTS teams_admin_all ON teams;
+
+-- Create new policies that allow club managers to manage teams in their club
+
+-- INSERT policy: admins can insert any team, club_managers only their club
+CREATE POLICY teams_insert_policy ON teams FOR INSERT
+WITH CHECK (
+    -- Admins can insert any team
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+    OR
+    -- Club managers can only insert teams into their club
+    (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'club_manager')
+     AND club_id = (SELECT club_id FROM user_profiles WHERE id = auth.uid()))
+);
+
+-- UPDATE policy: admins can update any team, club_managers only their club's teams
+CREATE POLICY teams_update_policy ON teams FOR UPDATE
+USING (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+    OR
+    (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'club_manager')
+     AND club_id = (SELECT club_id FROM user_profiles WHERE id = auth.uid()))
+);
+
+-- DELETE policy: only admins can delete teams
+CREATE POLICY teams_delete_policy ON teams FOR DELETE
+USING (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+);


### PR DESCRIPTION
## Summary
- Add Club Manager role with restricted admin panel access
- Club managers can manage Teams, Matches, and Invites only
- Club managers can create teams but only in their assigned club
- Add invite type support for club_manager invitations
- Update RLS policies for club manager team access

## Changes

### Backend
- Added `isClubManager` and `canManageClub` computed properties to auth store
- Added club_manager role mapping in signup flow
- Updated `POST /api/teams` to allow club managers with club_id validation
- Added club_manager invite type to invite service
- Updated invite_requests API to allow club_manager access

### Frontend
- Filtered admin sections for club managers (Teams, Matches, Invites only)
- Added club_manager option to invite creation form
- Auto-lock club selection dropdown for club managers
- Fixed API payload naming: `parent_club_id` → `club_id`

### Database Migrations
- `20251120155152_add_club_manager_role.sql` - Add club_manager to role constraint
- `20251121000001_club_manager_teams_rls.sql` - Update teams RLS for club managers

## Test Plan
- [ ] Log in as admin - verify all admin sections visible
- [ ] Log in as club_manager (tom_club) - verify only Teams, Matches, Invites visible
- [ ] As club manager, create team - verify club is auto-selected and locked
- [ ] As club manager, create invite for team - verify it works
- [ ] Verify RLS policies by attempting to create team in different club (should fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)