### PR TITLE
fix: Allow club_manager to edit matches via PUT endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1388,9 +1388,9 @@ async def add_match(request: Request, match: EnhancedMatch, current_user: dict[s
 
 @app.put("/api/matches/{match_id}")
 async def update_match(
-    match_id: int, match: EnhancedMatch, current_user: dict[str, Any] = Depends(require_admin_or_service_account)
+    match_id: int, match: EnhancedMatch, current_user: dict[str, Any] = Depends(require_match_management_permission)
 ):
-    """Update an existing match (admin or service account with manage_matches permission)."""
+    """Update an existing match (admin, club_manager, team-manager, or service account with manage_matches permission)."""
     try:
         # Get current match to check permissions
         current_match = sports_dao.get_match_by_id(match_id)


### PR DESCRIPTION
## Summary
- Fixed PUT `/api/matches/{match_id}` endpoint permission to allow club_manager role
- Changed from `require_admin_or_service_account` to `require_match_management_permission`

## Problem
Club managers could not edit matches for their club's teams. The PUT endpoint only allowed admins and service accounts.

## Solution
Updated the permission dependency to `require_match_management_permission` which allows:
- admin
- club_manager
- team-manager
- service accounts with `manage_matches` permission

The `can_edit_match` validation ensures club managers can only modify matches involving their club's teams.

## Match Endpoint Permissions (After Fix)

| Operation | Permission | club_manager? |
|-----------|------------|---------------|
| Add Match | `require_match_management_permission` | ✅ Yes |
| Edit Match (PUT) | `require_match_management_permission` | ✅ Yes |
| Edit Match (PATCH) | `require_match_management_permission` | ✅ Yes |
| Delete Match | `require_team_manager_or_admin` | ✅ Yes |

## Test plan
- [ ] Log in as tom_club (club_manager)
- [ ] Navigate to Admin > Matches
- [ ] Verify can add match for IFA Club team
- [ ] Verify can edit existing match for IFA Club team
- [ ] Verify cannot edit matches for other clubs' teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)