### PR TITLE
fix: Auto-open login modal when invite code in URL

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -421,6 +421,13 @@ export default {
         authenticated: authStore.isAuthenticated.value ? 'true' : 'false',
         user_role: authStore.userRole.value || 'anonymous',
       });
+
+      // Check for invite code in URL - automatically open login modal for signup
+      const urlParams = new URLSearchParams(window.location.search);
+      const inviteCode = urlParams.get('code');
+      if (inviteCode && !authStore.isAuthenticated.value) {
+        showLoginModal.value = true;
+      }
     });
 
     return {


### PR DESCRIPTION
## Summary
- Auto-open login modal when URL contains `?code=XXX` parameter
- Fixes issue where invite links weren't working because LoginForm wasn't mounted

## Important: URL Format Change

The correct invite URL format is now:
```
https://missingtable.com/?code=4G74V8GWXH2B
```

Not `/register?code=...` (there's no Vue Router, so no `/register` route exists).

## How it Works
1. App.vue checks for `code` query parameter on mount
2. If found and user is not authenticated, automatically opens the login modal
3. LoginForm.vue then reads the code and pre-fills the signup form

## Test plan
- [ ] Visit `https://missingtable.com/?code=4G74V8GWXH2B`
- [ ] Login modal should automatically open
- [ ] Sign Up form should appear with invite code pre-filled
- [ ] Invite should validate and show team/role info

🤖 Generated with [Claude Code](https://claude.com/claude-code)