### PR TITLE
fix: Read invite code from URL query parameter

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -296,6 +296,20 @@ export default {
 
     onMounted(() => {
       fetchTeams();
+
+      // Check for invite code in URL query parameter
+      const urlParams = new URLSearchParams(window.location.search);
+      const inviteCode = urlParams.get('code');
+
+      if (inviteCode) {
+        // Switch to invite signup form and pre-fill the code
+        showInviteSignup.value = true;
+        isSignup.value = true;
+        form.inviteCode = inviteCode;
+
+        // Validate the invite code automatically
+        validateInviteCode();
+      }
     });
 
     return {


### PR DESCRIPTION
## Summary

- Fixes invite links not pre-filling the invite code when visiting `/register?code=XXX`
- LoginForm now reads the `code` query parameter and:
  - Switches to the invite signup form automatically
  - Pre-fills the invite code field
  - Validates the invite code to show team info

## Test plan

- [x] Visit `http://localhost:8080/register?code=TESTCODE` 
- [x] Verify form shows "Sign Up with Invite" heading
- [x] Verify invite code field is pre-filled
- [ ] Deploy and test with real invite code on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)