### PR TITLE
fix: Make active-seasons and match-types endpoints public

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1068,7 +1068,7 @@ async def get_current_season(current_user: dict[str, Any] = Depends(get_current_
 
 
 @app.get("/api/active-seasons")
-async def get_active_seasons(current_user: dict[str, Any] = Depends(get_current_user_required)):
+async def get_active_seasons():
     """Get active seasons (current and future) for scheduling new matches."""
     try:
         active_seasons = sports_dao.get_active_seasons()
@@ -1079,7 +1079,7 @@ async def get_active_seasons(current_user: dict[str, Any] = Depends(get_current_
 
 
 @app.get("/api/match-types")
-async def get_match_types(current_user: dict[str, Any] = Depends(get_current_user_required)):
+async def get_match_types():
     """Get all match types."""
     try:
         match_types = sports_dao.get_all_match_types()


### PR DESCRIPTION
## Summary
- Remove auth requirement from `/api/active-seasons` and `/api/match-types` endpoints
- These are read-only reference data endpoints like `/api/age-groups`

## Issue
Club managers getting 403/401 errors on Add Match tab because MatchForm.vue makes fetch calls without Authorization headers.

## Test plan
- [ ] Log in as club_manager
- [ ] Go to Add Match tab
- [ ] Verify no 403/401 errors in Network tab
- [ ] Verify season and match type dropdowns populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)