### PR TITLE
fix: Change player_number type from str to int

### DIFF
--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -107,7 +107,7 @@ class PlayerCustomization(BaseModel):
     primary_color: str | None = None
     text_color: str | None = None
     accent_color: str | None = None
-    player_number: str | None = None
+    player_number: int | None = None  # Jersey number (1-99)
     positions: list[str] | None = None
     # Social media handles (username only, not full URLs)
     instagram_handle: str | None = None


### PR DESCRIPTION
## Summary
- Fix 422 validation error when updating player customization
- The frontend sends `player_number` as an integer (e.g., 35) but the model expected a string

## Root Cause
`PlayerCustomization.player_number` was typed as `str | None` but should be `int | None` to match:
- Database column type (integer)
- Frontend behavior (sends number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)