### PR TITLE
feat: Add Match Detail View with share-to-clipboard feature

### DIFF
--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -1251,12 +1251,18 @@ class MatchDAO:
                 self.client.table("matches")
                 .select("""
                     *,
-                    home_team:teams!matches_home_team_id_fkey(id, name),
-                    away_team:teams!matches_away_team_id_fkey(id, name),
+                    home_team:teams!matches_home_team_id_fkey(
+                        id, name,
+                        club:clubs(id, name, logo_url, primary_color, secondary_color)
+                    ),
+                    away_team:teams!matches_away_team_id_fkey(
+                        id, name,
+                        club:clubs(id, name, logo_url, primary_color, secondary_color)
+                    ),
                     season:seasons(id, name),
                     age_group:age_groups(id, name),
                     match_type:match_types(id, name),
-                    division:divisions(id, name)
+                    division:divisions(id, name, leagues(id, name))
                 """)
                 .eq("id", match_id)
                 .execute()
@@ -1276,6 +1282,12 @@ class MatchDAO:
                     "away_team_name": match["away_team"]["name"]
                     if match.get("away_team")
                     else "Unknown",
+                    "home_team_club": match["home_team"].get("club")
+                    if match.get("home_team")
+                    else None,
+                    "away_team_club": match["away_team"].get("club")
+                    if match.get("away_team")
+                    else None,
                     "home_score": match["home_score"],
                     "away_score": match["away_score"],
                     "season_id": match["season_id"],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@opentelemetry/semantic-conventions": "^1.38.0",
         "@supabase/supabase-js": "^2.38.0",
         "core-js": "^3.8.3",
+        "html2canvas": "^1.4.1",
         "vue": "^3.2.13",
         "vue-router": "^4.2.5",
         "web-vitals": "^5.1.0"
@@ -4306,6 +4307,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5254,6 +5264,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -7790,6 +7809,19 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -12762,6 +12794,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13079,6 +13120,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@opentelemetry/semantic-conventions": "^1.38.0",
     "@supabase/supabase-js": "^2.38.0",
     "core-js": "^3.8.3",
+    "html2canvas": "^1.4.1",
     "vue": "^3.2.13",
     "vue-router": "^4.2.5",
     "web-vitals": "^5.1.0"

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -1,0 +1,510 @@
+<template>
+  <div class="match-detail-view p-3 lg:p-4">
+    <!-- Back button -->
+    <button
+      @click="$emit('back')"
+      class="flex items-center gap-1.5 px-2 py-1 text-gray-600 hover:text-gray-900 font-medium text-xs mb-2 rounded hover:bg-gray-100 transition-colors"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        class="w-4 h-4"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7"
+        />
+      </svg>
+      <span>Back to Matches</span>
+    </button>
+
+    <!-- Loading state -->
+    <div v-if="loading" class="flex flex-col items-center justify-center py-12">
+      <div
+        class="w-8 h-8 border-3 border-gray-300 border-t-blue-500 rounded-full animate-spin mb-3"
+      ></div>
+      <p class="text-gray-500 text-sm">Loading match details...</p>
+    </div>
+
+    <!-- Error state -->
+    <div
+      v-else-if="error"
+      class="flex flex-col items-center justify-center py-12 text-center"
+    >
+      <div
+        class="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center text-red-500 text-xl font-bold mb-3"
+      >
+        !
+      </div>
+      <p class="text-gray-500 mb-3 text-sm">{{ error }}</p>
+      <button
+        @click="fetchMatch"
+        class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium text-sm transition-colors"
+      >
+        Try Again
+      </button>
+    </div>
+
+    <!-- Match content -->
+    <div v-else-if="match" class="max-w-sm mx-auto">
+      <!-- Capture container for share -->
+      <div ref="scoreboardRef" class="bg-slate-800 rounded-lg p-2">
+        <!-- Stadium Scoreboard -->
+        <div
+          class="scoreboard bg-gradient-to-r from-slate-800 via-slate-700 to-slate-800 rounded-lg p-3 mb-2"
+        >
+          <!-- LIVE indicator -->
+          <div
+            v-if="match.match_status === 'live'"
+            class="flex justify-center mb-3"
+          >
+            <div
+              class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-red-600 text-white font-bold uppercase tracking-wider text-xs animate-pulse shadow-[0_0_15px_rgba(220,38,38,0.7)]"
+            >
+              <span
+                class="w-1.5 h-1.5 rounded-full bg-white animate-ping"
+              ></span>
+              LIVE
+            </div>
+          </div>
+
+          <!-- Status badge for non-live matches -->
+          <div v-else class="flex justify-center mb-3">
+            <div
+              class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider"
+              :class="statusBadgeClass"
+            >
+              {{ match.match_status || 'scheduled' }}
+            </div>
+          </div>
+
+          <!-- Teams and Score -->
+          <div class="flex flex-row items-center justify-center gap-4 lg:gap-8">
+            <!-- Home Team -->
+            <div class="flex flex-col items-center text-center flex-1">
+              <!-- Club Logo -->
+              <div
+                class="w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white/10 backdrop-blur-sm overflow-hidden mb-2 border border-slate-500"
+                :style="{ boxShadow: `0 0 20px ${homeTeamColor}40` }"
+              >
+                <img
+                  v-if="match.home_team_club?.logo_url"
+                  :src="match.home_team_club.logo_url"
+                  :alt="`${match.home_team_name} logo`"
+                  class="w-12 h-12 lg:w-14 lg:h-14 object-contain"
+                />
+                <div v-else class="text-lg lg:text-xl font-bold text-slate-400">
+                  {{ getTeamInitials(match.home_team_name) }}
+                </div>
+              </div>
+              <h2 class="text-sm lg:text-base font-bold text-white mb-0.5">
+                {{ match.home_team_name }}
+              </h2>
+              <span class="text-[10px] text-slate-400 uppercase tracking-wider"
+                >Home</span
+              >
+            </div>
+
+            <!-- Score Display -->
+            <div class="flex items-center gap-2 lg:gap-3">
+              <span
+                class="score-number text-3xl lg:text-5xl font-bold text-white"
+              >
+                {{ match.home_score ?? '-' }}
+              </span>
+              <span class="text-xl lg:text-2xl font-light text-slate-500"
+                >-</span
+              >
+              <span
+                class="score-number text-3xl lg:text-5xl font-bold text-white"
+              >
+                {{ match.away_score ?? '-' }}
+              </span>
+            </div>
+
+            <!-- Away Team -->
+            <div class="flex flex-col items-center text-center flex-1">
+              <!-- Club Logo -->
+              <div
+                class="w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white/10 backdrop-blur-sm overflow-hidden mb-2 border border-slate-500"
+                :style="{ boxShadow: `0 0 20px ${awayTeamColor}40` }"
+              >
+                <img
+                  v-if="match.away_team_club?.logo_url"
+                  :src="match.away_team_club.logo_url"
+                  :alt="`${match.away_team_name} logo`"
+                  class="w-12 h-12 lg:w-14 lg:h-14 object-contain"
+                />
+                <div v-else class="text-lg lg:text-xl font-bold text-slate-400">
+                  {{ getTeamInitials(match.away_team_name) }}
+                </div>
+              </div>
+              <h2 class="text-sm lg:text-base font-bold text-white mb-0.5">
+                {{ match.away_team_name }}
+              </h2>
+              <span class="text-[10px] text-slate-400 uppercase tracking-wider"
+                >Away</span
+              >
+            </div>
+          </div>
+        </div>
+
+        <!-- Match Details Card -->
+        <div class="bg-slate-700/50 rounded-lg p-3">
+          <h3 class="text-sm font-semibold text-white mb-3">Match Details</h3>
+          <div class="grid grid-cols-2 lg:grid-cols-3 gap-2">
+            <div class="detail-item">
+              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
+                >Date</span
+              >
+              <span class="text-xs font-medium text-white">{{
+                formatDate(match.match_date)
+              }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
+                >Type</span
+              >
+              <span class="text-xs font-medium text-white">{{
+                match.match_type_name || 'League'
+              }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
+                >Season</span
+              >
+              <span class="text-xs font-medium text-white">{{
+                match.season_name
+              }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
+                >Age Group</span
+              >
+              <span class="text-xs font-medium text-white">{{
+                match.age_group_name
+              }}</span>
+            </div>
+            <div v-if="match.division_name" class="detail-item">
+              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
+                >Division</span
+              >
+              <span class="text-xs font-medium text-white">{{
+                match.division_name
+              }}</span>
+            </div>
+            <div v-if="leagueName" class="detail-item">
+              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
+                >League</span
+              >
+              <span class="text-xs font-medium text-white">{{
+                leagueName
+              }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- End capture container -->
+
+      <!-- Share Button (at bottom, not captured in image) -->
+      <div class="flex justify-center mt-3">
+        <button
+          @click="shareScoreboard"
+          :disabled="shareStatus === 'copying'"
+          class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors"
+          :class="{
+            'bg-green-600 text-white': shareStatus === 'success',
+            'bg-red-600 text-white': shareStatus === 'error',
+            'bg-gray-200 text-gray-700 hover:bg-gray-300':
+              !shareStatus || shareStatus === 'copying',
+          }"
+        >
+          <!-- Copy icon -->
+          <svg
+            v-if="!shareStatus"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="w-3.5 h-3.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+            />
+          </svg>
+          <!-- Loading spinner -->
+          <svg
+            v-else-if="shareStatus === 'copying'"
+            class="w-3.5 h-3.5 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            ></circle>
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            ></path>
+          </svg>
+          <!-- Check icon -->
+          <svg
+            v-else-if="shareStatus === 'success'"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="w-3.5 h-3.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+          <!-- Error icon -->
+          <svg
+            v-else-if="shareStatus === 'error'"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="w-3.5 h-3.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+          <span v-if="!shareStatus">Copy to Clipboard</span>
+          <span v-else-if="shareStatus === 'copying'">Copying...</span>
+          <span v-else-if="shareStatus === 'success'">Copied!</span>
+          <span v-else-if="shareStatus === 'error'">Failed</span>
+        </button>
+      </div>
+
+      <!-- Screen reader description -->
+      <span class="sr-only">
+        {{ match.home_team_name }} {{ match.home_score ?? 'no score' }} versus
+        {{ match.away_team_name }} {{ match.away_score ?? 'no score' }}. Match
+        status: {{ match.match_status || 'scheduled' }}.
+        {{ match.match_type_name }} match on {{ formatDate(match.match_date) }}.
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted, watch } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import { getApiBaseUrl } from '../config/api';
+import html2canvas from 'html2canvas';
+
+export default {
+  name: 'MatchDetailView',
+  props: {
+    matchId: {
+      type: [Number, String],
+      required: true,
+    },
+  },
+  emits: ['back'],
+  setup(props) {
+    const authStore = useAuthStore();
+    const loading = ref(true);
+    const error = ref(null);
+    const match = ref(null);
+    const scoreboardRef = ref(null);
+    const shareStatus = ref(null); // 'copying', 'success', 'error'
+
+    // Get home team primary color for glow effect
+    const homeTeamColor = computed(() => {
+      return match.value?.home_team_club?.primary_color || '#3B82F6';
+    });
+
+    // Get away team primary color for glow effect
+    const awayTeamColor = computed(() => {
+      return match.value?.away_team_club?.primary_color || '#EF4444';
+    });
+
+    // Get league name from division object
+    const leagueName = computed(() => {
+      return match.value?.division?.leagues?.name || null;
+    });
+
+    // Status badge class based on match status
+    const statusBadgeClass = computed(() => {
+      const status = match.value?.match_status || 'scheduled';
+      const classes = {
+        completed: 'bg-green-900/50 text-green-400 border border-green-700',
+        scheduled: 'bg-blue-900/50 text-blue-400 border border-blue-700',
+        postponed: 'bg-yellow-900/50 text-yellow-400 border border-yellow-700',
+        cancelled: 'bg-red-900/50 text-red-400 border border-red-700',
+      };
+      return classes[status] || classes.scheduled;
+    });
+
+    // Get team initials for fallback logo
+    const getTeamInitials = teamName => {
+      if (!teamName) return '?';
+      return teamName
+        .split(' ')
+        .map(word => word[0])
+        .join('')
+        .substring(0, 3)
+        .toUpperCase();
+    };
+
+    // Format date for display
+    const formatDate = dateString => {
+      if (!dateString) return '';
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    };
+
+    // Fetch match details
+    const fetchMatch = async () => {
+      loading.value = true;
+      error.value = null;
+
+      try {
+        const data = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/matches/${props.matchId}`
+        );
+        match.value = data;
+      } catch (err) {
+        console.error('Error fetching match:', err);
+        if (err.message?.includes('401') || err.message?.includes('403')) {
+          error.value = 'You must be logged in to view match details';
+        } else if (err.message?.includes('404')) {
+          error.value = 'Match not found';
+        } else {
+          error.value = 'Failed to load match details';
+        }
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    // Watch for matchId changes
+    watch(
+      () => props.matchId,
+      () => {
+        fetchMatch();
+      }
+    );
+
+    onMounted(() => {
+      fetchMatch();
+    });
+
+    // Share scoreboard as image to clipboard
+    const shareScoreboard = async () => {
+      if (!scoreboardRef.value) return;
+
+      shareStatus.value = 'copying';
+
+      try {
+        const canvas = await html2canvas(scoreboardRef.value, {
+          backgroundColor: '#1e293b', // slate-800
+          scale: 2, // Higher resolution
+          logging: false,
+        });
+
+        canvas.toBlob(async blob => {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ 'image/png': blob }),
+            ]);
+            shareStatus.value = 'success';
+            setTimeout(() => {
+              shareStatus.value = null;
+            }, 2000);
+          } catch (err) {
+            console.error('Failed to copy to clipboard:', err);
+            shareStatus.value = 'error';
+            setTimeout(() => {
+              shareStatus.value = null;
+            }, 2000);
+          }
+        }, 'image/png');
+      } catch (err) {
+        console.error('Failed to capture scoreboard:', err);
+        shareStatus.value = 'error';
+        setTimeout(() => {
+          shareStatus.value = null;
+        }, 2000);
+      }
+    };
+
+    return {
+      loading,
+      error,
+      match,
+      homeTeamColor,
+      awayTeamColor,
+      leagueName,
+      statusBadgeClass,
+      getTeamInitials,
+      formatDate,
+      fetchMatch,
+      scoreboardRef,
+      shareStatus,
+      shareScoreboard,
+    };
+  },
+};
+</script>
+
+<style scoped>
+/* Glowing score numbers */
+.score-number {
+  text-shadow:
+    0 0 20px rgba(255, 255, 255, 0.4),
+    0 0 40px rgba(255, 255, 255, 0.2),
+    0 0 60px rgba(255, 255, 255, 0.1);
+}
+
+/* Detail item styling */
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Scoreboard subtle animation for live matches */
+@keyframes pulse-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 20px rgba(239, 68, 68, 0.3);
+  }
+  50% {
+    box-shadow: 0 0 40px rgba(239, 68, 68, 0.5);
+  }
+}
+
+.scoreboard:has(.animate-pulse) {
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+</style>

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -1,809 +1,1229 @@
 <template>
   <div>
-    <!-- Loading State -->
-    <div v-if="loading" class="text-center py-4">
-      Loading teams and matches...
-    </div>
+    <!-- Match Detail View -->
+    <MatchDetailView
+      v-if="selectedMatchId"
+      :matchId="selectedMatchId"
+      @back="handleBackFromDetail"
+    />
 
-    <!-- Error State -->
-    <div v-if="error" class="text-red-600 p-4 mb-4">Error: {{ error }}</div>
-
+    <!-- Matches List View -->
     <div v-else>
-      <!-- View Tabs: All Matches vs My Club -->
-      <div class="mb-6 border-b border-gray-200">
-        <nav class="flex space-x-4" aria-label="Match view tabs">
-          <button
-            @click="selectedViewTab = 'all'"
-            :class="[
-              'py-3 px-4 text-sm font-medium border-b-2 transition-colors',
-              selectedViewTab === 'all'
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
-            ]"
-          >
-            All Matches
-          </button>
-          <button
-            @click="selectedViewTab = 'myclub'"
-            :class="[
-              'py-3 px-4 text-sm font-medium border-b-2 transition-colors',
-              selectedViewTab === 'myclub'
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
-            ]"
-          >
-            My Club
-          </button>
-        </nav>
+      <!-- Loading State -->
+      <div v-if="loading" class="text-center py-4">
+        Loading teams and matches...
       </div>
 
-      <!-- Filters Section -->
-      <div class="mb-6">
-        <!-- Mobile: Collapsible Filters -->
-        <div class="lg:hidden mb-4">
-          <button
-            @click="showFilters = !showFilters"
-            class="w-full flex items-center justify-between px-4 py-3 bg-blue-600 text-white rounded-lg font-medium"
-          >
-            <span>Filters</span>
-            <svg
+      <!-- Error State -->
+      <div v-if="error" class="text-red-600 p-4 mb-4">Error: {{ error }}</div>
+
+      <div v-else>
+        <!-- View Tabs: All Matches vs My Club -->
+        <div class="mb-6 border-b border-gray-200">
+          <nav class="flex space-x-4" aria-label="Match view tabs">
+            <button
+              @click="selectedViewTab = 'all'"
               :class="[
-                'w-5 h-5 transition-transform',
-                showFilters ? 'rotate-180' : '',
+                'py-3 px-4 text-sm font-medium border-b-2 transition-colors',
+                selectedViewTab === 'all'
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
               ]"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </button>
+              All Matches
+            </button>
+            <button
+              @click="selectedViewTab = 'myclub'"
+              :class="[
+                'py-3 px-4 text-sm font-medium border-b-2 transition-colors',
+                selectedViewTab === 'myclub'
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+              ]"
+            >
+              My Club
+            </button>
+          </nav>
         </div>
 
-        <!-- Filters Content -->
-        <div :class="['space-y-4', showFilters || 'hidden lg:block']">
-          <!-- My Club Filters - Only show on My Club tab -->
-          <div v-if="selectedViewTab === 'myclub'" class="space-y-4">
-            <!-- League Selector - For admins and players who can browse all -->
-            <div v-if="authStore.canBrowseAll.value">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
-                >Select League</label
+        <!-- Filters Section -->
+        <div class="mb-6">
+          <!-- Mobile: Collapsible Filters -->
+          <div class="lg:hidden mb-4">
+            <button
+              @click="showFilters = !showFilters"
+              class="w-full flex items-center justify-between px-4 py-3 bg-blue-600 text-white rounded-lg font-medium"
+            >
+              <span>Filters</span>
+              <svg
+                :class="[
+                  'w-5 h-5 transition-transform',
+                  showFilters ? 'rotate-180' : '',
+                ]"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
               >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Filters Content -->
+          <div :class="['space-y-4', showFilters || 'hidden lg:block']">
+            <!-- My Club Filters - Only show on My Club tab -->
+            <div v-if="selectedViewTab === 'myclub'" class="space-y-4">
+              <!-- League Selector - For admins and players who can browse all -->
+              <div v-if="authStore.canBrowseAll.value">
+                <label class="block text-sm font-medium text-gray-700 mb-2"
+                  >Select League</label
+                >
+                <select
+                  v-model="selectedLeagueId"
+                  class="block w-full px-4 py-3 text-base border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option :value="null">-- Select a league --</option>
+                  <option
+                    v-for="league in leagues"
+                    :key="league.id"
+                    :value="league.id"
+                  >
+                    {{ league.name }}
+                  </option>
+                </select>
+              </div>
+
+              <!-- League Display - For non-admins who cannot browse all (read-only) -->
+              <div v-else-if="userLeagueInfo">
+                <label class="block text-sm font-medium text-gray-700 mb-2"
+                  >League</label
+                >
+                <div
+                  class="block w-full px-4 py-3 text-base bg-gray-50 border border-gray-300 rounded-lg text-gray-700"
+                >
+                  {{ userLeagueInfo.leagueName }}
+                </div>
+              </div>
+
+              <!-- Team Selector -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2"
+                  >Select Club</label
+                >
+                <select
+                  v-model="selectedTeam"
+                  @change="onTeamChange"
+                  :disabled="
+                    !authStore.canBrowseAll.value && authStore.userTeamId.value
+                  "
+                  class="block w-full px-4 py-3 text-base border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-700"
+                >
+                  <option value="">
+                    {{
+                      authStore.canBrowseAll.value
+                        ? '-- Select a club --'
+                        : 'No club assigned'
+                    }}
+                  </option>
+                  <option
+                    v-for="team in filteredTeamsByLeague"
+                    :key="team.id"
+                    :value="team.id"
+                  >
+                    {{ getTeamDisplayName(team) }}
+                  </option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Age Group Filter -->
+            <div>
+              <h3 class="text-sm font-medium text-gray-700 mb-2">Age Groups</h3>
+              <div
+                class="grid grid-cols-2 sm:grid-cols-3 lg:flex lg:flex-wrap gap-2"
+              >
+                <button
+                  v-for="ageGroup in filteredAgeGroups"
+                  :key="ageGroup.id"
+                  @click="selectedAgeGroupId = ageGroup.id"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    selectedAgeGroupId === ageGroup.id
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300',
+                  ]"
+                >
+                  {{ ageGroup.name }}
+                </button>
+              </div>
+            </div>
+
+            <!-- Season Dropdown -->
+            <div>
+              <h3 class="text-sm font-medium text-gray-700 mb-2">Season</h3>
               <select
-                v-model="selectedLeagueId"
+                v-model="selectedSeasonId"
                 class="block w-full px-4 py-3 text-base border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               >
-                <option :value="null">-- Select a league --</option>
                 <option
-                  v-for="league in leagues"
-                  :key="league.id"
-                  :value="league.id"
+                  v-for="season in seasons"
+                  :key="season.id"
+                  :value="season.id"
                 >
-                  {{ league.name }}
+                  {{ season.name }} ({{ formatSeasonDates(season) }})
                 </option>
               </select>
             </div>
 
-            <!-- League Display - For non-admins who cannot browse all (read-only) -->
-            <div v-else-if="userLeagueInfo">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
-                >League</label
-              >
-              <div
-                class="block w-full px-4 py-3 text-base bg-gray-50 border border-gray-300 rounded-lg text-gray-700"
-              >
-                {{ userLeagueInfo.leagueName }}
-              </div>
-            </div>
-
-            <!-- Team Selector -->
+            <!-- Match Type Filter -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
-                >Select Club</label
+              <h3 class="text-sm font-medium text-gray-700 mb-2">Match Type</h3>
+              <div
+                class="grid grid-cols-2 sm:grid-cols-3 lg:flex lg:flex-wrap gap-2"
               >
-              <select
-                v-model="selectedTeam"
-                @change="onTeamChange"
-                :disabled="
-                  !authStore.canBrowseAll.value && authStore.userTeamId.value
-                "
-                class="block w-full px-4 py-3 text-base border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-700"
-              >
-                <option value="">
-                  {{
-                    authStore.canBrowseAll.value
-                      ? '-- Select a club --'
-                      : 'No club assigned'
-                  }}
-                </option>
-                <option
-                  v-for="team in filteredTeamsByLeague"
-                  :key="team.id"
-                  :value="team.id"
+                <button
+                  @click="selectedMatchTypeId = 1"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    selectedMatchTypeId === 1
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300',
+                  ]"
                 >
-                  {{ getTeamDisplayName(team) }}
-                </option>
-              </select>
+                  League
+                </button>
+                <button
+                  @click="selectedMatchTypeId = 3"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    selectedMatchTypeId === 3
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300',
+                  ]"
+                >
+                  Friendly
+                </button>
+                <button
+                  @click="selectedMatchTypeId = 2"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    selectedMatchTypeId === 2
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300',
+                  ]"
+                >
+                  Tournament
+                </button>
+                <button
+                  @click="selectedMatchTypeId = 4"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    selectedMatchTypeId === 4
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300',
+                  ]"
+                >
+                  Playoff
+                </button>
+                <button
+                  @click="selectedMatchTypeId = null"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    selectedMatchTypeId === null
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300',
+                  ]"
+                >
+                  All Matches
+                </button>
+              </div>
             </div>
-          </div>
 
-          <!-- Age Group Filter -->
-          <div>
-            <h3 class="text-sm font-medium text-gray-700 mb-2">Age Groups</h3>
-            <div
-              class="grid grid-cols-2 sm:grid-cols-3 lg:flex lg:flex-wrap gap-2"
-            >
-              <button
-                v-for="ageGroup in filteredAgeGroups"
-                :key="ageGroup.id"
-                @click="selectedAgeGroupId = ageGroup.id"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  selectedAgeGroupId === ageGroup.id
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300',
-                ]"
-              >
-                {{ ageGroup.name }}
-              </button>
-            </div>
-          </div>
-
-          <!-- Season Dropdown -->
-          <div>
-            <h3 class="text-sm font-medium text-gray-700 mb-2">Season</h3>
-            <select
-              v-model="selectedSeasonId"
-              class="block w-full px-4 py-3 text-base border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-            >
-              <option
-                v-for="season in seasons"
-                :key="season.id"
-                :value="season.id"
-              >
-                {{ season.name }} ({{ formatSeasonDates(season) }})
-              </option>
-            </select>
-          </div>
-
-          <!-- Match Type Filter -->
-          <div>
-            <h3 class="text-sm font-medium text-gray-700 mb-2">Match Type</h3>
-            <div
-              class="grid grid-cols-2 sm:grid-cols-3 lg:flex lg:flex-wrap gap-2"
-            >
-              <button
-                @click="selectedMatchTypeId = 1"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  selectedMatchTypeId === 1
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300',
-                ]"
-              >
-                League
-              </button>
-              <button
-                @click="selectedMatchTypeId = 3"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  selectedMatchTypeId === 3
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300',
-                ]"
-              >
-                Friendly
-              </button>
-              <button
-                @click="selectedMatchTypeId = 2"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  selectedMatchTypeId === 2
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300',
-                ]"
-              >
-                Tournament
-              </button>
-              <button
-                @click="selectedMatchTypeId = 4"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  selectedMatchTypeId === 4
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300',
-                ]"
-              >
-                Playoff
-              </button>
-              <button
-                @click="selectedMatchTypeId = null"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  selectedMatchTypeId === null
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300',
-                ]"
-              >
-                All Matches
-              </button>
-            </div>
-          </div>
-
-          <!-- Time Range Filter - Only show on "All Matches" tab -->
-          <div v-if="selectedViewTab === 'all'">
-            <h3 class="text-sm font-medium text-gray-700 mb-2">
-              Week Navigation
-            </h3>
-            <div class="grid grid-cols-3 gap-2">
-              <button
-                @click="weekOffset--"
-                class="px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px] bg-gray-100 text-gray-700 active:bg-gray-300 hover:bg-gray-200"
-              >
-                ← Previous
-              </button>
-              <button
-                @click="weekOffset = 0"
-                :class="[
-                  'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
-                  weekOffset === 0
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 active:bg-gray-300 hover:bg-gray-200',
-                ]"
-              >
-                This Week
-              </button>
-              <button
-                @click="weekOffset++"
-                class="px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px] bg-gray-100 text-gray-700 active:bg-gray-300 hover:bg-gray-200"
-              >
-                Next →
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Display Filtered Matchs -->
-      <div v-if="sortedGames.length > 0">
-        <div class="mb-4">
-          <!-- All Matches: Show week range -->
-          <div v-if="selectedViewTab === 'all'">
-            <h3 class="text-lg font-semibold mb-2">{{ weekRangeDisplay }}</h3>
-          </div>
-
-          <!-- My Club: Show team name and league info -->
-          <div v-else>
-            <h3 class="text-lg font-semibold mb-2">
-              Matchs for {{ getSelectedTeamName() }}
-            </h3>
-
-            <!-- League Information -->
-            <div
-              v-if="selectedTeamLeagueInfo"
-              class="inline-flex items-center space-x-2 px-3 py-1 bg-blue-50 border border-blue-200 rounded-md text-sm"
-            >
-              <span class="font-medium text-blue-800">League:</span>
-              <span class="text-blue-700"
-                >{{ selectedTeamLeagueInfo.league }} -
-                {{ selectedTeamLeagueInfo.division }} ({{
-                  selectedTeamLeagueInfo.ageGroup
-                }})</span
-              >
-              <span class="text-blue-600">• {{ selectedSeasonName }}</span>
+            <!-- Time Range Filter - Only show on "All Matches" tab -->
+            <div v-if="selectedViewTab === 'all'">
+              <h3 class="text-sm font-medium text-gray-700 mb-2">
+                Week Navigation
+              </h3>
+              <div class="grid grid-cols-3 gap-2">
+                <button
+                  @click="weekOffset--"
+                  class="px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px] bg-gray-100 text-gray-700 active:bg-gray-300 hover:bg-gray-200"
+                >
+                  ← Previous
+                </button>
+                <button
+                  @click="weekOffset = 0"
+                  :class="[
+                    'px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px]',
+                    weekOffset === 0
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 active:bg-gray-300 hover:bg-gray-200',
+                  ]"
+                >
+                  This Week
+                </button>
+                <button
+                  @click="weekOffset++"
+                  class="px-4 py-3 text-sm rounded-lg font-medium transition-colors min-h-[44px] bg-gray-100 text-gray-700 active:bg-gray-300 hover:bg-gray-200"
+                >
+                  Next →
+                </button>
+              </div>
             </div>
           </div>
         </div>
 
-        <!-- Season Summary Stats - Only show on My Club tab when a team is selected -->
-        <div
-          v-if="selectedViewTab === 'myclub' && selectedTeam"
-          class="mb-4 space-y-3"
-        >
-          <div class="p-4 bg-gray-50 rounded-lg border border-gray-200">
-            <h4 class="font-medium text-gray-700 mb-3">Season Summary</h4>
-            <div class="grid grid-cols-4 sm:grid-cols-8 gap-3 text-sm">
-              <div class="font-medium">GP: {{ seasonStats.matchesPlayed }}</div>
-              <div class="font-medium">W: {{ seasonStats.wins }}</div>
-              <div class="font-medium">D: {{ seasonStats.draws }}</div>
-              <div class="font-medium">L: {{ seasonStats.losses }}</div>
-              <div>GF: {{ seasonStats.goalsFor }}</div>
-              <div>GA: {{ seasonStats.goalsAgainst }}</div>
-              <div>
-                GD: {{ seasonStats.goalDifference > 0 ? '+' : ''
-                }}{{ seasonStats.goalDifference }}
+        <!-- Display Filtered Matchs -->
+        <div v-if="sortedGames.length > 0">
+          <div class="mb-4">
+            <!-- All Matches: Show week range -->
+            <div v-if="selectedViewTab === 'all'">
+              <h3 class="text-lg font-semibold mb-2">{{ weekRangeDisplay }}</h3>
+            </div>
+
+            <!-- My Club: Show team name and league info -->
+            <div v-else>
+              <h3 class="text-lg font-semibold mb-2">
+                Matchs for {{ getSelectedTeamName() }}
+              </h3>
+
+              <!-- League Information -->
+              <div
+                v-if="selectedTeamLeagueInfo"
+                class="inline-flex items-center space-x-2 px-3 py-1 bg-blue-50 border border-blue-200 rounded-md text-sm"
+              >
+                <span class="font-medium text-blue-800">League:</span>
+                <span class="text-blue-700"
+                  >{{ selectedTeamLeagueInfo.league }} -
+                  {{ selectedTeamLeagueInfo.division }} ({{
+                    selectedTeamLeagueInfo.ageGroup
+                  }})</span
+                >
+                <span class="text-blue-600">• {{ selectedSeasonName }}</span>
               </div>
-              <div class="font-bold">PTS: {{ seasonStats.points }}</div>
             </div>
           </div>
 
-          <!-- Season Segments - Stack on mobile -->
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            <!-- Fall Segment - Only show if Fall matches exist -->
-            <div
-              v-if="seasonStats.hasFallGames"
-              class="p-4 bg-blue-50 rounded-lg border border-blue-100"
-            >
-              <h4 class="font-medium text-blue-700 mb-2">Fall Segment</h4>
-              <div class="grid grid-cols-3 gap-2 text-sm">
+          <!-- Season Summary Stats - Only show on My Club tab when a team is selected -->
+          <div
+            v-if="selectedViewTab === 'myclub' && selectedTeam"
+            class="mb-4 space-y-3"
+          >
+            <div class="p-4 bg-gray-50 rounded-lg border border-gray-200">
+              <h4 class="font-medium text-gray-700 mb-3">Season Summary</h4>
+              <div class="grid grid-cols-4 sm:grid-cols-8 gap-3 text-sm">
                 <div class="font-medium">
-                  W: {{ seasonStats.fallWins || 0 }}
+                  GP: {{ seasonStats.matchesPlayed }}
                 </div>
-                <div class="font-medium">
-                  D: {{ seasonStats.fallDraws || 0 }}
+                <div class="font-medium">W: {{ seasonStats.wins }}</div>
+                <div class="font-medium">D: {{ seasonStats.draws }}</div>
+                <div class="font-medium">L: {{ seasonStats.losses }}</div>
+                <div>GF: {{ seasonStats.goalsFor }}</div>
+                <div>GA: {{ seasonStats.goalsAgainst }}</div>
+                <div>
+                  GD: {{ seasonStats.goalDifference > 0 ? '+' : ''
+                  }}{{ seasonStats.goalDifference }}
                 </div>
-                <div class="font-medium">
-                  L: {{ seasonStats.fallLosses || 0 }}
-                </div>
-                <div class="col-span-3 text-xs text-gray-500 mt-1">
-                  Aug - Dec matches
-                </div>
+                <div class="font-bold">PTS: {{ seasonStats.points }}</div>
               </div>
             </div>
 
-            <!-- Spring Segment - Only show if Spring matches exist -->
-            <div
-              v-if="seasonStats.hasSpringGames"
-              class="p-4 bg-green-50 rounded-lg border border-green-100"
-            >
-              <h4 class="font-medium text-green-700 mb-2">Spring Segment</h4>
-              <div class="grid grid-cols-3 gap-2 text-sm">
-                <div class="font-medium">
-                  W: {{ seasonStats.springWins || 0 }}
+            <!-- Season Segments - Stack on mobile -->
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              <!-- Fall Segment - Only show if Fall matches exist -->
+              <div
+                v-if="seasonStats.hasFallGames"
+                class="p-4 bg-blue-50 rounded-lg border border-blue-100"
+              >
+                <h4 class="font-medium text-blue-700 mb-2">Fall Segment</h4>
+                <div class="grid grid-cols-3 gap-2 text-sm">
+                  <div class="font-medium">
+                    W: {{ seasonStats.fallWins || 0 }}
+                  </div>
+                  <div class="font-medium">
+                    D: {{ seasonStats.fallDraws || 0 }}
+                  </div>
+                  <div class="font-medium">
+                    L: {{ seasonStats.fallLosses || 0 }}
+                  </div>
+                  <div class="col-span-3 text-xs text-gray-500 mt-1">
+                    Aug - Dec matches
+                  </div>
                 </div>
-                <div class="font-medium">
-                  D: {{ seasonStats.springDraws || 0 }}
+              </div>
+
+              <!-- Spring Segment - Only show if Spring matches exist -->
+              <div
+                v-if="seasonStats.hasSpringGames"
+                class="p-4 bg-green-50 rounded-lg border border-green-100"
+              >
+                <h4 class="font-medium text-green-700 mb-2">Spring Segment</h4>
+                <div class="grid grid-cols-3 gap-2 text-sm">
+                  <div class="font-medium">
+                    W: {{ seasonStats.springWins || 0 }}
+                  </div>
+                  <div class="font-medium">
+                    D: {{ seasonStats.springDraws || 0 }}
+                  </div>
+                  <div class="font-medium">
+                    L: {{ seasonStats.springLosses || 0 }}
+                  </div>
+                  <div class="col-span-3 text-xs text-gray-500 mt-1">
+                    Jan - July matches
+                  </div>
                 </div>
-                <div class="font-medium">
-                  L: {{ seasonStats.springLosses || 0 }}
-                </div>
-                <div class="col-span-3 text-xs text-gray-500 mt-1">
-                  Jan - July matches
+              </div>
+
+              <!-- Last 5 Matchs - Only show if matches exist -->
+              <div
+                v-if="seasonStats.matchesPlayed > 0"
+                class="p-4 bg-purple-50 rounded-lg border border-purple-100"
+              >
+                <h4 class="font-medium text-purple-700 mb-2">Last 5 Matchs</h4>
+                <div class="flex space-x-2 justify-center sm:justify-start">
+                  <template v-if="seasonStats.lastFive.length > 0">
+                    <span
+                      v-for="(result, index) in seasonStats.lastFive"
+                      :key="index"
+                      class="w-8 h-8 flex items-center justify-center rounded-full text-sm font-medium"
+                      :class="{
+                        'bg-green-100 text-green-800': result === 'W',
+                        'bg-yellow-100 text-yellow-800': result === 'D',
+                        'bg-red-100 text-red-800': result === 'L',
+                        'bg-gray-100 text-gray-500': result === '-',
+                      }"
+                    >
+                      {{ result }}
+                    </span>
+                  </template>
+                  <span v-else class="text-sm text-gray-500"
+                    >No recent matches</span
+                  >
                 </div>
               </div>
             </div>
+          </div>
 
-            <!-- Last 5 Matchs - Only show if matches exist -->
-            <div
-              v-if="seasonStats.matchesPlayed > 0"
-              class="p-4 bg-purple-50 rounded-lg border border-purple-100"
-            >
-              <h4 class="font-medium text-purple-700 mb-2">Last 5 Matchs</h4>
-              <div class="flex space-x-2 justify-center sm:justify-start">
-                <template v-if="seasonStats.lastFive.length > 0">
+          <!-- Desktop: Table View -->
+          <table class="hidden lg:table w-full border border-gray-300">
+            <thead>
+              <tr>
+                <th
+                  v-if="selectedViewTab === 'myclub'"
+                  class="border-b text-right w-12"
+                >
+                  #
+                </th>
+                <th class="border-b text-center w-32">Date</th>
+                <th class="border-b text-left px-2">Team</th>
+                <th class="border-b text-center w-24">Score</th>
+                <th
+                  v-if="selectedViewTab === 'myclub'"
+                  class="border-b text-center w-20"
+                >
+                  Result
+                </th>
+                <th class="border-b text-center w-24">Match Type</th>
+                <th class="border-b text-center w-24">Status</th>
+                <th
+                  v-if="authStore.isAdmin.value"
+                  class="border-b text-center w-32"
+                >
+                  Match ID
+                </th>
+                <th
+                  v-if="authStore.isAdmin.value"
+                  class="border-b text-center w-16"
+                >
+                  Source
+                </th>
+                <th
+                  v-if="authStore.isAuthenticated.value"
+                  class="border-b text-center w-24"
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- All Matches view: Group by league with section headers -->
+              <template v-if="selectedViewTab === 'all'">
+                <!-- Homegrown Section -->
+                <tr v-if="homegrownMatches.length > 0">
+                  <td
+                    :colspan="tableColumnCount"
+                    class="bg-blue-600 text-white font-bold text-sm py-2 px-4 border-b-2 border-blue-700"
+                  >
+                    HOMEGROWN LEAGUE
+                  </td>
+                </tr>
+                <tr
+                  v-for="(match, index) in homegrownMatches"
+                  :key="`homegrown-${match.id}`"
+                  :class="{ 'bg-gray-100': index % 2 === 0 }"
+                >
+                  <td class="border-b text-center">{{ match.match_date }}</td>
+                  <td
+                    class="border-b text-left px-2"
+                    v-html="getTeamDisplay(match)"
+                  ></td>
+                  <td class="border-b text-center">
+                    {{ getScoreDisplay(match) }}
+                  </td>
+                  <td class="border-b text-center">
+                    {{ match.match_type_name || 'League' }}
+                  </td>
+                  <td class="border-b text-center">
+                    <span
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-green-100 text-green-800':
+                          match.match_status === 'completed',
+                        'bg-blue-100 text-blue-800':
+                          match.match_status === 'scheduled',
+                        'bg-yellow-100 text-yellow-800':
+                          match.match_status === 'postponed',
+                        'bg-red-100 text-red-800':
+                          match.match_status === 'cancelled',
+                        'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
+                          match.match_status === 'live',
+                        'bg-gray-100 text-gray-800': !match.match_status,
+                      }"
+                    >
+                      {{
+                        match.match_status === 'live'
+                          ? '🔴 LIVE'
+                          : match.match_status || 'scheduled'
+                      }}
+                    </span>
+                  </td>
+                  <td
+                    v-if="authStore.isAdmin.value"
+                    class="border-b text-center"
+                  >
+                    <span
+                      v-if="match.match_id"
+                      class="text-xs font-mono text-gray-700"
+                      :title="`External Match ID: ${match.match_id}`"
+                    >
+                      {{ match.match_id }}
+                    </span>
+                    <span v-else class="text-gray-400 text-xs">-</span>
+                  </td>
+                  <td
+                    v-if="authStore.isAdmin.value"
+                    class="border-b text-center"
+                  >
+                    <span
+                      :title="getSourceTooltip(match)"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-purple-100 text-purple-800':
+                          match.source === 'match-scraper',
+                        'bg-gray-100 text-gray-700': match.source === 'manual',
+                        'bg-yellow-100 text-yellow-700':
+                          match.source === 'import',
+                      }"
+                    >
+                      {{ getSourceDisplay(match.source) }}
+                    </span>
+                  </td>
+                  <td
+                    v-if="authStore.isAuthenticated.value"
+                    class="border-b text-center space-x-2"
+                  >
+                    <button
+                      @click="viewMatch(match)"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      View
+                    </button>
+                    <button
+                      v-if="canEditGame(match)"
+                      @click="editMatch(match)"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+
+                <!-- Academy Section -->
+                <tr v-if="academyMatches.length > 0">
+                  <td
+                    :colspan="tableColumnCount"
+                    class="bg-green-600 text-white font-bold text-sm py-2 px-4 border-b-2 border-green-700"
+                  >
+                    ACADEMY LEAGUE
+                  </td>
+                </tr>
+                <tr
+                  v-for="(match, index) in academyMatches"
+                  :key="`academy-${match.id}`"
+                  :class="{ 'bg-gray-100': index % 2 === 0 }"
+                >
+                  <td class="border-b text-center">{{ match.match_date }}</td>
+                  <td
+                    class="border-b text-left px-2"
+                    v-html="getTeamDisplay(match)"
+                  ></td>
+                  <td class="border-b text-center">
+                    {{ getScoreDisplay(match) }}
+                  </td>
+                  <td class="border-b text-center">
+                    {{ match.match_type_name || 'League' }}
+                  </td>
+                  <td class="border-b text-center">
+                    <span
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-green-100 text-green-800':
+                          match.match_status === 'completed',
+                        'bg-blue-100 text-blue-800':
+                          match.match_status === 'scheduled',
+                        'bg-yellow-100 text-yellow-800':
+                          match.match_status === 'postponed',
+                        'bg-red-100 text-red-800':
+                          match.match_status === 'cancelled',
+                        'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
+                          match.match_status === 'live',
+                        'bg-gray-100 text-gray-800': !match.match_status,
+                      }"
+                    >
+                      {{
+                        match.match_status === 'live'
+                          ? '🔴 LIVE'
+                          : match.match_status || 'scheduled'
+                      }}
+                    </span>
+                  </td>
+                  <td
+                    v-if="authStore.isAdmin.value"
+                    class="border-b text-center"
+                  >
+                    <span
+                      v-if="match.match_id"
+                      class="text-xs font-mono text-gray-700"
+                      :title="`External Match ID: ${match.match_id}`"
+                    >
+                      {{ match.match_id }}
+                    </span>
+                    <span v-else class="text-gray-400 text-xs">-</span>
+                  </td>
+                  <td
+                    v-if="authStore.isAdmin.value"
+                    class="border-b text-center"
+                  >
+                    <span
+                      :title="getSourceTooltip(match)"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-purple-100 text-purple-800':
+                          match.source === 'match-scraper',
+                        'bg-gray-100 text-gray-700': match.source === 'manual',
+                        'bg-yellow-100 text-yellow-700':
+                          match.source === 'import',
+                      }"
+                    >
+                      {{ getSourceDisplay(match.source) }}
+                    </span>
+                  </td>
+                  <td
+                    v-if="authStore.isAuthenticated.value"
+                    class="border-b text-center space-x-2"
+                  >
+                    <button
+                      @click="viewMatch(match)"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      View
+                    </button>
+                    <button
+                      v-if="canEditGame(match)"
+                      @click="editMatch(match)"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+
+                <!-- Other matches (without league info) -->
+                <tr v-if="otherMatches.length > 0">
+                  <td
+                    :colspan="tableColumnCount"
+                    class="bg-gray-600 text-white font-bold text-sm py-2 px-4 border-b-2 border-gray-700"
+                  >
+                    OTHER MATCHES
+                  </td>
+                </tr>
+                <tr
+                  v-for="(match, index) in otherMatches"
+                  :key="`other-${match.id}`"
+                  :class="{ 'bg-gray-100': index % 2 === 0 }"
+                >
+                  <td class="border-b text-center">{{ match.match_date }}</td>
+                  <td
+                    class="border-b text-left px-2"
+                    v-html="getTeamDisplay(match)"
+                  ></td>
+                  <td class="border-b text-center">
+                    {{ getScoreDisplay(match) }}
+                  </td>
+                  <td class="border-b text-center">
+                    {{ match.match_type_name || 'League' }}
+                  </td>
+                  <td class="border-b text-center">
+                    <span
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-green-100 text-green-800':
+                          match.match_status === 'completed',
+                        'bg-blue-100 text-blue-800':
+                          match.match_status === 'scheduled',
+                        'bg-yellow-100 text-yellow-800':
+                          match.match_status === 'postponed',
+                        'bg-red-100 text-red-800':
+                          match.match_status === 'cancelled',
+                        'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
+                          match.match_status === 'live',
+                        'bg-gray-100 text-gray-800': !match.match_status,
+                      }"
+                    >
+                      {{
+                        match.match_status === 'live'
+                          ? '🔴 LIVE'
+                          : match.match_status || 'scheduled'
+                      }}
+                    </span>
+                  </td>
+                  <td
+                    v-if="authStore.isAdmin.value"
+                    class="border-b text-center"
+                  >
+                    <span
+                      v-if="match.match_id"
+                      class="text-xs font-mono text-gray-700"
+                      :title="`External Match ID: ${match.match_id}`"
+                    >
+                      {{ match.match_id }}
+                    </span>
+                    <span v-else class="text-gray-400 text-xs">-</span>
+                  </td>
+                  <td
+                    v-if="authStore.isAdmin.value"
+                    class="border-b text-center"
+                  >
+                    <span
+                      :title="getSourceTooltip(match)"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-purple-100 text-purple-800':
+                          match.source === 'match-scraper',
+                        'bg-gray-100 text-gray-700': match.source === 'manual',
+                        'bg-yellow-100 text-yellow-700':
+                          match.source === 'import',
+                      }"
+                    >
+                      {{ getSourceDisplay(match.source) }}
+                    </span>
+                  </td>
+                  <td
+                    v-if="authStore.isAuthenticated.value"
+                    class="border-b text-center space-x-2"
+                  >
+                    <button
+                      @click="viewMatch(match)"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      View
+                    </button>
+                    <button
+                      v-if="canEditGame(match)"
+                      @click="editMatch(match)"
+                      class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    >
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              </template>
+
+              <!-- My Club view: Regular rendering -->
+              <tr
+                v-else
+                v-for="(match, index) in sortedGames"
+                :key="match.id"
+                :class="{ 'bg-gray-100': index % 2 === 0 }"
+              >
+                <td
+                  v-if="selectedViewTab === 'myclub'"
+                  class="border-b text-right"
+                >
+                  {{ index + 1 }}
+                </td>
+                <td class="border-b text-center">{{ match.match_date }}</td>
+                <td
+                  class="border-b text-left px-2"
+                  v-html="getTeamDisplay(match)"
+                ></td>
+                <td class="border-b text-center">
+                  {{ getScoreDisplay(match) }}
+                </td>
+                <td
+                  v-if="selectedViewTab === 'myclub'"
+                  class="border-b text-center"
+                >
                   <span
-                    v-for="(result, index) in seasonStats.lastFive"
-                    :key="index"
-                    class="w-8 h-8 flex items-center justify-center rounded-full text-sm font-medium"
+                    v-if="
+                      match.match_status === 'completed' &&
+                      getResult(match) !== '-'
+                    "
+                    class="px-2 py-1 rounded-full text-sm font-bold"
                     :class="{
-                      'bg-green-100 text-green-800': result === 'W',
-                      'bg-yellow-100 text-yellow-800': result === 'D',
-                      'bg-red-100 text-red-800': result === 'L',
-                      'bg-gray-100 text-gray-500': result === '-',
+                      'bg-green-100 text-green-800': getResult(match) === 'W',
+                      'bg-yellow-100 text-yellow-800': getResult(match) === 'T',
+                      'bg-red-100 text-red-800': getResult(match) === 'L',
                     }"
                   >
-                    {{ result }}
+                    {{ getResult(match) }}
                   </span>
-                </template>
-                <span v-else class="text-sm text-gray-500"
-                  >No recent matches</span
+                  <span v-else class="text-gray-400">-</span>
+                </td>
+                <td class="border-b text-center">
+                  {{ match.match_type_name || 'League' }}
+                </td>
+                <td class="border-b text-center">
+                  <span
+                    :class="{
+                      'px-2 py-1 rounded text-xs font-medium': true,
+                      'bg-green-100 text-green-800':
+                        match.match_status === 'completed',
+                      'bg-blue-100 text-blue-800':
+                        match.match_status === 'scheduled',
+                      'bg-yellow-100 text-yellow-800':
+                        match.match_status === 'postponed',
+                      'bg-red-100 text-red-800':
+                        match.match_status === 'cancelled',
+                      'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
+                        match.match_status === 'live',
+                      'bg-gray-100 text-gray-800': !match.match_status,
+                    }"
+                  >
+                    {{
+                      match.match_status === 'live'
+                        ? '🔴 LIVE'
+                        : match.match_status || 'scheduled'
+                    }}
+                  </span>
+                </td>
+                <td v-if="authStore.isAdmin.value" class="border-b text-center">
+                  <span
+                    v-if="match.match_id"
+                    class="text-xs font-mono text-gray-700"
+                    :title="`External Match ID: ${match.match_id}`"
+                  >
+                    {{ match.match_id }}
+                  </span>
+                  <span v-else class="text-gray-400 text-xs">-</span>
+                </td>
+                <td v-if="authStore.isAdmin.value" class="border-b text-center">
+                  <span
+                    :title="getSourceTooltip(match)"
+                    :class="{
+                      'px-2 py-1 rounded text-xs font-medium': true,
+                      'bg-purple-100 text-purple-800':
+                        match.source === 'match-scraper',
+                      'bg-gray-100 text-gray-700': match.source === 'manual',
+                      'bg-yellow-100 text-yellow-700':
+                        match.source === 'import',
+                    }"
+                  >
+                    {{ getSourceDisplay(match.source) }}
+                  </span>
+                </td>
+                <td
+                  v-if="authStore.isAuthenticated.value"
+                  class="border-b text-center space-x-2"
                 >
-              </div>
-            </div>
-          </div>
-        </div>
+                  <button
+                    @click="viewMatch(match)"
+                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                  >
+                    View
+                  </button>
+                  <button
+                    v-if="canEditGame(match)"
+                    @click="editMatch(match)"
+                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                  >
+                    Edit
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
 
-        <!-- Desktop: Table View -->
-        <table class="hidden lg:table w-full border border-gray-300">
-          <thead>
-            <tr>
-              <th
-                v-if="selectedViewTab === 'myclub'"
-                class="border-b text-right w-12"
-              >
-                #
-              </th>
-              <th class="border-b text-center w-32">Date</th>
-              <th class="border-b text-left px-2">Team</th>
-              <th class="border-b text-center w-24">Score</th>
-              <th
-                v-if="selectedViewTab === 'myclub'"
-                class="border-b text-center w-20"
-              >
-                Result
-              </th>
-              <th class="border-b text-center w-24">Match Type</th>
-              <th class="border-b text-center w-24">Status</th>
-              <th class="border-b text-center w-32">Match ID</th>
-              <th class="border-b text-center w-16">Source</th>
-              <th v-if="canEditGames" class="border-b text-center w-24">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+          <!-- Mobile: Card View -->
+          <div class="lg:hidden space-y-3">
             <!-- All Matches view: Group by league with section headers -->
             <template v-if="selectedViewTab === 'all'">
               <!-- Homegrown Section -->
-              <tr v-if="homegrownMatches.length > 0">
-                <td
-                  :colspan="canEditGames ? 9 : 8"
-                  class="bg-blue-600 text-white font-bold text-sm py-2 px-4 border-b-2 border-blue-700"
-                >
-                  HOMEGROWN LEAGUE
-                </td>
-              </tr>
-              <tr
+              <div
+                v-if="homegrownMatches.length > 0"
+                class="bg-blue-600 text-white font-bold text-sm py-2 px-4 rounded-lg"
+              >
+                HOMEGROWN LEAGUE
+              </div>
+              <div
                 v-for="(match, index) in homegrownMatches"
                 :key="`homegrown-${match.id}`"
-                :class="{ 'bg-gray-100': index % 2 === 0 }"
+                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
               >
-                <td class="border-b text-center">{{ match.match_date }}</td>
-                <td
-                  class="border-b text-left px-2"
-                  v-html="getTeamDisplay(match)"
-                ></td>
-                <td class="border-b text-center">
-                  {{ getScoreDisplay(match) }}
-                </td>
-                <td class="border-b text-center">
-                  {{ match.match_type_name || 'League' }}
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-green-100 text-green-800':
-                        match.match_status === 'completed',
-                      'bg-blue-100 text-blue-800':
-                        match.match_status === 'scheduled',
-                      'bg-yellow-100 text-yellow-800':
-                        match.match_status === 'postponed',
-                      'bg-red-100 text-red-800':
-                        match.match_status === 'cancelled',
-                      'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
-                        match.match_status === 'live',
-                      'bg-gray-100 text-gray-800': !match.match_status,
-                    }"
+                <!-- Match Number and Date -->
+                <div
+                  class="flex items-center justify-between mb-3 pb-3 border-b border-gray-100"
+                >
+                  <span class="text-xs font-medium text-gray-500"
+                    >Game #{{ index + 1 }}</span
                   >
-                    {{
-                      match.match_status === 'live'
-                        ? '🔴 LIVE'
-                        : match.match_status || 'scheduled'
-                    }}
-                  </span>
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    v-if="match.match_id"
-                    class="text-xs font-mono text-gray-700"
-                    :title="`External Match ID: ${match.match_id}`"
+                  <span class="text-sm font-medium text-gray-700">{{
+                    match.match_date
+                  }}</span>
+                </div>
+
+                <!-- Teams and Score -->
+                <div class="mb-3">
+                  <div
+                    class="text-base font-medium text-gray-900 mb-2"
+                    v-html="getTeamDisplay(match)"
+                  ></div>
+                  <div class="flex items-center space-x-3">
+                    <span class="text-2xl font-bold text-gray-900">
+                      {{ getScoreDisplay(match) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Match Details -->
+                <div class="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <span class="text-gray-500">Type:</span>
+                    <span class="ml-1 font-medium">{{
+                      match.match_type_name || 'League'
+                    }}</span>
+                  </div>
+                  <div>
+                    <span class="text-gray-500">Status:</span>
+                    <span
+                      class="ml-1"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-green-100 text-green-800':
+                          match.match_status === 'completed',
+                        'bg-blue-100 text-blue-800':
+                          match.match_status === 'scheduled',
+                        'bg-yellow-100 text-yellow-800':
+                          match.match_status === 'postponed',
+                        'bg-red-100 text-red-800':
+                          match.match_status === 'cancelled',
+                        'bg-red-600 text-white font-extrabold':
+                          match.match_status === 'live',
+                      }"
+                    >
+                      {{
+                        match.match_status === 'live'
+                          ? '🔴 LIVE'
+                          : match.match_status || 'scheduled'
+                      }}
+                    </span>
+                  </div>
+                  <div v-if="authStore.isAdmin.value && match.match_id">
+                    <span class="text-gray-500">Match ID:</span>
+                    <span class="ml-1 font-mono text-xs">{{
+                      match.match_id
+                    }}</span>
+                  </div>
+                  <div v-if="authStore.isAdmin.value">
+                    <span class="text-gray-500">Source:</span>
+                    <span
+                      class="ml-1"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-purple-100 text-purple-800':
+                          match.source === 'match-scraper',
+                        'bg-gray-100 text-gray-700': match.source === 'manual',
+                        'bg-yellow-100 text-yellow-700':
+                          match.source === 'import',
+                      }"
+                    >
+                      {{ getSourceDisplay(match.source) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Actions -->
+                <div
+                  v-if="authStore.isAuthenticated.value"
+                  class="mt-3 pt-3 border-t border-gray-100 space-y-2"
+                >
+                  <button
+                    @click="viewMatch(match)"
+                    class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
-                    {{ match.match_id }}
-                  </span>
-                  <span v-else class="text-gray-400 text-xs">-</span>
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    :title="getSourceTooltip(match)"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-purple-100 text-purple-800':
-                        match.source === 'match-scraper',
-                      'bg-gray-100 text-gray-700': match.source === 'manual',
-                      'bg-yellow-100 text-yellow-700':
-                        match.source === 'import',
-                    }"
-                  >
-                    {{ getSourceDisplay(match.source) }}
-                  </span>
-                </td>
-                <td v-if="canEditGames" class="border-b text-center">
+                    View Match
+                  </button>
                   <button
                     v-if="canEditGame(match)"
                     @click="editMatch(match)"
-                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
-                    Edit
+                    Edit Match
                   </button>
-                </td>
-              </tr>
+                </div>
+              </div>
 
               <!-- Academy Section -->
-              <tr v-if="academyMatches.length > 0">
-                <td
-                  :colspan="canEditGames ? 9 : 8"
-                  class="bg-green-600 text-white font-bold text-sm py-2 px-4 border-b-2 border-green-700"
-                >
-                  ACADEMY LEAGUE
-                </td>
-              </tr>
-              <tr
+              <div
+                v-if="academyMatches.length > 0"
+                class="bg-green-600 text-white font-bold text-sm py-2 px-4 rounded-lg"
+              >
+                ACADEMY LEAGUE
+              </div>
+              <div
                 v-for="(match, index) in academyMatches"
                 :key="`academy-${match.id}`"
-                :class="{ 'bg-gray-100': index % 2 === 0 }"
+                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
               >
-                <td class="border-b text-center">{{ match.match_date }}</td>
-                <td
-                  class="border-b text-left px-2"
-                  v-html="getTeamDisplay(match)"
-                ></td>
-                <td class="border-b text-center">
-                  {{ getScoreDisplay(match) }}
-                </td>
-                <td class="border-b text-center">
-                  {{ match.match_type_name || 'League' }}
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-green-100 text-green-800':
-                        match.match_status === 'completed',
-                      'bg-blue-100 text-blue-800':
-                        match.match_status === 'scheduled',
-                      'bg-yellow-100 text-yellow-800':
-                        match.match_status === 'postponed',
-                      'bg-red-100 text-red-800':
-                        match.match_status === 'cancelled',
-                      'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
-                        match.match_status === 'live',
-                      'bg-gray-100 text-gray-800': !match.match_status,
-                    }"
+                <!-- Match Number and Date -->
+                <div
+                  class="flex items-center justify-between mb-3 pb-3 border-b border-gray-100"
+                >
+                  <span class="text-xs font-medium text-gray-500"
+                    >Game #{{ index + 1 }}</span
                   >
-                    {{
-                      match.match_status === 'live'
-                        ? '🔴 LIVE'
-                        : match.match_status || 'scheduled'
-                    }}
-                  </span>
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    v-if="match.match_id"
-                    class="text-xs font-mono text-gray-700"
-                    :title="`External Match ID: ${match.match_id}`"
+                  <span class="text-sm font-medium text-gray-700">{{
+                    match.match_date
+                  }}</span>
+                </div>
+
+                <!-- Teams and Score -->
+                <div class="mb-3">
+                  <div
+                    class="text-base font-medium text-gray-900 mb-2"
+                    v-html="getTeamDisplay(match)"
+                  ></div>
+                  <div class="flex items-center space-x-3">
+                    <span class="text-2xl font-bold text-gray-900">
+                      {{ getScoreDisplay(match) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Match Details -->
+                <div class="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <span class="text-gray-500">Type:</span>
+                    <span class="ml-1 font-medium">{{
+                      match.match_type_name || 'League'
+                    }}</span>
+                  </div>
+                  <div>
+                    <span class="text-gray-500">Status:</span>
+                    <span
+                      class="ml-1"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-green-100 text-green-800':
+                          match.match_status === 'completed',
+                        'bg-blue-100 text-blue-800':
+                          match.match_status === 'scheduled',
+                        'bg-yellow-100 text-yellow-800':
+                          match.match_status === 'postponed',
+                        'bg-red-100 text-red-800':
+                          match.match_status === 'cancelled',
+                        'bg-red-600 text-white font-extrabold':
+                          match.match_status === 'live',
+                      }"
+                    >
+                      {{
+                        match.match_status === 'live'
+                          ? '🔴 LIVE'
+                          : match.match_status || 'scheduled'
+                      }}
+                    </span>
+                  </div>
+                  <div v-if="authStore.isAdmin.value && match.match_id">
+                    <span class="text-gray-500">Match ID:</span>
+                    <span class="ml-1 font-mono text-xs">{{
+                      match.match_id
+                    }}</span>
+                  </div>
+                  <div v-if="authStore.isAdmin.value">
+                    <span class="text-gray-500">Source:</span>
+                    <span
+                      class="ml-1"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-purple-100 text-purple-800':
+                          match.source === 'match-scraper',
+                        'bg-gray-100 text-gray-700': match.source === 'manual',
+                        'bg-yellow-100 text-yellow-700':
+                          match.source === 'import',
+                      }"
+                    >
+                      {{ getSourceDisplay(match.source) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Actions -->
+                <div
+                  v-if="authStore.isAuthenticated.value"
+                  class="mt-3 pt-3 border-t border-gray-100 space-y-2"
+                >
+                  <button
+                    @click="viewMatch(match)"
+                    class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
-                    {{ match.match_id }}
-                  </span>
-                  <span v-else class="text-gray-400 text-xs">-</span>
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    :title="getSourceTooltip(match)"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-purple-100 text-purple-800':
-                        match.source === 'match-scraper',
-                      'bg-gray-100 text-gray-700': match.source === 'manual',
-                      'bg-yellow-100 text-yellow-700':
-                        match.source === 'import',
-                    }"
-                  >
-                    {{ getSourceDisplay(match.source) }}
-                  </span>
-                </td>
-                <td v-if="canEditGames" class="border-b text-center">
+                    View Match
+                  </button>
                   <button
                     v-if="canEditGame(match)"
                     @click="editMatch(match)"
-                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
-                    Edit
+                    Edit Match
                   </button>
-                </td>
-              </tr>
+                </div>
+              </div>
 
-              <!-- Other matches (without league info) -->
-              <tr v-if="otherMatches.length > 0">
-                <td
-                  :colspan="canEditGames ? 9 : 8"
-                  class="bg-gray-600 text-white font-bold text-sm py-2 px-4 border-b-2 border-gray-700"
-                >
-                  OTHER MATCHES
-                </td>
-              </tr>
-              <tr
+              <!-- Other Matches Section -->
+              <div
+                v-if="otherMatches.length > 0"
+                class="bg-gray-600 text-white font-bold text-sm py-2 px-4 rounded-lg"
+              >
+                OTHER MATCHES
+              </div>
+              <div
                 v-for="(match, index) in otherMatches"
                 :key="`other-${match.id}`"
-                :class="{ 'bg-gray-100': index % 2 === 0 }"
+                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
               >
-                <td class="border-b text-center">{{ match.match_date }}</td>
-                <td
-                  class="border-b text-left px-2"
-                  v-html="getTeamDisplay(match)"
-                ></td>
-                <td class="border-b text-center">
-                  {{ getScoreDisplay(match) }}
-                </td>
-                <td class="border-b text-center">
-                  {{ match.match_type_name || 'League' }}
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-green-100 text-green-800':
-                        match.match_status === 'completed',
-                      'bg-blue-100 text-blue-800':
-                        match.match_status === 'scheduled',
-                      'bg-yellow-100 text-yellow-800':
-                        match.match_status === 'postponed',
-                      'bg-red-100 text-red-800':
-                        match.match_status === 'cancelled',
-                      'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
-                        match.match_status === 'live',
-                      'bg-gray-100 text-gray-800': !match.match_status,
-                    }"
+                <!-- Match Number and Date -->
+                <div
+                  class="flex items-center justify-between mb-3 pb-3 border-b border-gray-100"
+                >
+                  <span class="text-xs font-medium text-gray-500"
+                    >Game #{{ index + 1 }}</span
                   >
-                    {{
-                      match.match_status === 'live'
-                        ? '🔴 LIVE'
-                        : match.match_status || 'scheduled'
-                    }}
-                  </span>
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    v-if="match.match_id"
-                    class="text-xs font-mono text-gray-700"
-                    :title="`External Match ID: ${match.match_id}`"
+                  <span class="text-sm font-medium text-gray-700">{{
+                    match.match_date
+                  }}</span>
+                </div>
+
+                <!-- Teams and Score -->
+                <div class="mb-3">
+                  <div
+                    class="text-base font-medium text-gray-900 mb-2"
+                    v-html="getTeamDisplay(match)"
+                  ></div>
+                  <div class="flex items-center space-x-3">
+                    <span class="text-2xl font-bold text-gray-900">
+                      {{ getScoreDisplay(match) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Match Details -->
+                <div class="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <span class="text-gray-500">Type:</span>
+                    <span class="ml-1 font-medium">{{
+                      match.match_type_name || 'League'
+                    }}</span>
+                  </div>
+                  <div>
+                    <span class="text-gray-500">Status:</span>
+                    <span
+                      class="ml-1"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-green-100 text-green-800':
+                          match.match_status === 'completed',
+                        'bg-blue-100 text-blue-800':
+                          match.match_status === 'scheduled',
+                        'bg-yellow-100 text-yellow-800':
+                          match.match_status === 'postponed',
+                        'bg-red-100 text-red-800':
+                          match.match_status === 'cancelled',
+                        'bg-red-600 text-white font-extrabold':
+                          match.match_status === 'live',
+                      }"
+                    >
+                      {{
+                        match.match_status === 'live'
+                          ? '🔴 LIVE'
+                          : match.match_status || 'scheduled'
+                      }}
+                    </span>
+                  </div>
+                  <div v-if="authStore.isAdmin.value && match.match_id">
+                    <span class="text-gray-500">Match ID:</span>
+                    <span class="ml-1 font-mono text-xs">{{
+                      match.match_id
+                    }}</span>
+                  </div>
+                  <div v-if="authStore.isAdmin.value">
+                    <span class="text-gray-500">Source:</span>
+                    <span
+                      class="ml-1"
+                      :class="{
+                        'px-2 py-1 rounded text-xs font-medium': true,
+                        'bg-purple-100 text-purple-800':
+                          match.source === 'match-scraper',
+                        'bg-gray-100 text-gray-700': match.source === 'manual',
+                        'bg-yellow-100 text-yellow-700':
+                          match.source === 'import',
+                      }"
+                    >
+                      {{ getSourceDisplay(match.source) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Actions -->
+                <div
+                  v-if="authStore.isAuthenticated.value"
+                  class="mt-3 pt-3 border-t border-gray-100 space-y-2"
+                >
+                  <button
+                    @click="viewMatch(match)"
+                    class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
-                    {{ match.match_id }}
-                  </span>
-                  <span v-else class="text-gray-400 text-xs">-</span>
-                </td>
-                <td class="border-b text-center">
-                  <span
-                    :title="getSourceTooltip(match)"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-purple-100 text-purple-800':
-                        match.source === 'match-scraper',
-                      'bg-gray-100 text-gray-700': match.source === 'manual',
-                      'bg-yellow-100 text-yellow-700':
-                        match.source === 'import',
-                    }"
-                  >
-                    {{ getSourceDisplay(match.source) }}
-                  </span>
-                </td>
-                <td v-if="canEditGames" class="border-b text-center">
+                    View Match
+                  </button>
                   <button
                     v-if="canEditGame(match)"
                     @click="editMatch(match)"
-                    class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
-                    Edit
+                    Edit Match
                   </button>
-                </td>
-              </tr>
+                </div>
+              </div>
             </template>
 
             <!-- My Club view: Regular rendering -->
-            <tr
+            <div
               v-else
               v-for="(match, index) in sortedGames"
               :key="match.id"
-              :class="{ 'bg-gray-100': index % 2 === 0 }"
-            >
-              <td
-                v-if="selectedViewTab === 'myclub'"
-                class="border-b text-right"
-              >
-                {{ index + 1 }}
-              </td>
-              <td class="border-b text-center">{{ match.match_date }}</td>
-              <td
-                class="border-b text-left px-2"
-                v-html="getTeamDisplay(match)"
-              ></td>
-              <td class="border-b text-center">
-                {{ getScoreDisplay(match) }}
-              </td>
-              <td
-                v-if="selectedViewTab === 'myclub'"
-                class="border-b text-center"
-              >
-                <span
-                  v-if="
-                    match.match_status === 'completed' &&
-                    getResult(match) !== '-'
-                  "
-                  class="px-2 py-1 rounded-full text-sm font-bold"
-                  :class="{
-                    'bg-green-100 text-green-800': getResult(match) === 'W',
-                    'bg-yellow-100 text-yellow-800': getResult(match) === 'T',
-                    'bg-red-100 text-red-800': getResult(match) === 'L',
-                  }"
-                >
-                  {{ getResult(match) }}
-                </span>
-                <span v-else class="text-gray-400">-</span>
-              </td>
-              <td class="border-b text-center">
-                {{ match.match_type_name || 'League' }}
-              </td>
-              <td class="border-b text-center">
-                <span
-                  :class="{
-                    'px-2 py-1 rounded text-xs font-medium': true,
-                    'bg-green-100 text-green-800':
-                      match.match_status === 'completed',
-                    'bg-blue-100 text-blue-800':
-                      match.match_status === 'scheduled',
-                    'bg-yellow-100 text-yellow-800':
-                      match.match_status === 'postponed',
-                    'bg-red-100 text-red-800':
-                      match.match_status === 'cancelled',
-                    'bg-red-600 text-white font-extrabold text-sm px-4 py-2 animate-pulse shadow-lg whitespace-nowrap':
-                      match.match_status === 'live',
-                    'bg-gray-100 text-gray-800': !match.match_status,
-                  }"
-                >
-                  {{
-                    match.match_status === 'live'
-                      ? '🔴 LIVE'
-                      : match.match_status || 'scheduled'
-                  }}
-                </span>
-              </td>
-              <td class="border-b text-center">
-                <span
-                  v-if="match.match_id"
-                  class="text-xs font-mono text-gray-700"
-                  :title="`External Match ID: ${match.match_id}`"
-                >
-                  {{ match.match_id }}
-                </span>
-                <span v-else class="text-gray-400 text-xs">-</span>
-              </td>
-              <td class="border-b text-center">
-                <span
-                  :title="getSourceTooltip(match)"
-                  :class="{
-                    'px-2 py-1 rounded text-xs font-medium': true,
-                    'bg-purple-100 text-purple-800':
-                      match.source === 'match-scraper',
-                    'bg-gray-100 text-gray-700': match.source === 'manual',
-                    'bg-yellow-100 text-yellow-700': match.source === 'import',
-                  }"
-                >
-                  {{ getSourceDisplay(match.source) }}
-                </span>
-              </td>
-              <td v-if="canEditGames" class="border-b text-center">
-                <button
-                  v-if="canEditGame(match)"
-                  @click="editMatch(match)"
-                  class="text-blue-600 hover:text-blue-800 text-sm font-medium"
-                >
-                  Edit
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <!-- Mobile: Card View -->
-        <div class="lg:hidden space-y-3">
-          <!-- All Matches view: Group by league with section headers -->
-          <template v-if="selectedViewTab === 'all'">
-            <!-- Homegrown Section -->
-            <div
-              v-if="homegrownMatches.length > 0"
-              class="bg-blue-600 text-white font-bold text-sm py-2 px-4 rounded-lg"
-            >
-              HOMEGROWN LEAGUE
-            </div>
-            <div
-              v-for="(match, index) in homegrownMatches"
-              :key="`homegrown-${match.id}`"
               class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
             >
               <!-- Match Number and Date -->
@@ -828,11 +1248,25 @@
                   <span class="text-2xl font-bold text-gray-900">
                     {{ getScoreDisplay(match) }}
                   </span>
+                  <span
+                    v-if="
+                      match.match_status === 'completed' &&
+                      getResult(match) !== '-'
+                    "
+                    class="px-3 py-1 rounded-full text-sm font-bold"
+                    :class="{
+                      'bg-green-100 text-green-800': getResult(match) === 'W',
+                      'bg-yellow-100 text-yellow-800': getResult(match) === 'T',
+                      'bg-red-100 text-red-800': getResult(match) === 'L',
+                    }"
+                  >
+                    {{ getResult(match) }}
+                  </span>
                 </div>
               </div>
 
               <!-- Match Details -->
-              <div class="grid grid-cols-2 gap-3 text-sm">
+              <div class="grid grid-cols-2 gap-2 text-sm">
                 <div>
                   <span class="text-gray-500">Type:</span>
                   <span class="ml-1 font-medium">{{
@@ -842,9 +1276,8 @@
                 <div>
                   <span class="text-gray-500">Status:</span>
                   <span
-                    class="ml-1"
+                    class="ml-1 px-2 py-0.5 rounded text-xs font-medium"
                     :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
                       'bg-green-100 text-green-800':
                         match.match_status === 'completed',
                       'bg-blue-100 text-blue-800':
@@ -853,8 +1286,9 @@
                         match.match_status === 'postponed',
                       'bg-red-100 text-red-800':
                         match.match_status === 'cancelled',
-                      'bg-red-600 text-white font-extrabold':
+                      'bg-red-600 text-white font-extrabold px-3 py-1 animate-pulse shadow-lg whitespace-nowrap':
                         match.match_status === 'live',
+                      'bg-gray-100 text-gray-800': !match.match_status,
                     }"
                   >
                     {{
@@ -864,380 +1298,59 @@
                     }}
                   </span>
                 </div>
-                <div v-if="match.match_id">
+                <div v-if="authStore.isAdmin.value && match.match_id">
                   <span class="text-gray-500">Match ID:</span>
                   <span class="ml-1 font-mono text-xs">{{
                     match.match_id
                   }}</span>
                 </div>
-                <div>
+                <div v-if="authStore.isAdmin.value">
                   <span class="text-gray-500">Source:</span>
-                  <span
-                    class="ml-1"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-purple-100 text-purple-800':
-                        match.source === 'match-scraper',
-                      'bg-gray-100 text-gray-700': match.source === 'manual',
-                      'bg-yellow-100 text-yellow-700':
-                        match.source === 'import',
-                    }"
-                  >
+                  <span class="ml-1" :title="getSourceTooltip(match)">
                     {{ getSourceDisplay(match.source) }}
                   </span>
                 </div>
-              </div>
-
-              <!-- Actions -->
-              <div
-                v-if="canEditGames && canEditGame(match)"
-                class="mt-3 pt-3 border-t border-gray-100"
-              >
-                <button
-                  @click="editMatch(match)"
-                  class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
-                >
-                  Edit Match
-                </button>
-              </div>
-            </div>
-
-            <!-- Academy Section -->
-            <div
-              v-if="academyMatches.length > 0"
-              class="bg-green-600 text-white font-bold text-sm py-2 px-4 rounded-lg"
-            >
-              ACADEMY LEAGUE
-            </div>
-            <div
-              v-for="(match, index) in academyMatches"
-              :key="`academy-${match.id}`"
-              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
-            >
-              <!-- Match Number and Date -->
-              <div
-                class="flex items-center justify-between mb-3 pb-3 border-b border-gray-100"
-              >
-                <span class="text-xs font-medium text-gray-500"
-                  >Game #{{ index + 1 }}</span
-                >
-                <span class="text-sm font-medium text-gray-700">{{
-                  match.match_date
-                }}</span>
-              </div>
-
-              <!-- Teams and Score -->
-              <div class="mb-3">
                 <div
-                  class="text-base font-medium text-gray-900 mb-2"
-                  v-html="getTeamDisplay(match)"
-                ></div>
-                <div class="flex items-center space-x-3">
-                  <span class="text-2xl font-bold text-gray-900">
-                    {{ getScoreDisplay(match) }}
-                  </span>
-                </div>
-              </div>
-
-              <!-- Match Details -->
-              <div class="grid grid-cols-2 gap-3 text-sm">
-                <div>
-                  <span class="text-gray-500">Type:</span>
-                  <span class="ml-1 font-medium">{{
-                    match.match_type_name || 'League'
-                  }}</span>
-                </div>
-                <div>
-                  <span class="text-gray-500">Status:</span>
-                  <span
-                    class="ml-1"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-green-100 text-green-800':
-                        match.match_status === 'completed',
-                      'bg-blue-100 text-blue-800':
-                        match.match_status === 'scheduled',
-                      'bg-yellow-100 text-yellow-800':
-                        match.match_status === 'postponed',
-                      'bg-red-100 text-red-800':
-                        match.match_status === 'cancelled',
-                      'bg-red-600 text-white font-extrabold':
-                        match.match_status === 'live',
-                    }"
+                  v-if="authStore.isAuthenticated.value"
+                  class="text-right space-x-3"
+                >
+                  <button
+                    @click="viewMatch(match)"
+                    class="text-blue-600 font-medium text-sm active:text-blue-800"
                   >
-                    {{
-                      match.match_status === 'live'
-                        ? '🔴 LIVE'
-                        : match.match_status || 'scheduled'
-                    }}
-                  </span>
-                </div>
-                <div v-if="match.match_id">
-                  <span class="text-gray-500">Match ID:</span>
-                  <span class="ml-1 font-mono text-xs">{{
-                    match.match_id
-                  }}</span>
-                </div>
-                <div>
-                  <span class="text-gray-500">Source:</span>
-                  <span
-                    class="ml-1"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-purple-100 text-purple-800':
-                        match.source === 'match-scraper',
-                      'bg-gray-100 text-gray-700': match.source === 'manual',
-                      'bg-yellow-100 text-yellow-700':
-                        match.source === 'import',
-                    }"
+                    View
+                  </button>
+                  <button
+                    v-if="canEditGame(match)"
+                    @click="editMatch(match)"
+                    class="text-blue-600 font-medium text-sm active:text-blue-800"
                   >
-                    {{ getSourceDisplay(match.source) }}
-                  </span>
+                    Edit
+                  </button>
                 </div>
-              </div>
-
-              <!-- Actions -->
-              <div
-                v-if="canEditGames && canEditGame(match)"
-                class="mt-3 pt-3 border-t border-gray-100"
-              >
-                <button
-                  @click="editMatch(match)"
-                  class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
-                >
-                  Edit Match
-                </button>
-              </div>
-            </div>
-
-            <!-- Other Matches Section -->
-            <div
-              v-if="otherMatches.length > 0"
-              class="bg-gray-600 text-white font-bold text-sm py-2 px-4 rounded-lg"
-            >
-              OTHER MATCHES
-            </div>
-            <div
-              v-for="(match, index) in otherMatches"
-              :key="`other-${match.id}`"
-              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
-            >
-              <!-- Match Number and Date -->
-              <div
-                class="flex items-center justify-between mb-3 pb-3 border-b border-gray-100"
-              >
-                <span class="text-xs font-medium text-gray-500"
-                  >Game #{{ index + 1 }}</span
-                >
-                <span class="text-sm font-medium text-gray-700">{{
-                  match.match_date
-                }}</span>
-              </div>
-
-              <!-- Teams and Score -->
-              <div class="mb-3">
-                <div
-                  class="text-base font-medium text-gray-900 mb-2"
-                  v-html="getTeamDisplay(match)"
-                ></div>
-                <div class="flex items-center space-x-3">
-                  <span class="text-2xl font-bold text-gray-900">
-                    {{ getScoreDisplay(match) }}
-                  </span>
-                </div>
-              </div>
-
-              <!-- Match Details -->
-              <div class="grid grid-cols-2 gap-3 text-sm">
-                <div>
-                  <span class="text-gray-500">Type:</span>
-                  <span class="ml-1 font-medium">{{
-                    match.match_type_name || 'League'
-                  }}</span>
-                </div>
-                <div>
-                  <span class="text-gray-500">Status:</span>
-                  <span
-                    class="ml-1"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-green-100 text-green-800':
-                        match.match_status === 'completed',
-                      'bg-blue-100 text-blue-800':
-                        match.match_status === 'scheduled',
-                      'bg-yellow-100 text-yellow-800':
-                        match.match_status === 'postponed',
-                      'bg-red-100 text-red-800':
-                        match.match_status === 'cancelled',
-                      'bg-red-600 text-white font-extrabold':
-                        match.match_status === 'live',
-                    }"
-                  >
-                    {{
-                      match.match_status === 'live'
-                        ? '🔴 LIVE'
-                        : match.match_status || 'scheduled'
-                    }}
-                  </span>
-                </div>
-                <div v-if="match.match_id">
-                  <span class="text-gray-500">Match ID:</span>
-                  <span class="ml-1 font-mono text-xs">{{
-                    match.match_id
-                  }}</span>
-                </div>
-                <div>
-                  <span class="text-gray-500">Source:</span>
-                  <span
-                    class="ml-1"
-                    :class="{
-                      'px-2 py-1 rounded text-xs font-medium': true,
-                      'bg-purple-100 text-purple-800':
-                        match.source === 'match-scraper',
-                      'bg-gray-100 text-gray-700': match.source === 'manual',
-                      'bg-yellow-100 text-yellow-700':
-                        match.source === 'import',
-                    }"
-                  >
-                    {{ getSourceDisplay(match.source) }}
-                  </span>
-                </div>
-              </div>
-
-              <!-- Actions -->
-              <div
-                v-if="canEditGames && canEditGame(match)"
-                class="mt-3 pt-3 border-t border-gray-100"
-              >
-                <button
-                  @click="editMatch(match)"
-                  class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
-                >
-                  Edit Match
-                </button>
-              </div>
-            </div>
-          </template>
-
-          <!-- My Club view: Regular rendering -->
-          <div
-            v-else
-            v-for="(match, index) in sortedGames"
-            :key="match.id"
-            class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
-          >
-            <!-- Match Number and Date -->
-            <div
-              class="flex items-center justify-between mb-3 pb-3 border-b border-gray-100"
-            >
-              <span class="text-xs font-medium text-gray-500"
-                >Game #{{ index + 1 }}</span
-              >
-              <span class="text-sm font-medium text-gray-700">{{
-                match.match_date
-              }}</span>
-            </div>
-
-            <!-- Teams and Score -->
-            <div class="mb-3">
-              <div
-                class="text-base font-medium text-gray-900 mb-2"
-                v-html="getTeamDisplay(match)"
-              ></div>
-              <div class="flex items-center space-x-3">
-                <span class="text-2xl font-bold text-gray-900">
-                  {{ getScoreDisplay(match) }}
-                </span>
-                <span
-                  v-if="
-                    match.match_status === 'completed' &&
-                    getResult(match) !== '-'
-                  "
-                  class="px-3 py-1 rounded-full text-sm font-bold"
-                  :class="{
-                    'bg-green-100 text-green-800': getResult(match) === 'W',
-                    'bg-yellow-100 text-yellow-800': getResult(match) === 'T',
-                    'bg-red-100 text-red-800': getResult(match) === 'L',
-                  }"
-                >
-                  {{ getResult(match) }}
-                </span>
-              </div>
-            </div>
-
-            <!-- Match Details -->
-            <div class="grid grid-cols-2 gap-2 text-sm">
-              <div>
-                <span class="text-gray-500">Type:</span>
-                <span class="ml-1 font-medium">{{
-                  match.match_type_name || 'League'
-                }}</span>
-              </div>
-              <div>
-                <span class="text-gray-500">Status:</span>
-                <span
-                  class="ml-1 px-2 py-0.5 rounded text-xs font-medium"
-                  :class="{
-                    'bg-green-100 text-green-800':
-                      match.match_status === 'completed',
-                    'bg-blue-100 text-blue-800':
-                      match.match_status === 'scheduled',
-                    'bg-yellow-100 text-yellow-800':
-                      match.match_status === 'postponed',
-                    'bg-red-100 text-red-800':
-                      match.match_status === 'cancelled',
-                    'bg-red-600 text-white font-extrabold px-3 py-1 animate-pulse shadow-lg whitespace-nowrap':
-                      match.match_status === 'live',
-                    'bg-gray-100 text-gray-800': !match.match_status,
-                  }"
-                >
-                  {{
-                    match.match_status === 'live'
-                      ? '🔴 LIVE'
-                      : match.match_status || 'scheduled'
-                  }}
-                </span>
-              </div>
-              <div v-if="match.match_id">
-                <span class="text-gray-500">Match ID:</span>
-                <span class="ml-1 font-mono text-xs">{{ match.match_id }}</span>
-              </div>
-              <div>
-                <span class="text-gray-500">Source:</span>
-                <span class="ml-1" :title="getSourceTooltip(match)">
-                  {{ getSourceDisplay(match.source) }}
-                </span>
-              </div>
-              <div v-if="canEditGames && canEditGame(match)" class="text-right">
-                <button
-                  @click="editMatch(match)"
-                  class="text-blue-600 font-medium text-sm active:text-blue-800"
-                >
-                  Edit
-                </button>
               </div>
             </div>
           </div>
         </div>
+        <div v-else>
+          <p class="text-center text-gray-500 py-8">
+            No matches found for the selected team.
+          </p>
+        </div>
       </div>
-      <div v-else>
-        <p class="text-center text-gray-500 py-8">
-          No matches found for the selected team.
-        </p>
-      </div>
-    </div>
 
-    <!-- Match Edit Modal -->
-    <MatchEditModal
-      :show="showEditModal"
-      :match="editingMatch"
-      :teams="teams"
-      :seasons="seasons"
-      :match-types="matchTypes"
-      :age-groups="ageGroups"
-      @close="closeEditModal"
-      @updated="onGameUpdated"
-    />
+      <!-- Match Edit Modal -->
+      <MatchEditModal
+        :show="showEditModal"
+        :match="editingMatch"
+        :teams="teams"
+        :seasons="seasons"
+        :match-types="matchTypes"
+        :age-groups="ageGroups"
+        @close="closeEditModal"
+        @updated="onGameUpdated"
+      />
+    </div>
   </div>
 </template>
 
@@ -1246,11 +1359,13 @@ import { ref, onMounted, onUnmounted, computed, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 import MatchEditModal from '@/components/MatchEditModal.vue';
+import MatchDetailView from '@/components/MatchDetailView.vue';
 
 export default {
   name: 'MatchesView',
   components: {
     MatchEditModal,
+    MatchDetailView,
   },
   setup() {
     const authStore = useAuthStore();
@@ -1272,6 +1387,7 @@ export default {
     const showEditModal = ref(false);
     const editingMatch = ref(null);
     const showFilters = ref(true); // Filters visible by default on mobile
+    const selectedMatchId = ref(null); // For match detail view navigation
     let liveMatchRefreshInterval = null; // Auto-refresh interval for live matches
 
     const fetchAgeGroups = async () => {
@@ -1960,6 +2076,17 @@ export default {
       return authStore.isAdmin.value || authStore.isTeamManager.value;
     });
 
+    // Calculate table column count for colspan (admin sees Match ID and Source columns)
+    const tableColumnCount = computed(() => {
+      // Base columns: Date, Team, Score, Match Type, Status = 5
+      // Admin-only columns: Match ID, Source = 2
+      // Conditional: Actions column (authenticated users) = 1
+      const baseColumns = 5;
+      const adminColumns = authStore.isAdmin.value ? 2 : 0;
+      const actionColumn = authStore.isAuthenticated.value ? 1 : 0;
+      return baseColumns + adminColumns + actionColumn;
+    });
+
     const canEditGame = match => {
       // Admins can edit all matches
       if (authStore.isAdmin.value) {
@@ -1981,6 +2108,14 @@ export default {
     const editMatch = match => {
       editingMatch.value = match;
       showEditModal.value = true;
+    };
+
+    const viewMatch = match => {
+      selectedMatchId.value = match.id;
+    };
+
+    const handleBackFromDetail = () => {
+      selectedMatchId.value = null;
     };
 
     const closeEditModal = () => {
@@ -2098,8 +2233,12 @@ export default {
       formatSeasonDates,
       getSegmentGridClass,
       canEditGames,
+      tableColumnCount,
       canEditGame,
       editMatch,
+      viewMatch,
+      handleBackFromDetail,
+      selectedMatchId,
       closeEditModal,
       onGameUpdated,
       showEditModal,


### PR DESCRIPTION
## Summary
- Add new **MatchDetailView** component with stadium scoreboard design
- Add **View** button to match rows for all logged-in users
- Add **Copy to Clipboard** feature to share match results as images
- Hide Match ID and Source columns from non-admin users
- Change View button color from green to blue (UX best practice)

## Changes
- `frontend/src/components/MatchDetailView.vue` - New stadium scoreboard component
- `frontend/src/components/MatchesView.vue` - Add View button, hide admin columns
- `backend/dao/match_dao.py` - Include club data for team logos
- `frontend/package.json` - Add html2canvas dependency

## Features
- **Stadium Scoreboard**: Dark themed card with team initials, score, status badge
- **Match Details**: Date, Type, Season, Age Group, Division, League
- **Share Feature**: Capture scoreboard + details as PNG, copy to clipboard for pasting into iMessage/Slack
- **Responsive**: Works on mobile and desktop

## Test plan
- [ ] Log in as any user (fan, player, manager)
- [ ] Navigate to Matches tab
- [ ] Click View button on any match
- [ ] Verify scoreboard displays correctly
- [ ] Click "Copy to Clipboard" button
- [ ] Paste into a text message or Slack to verify image

🤖 Generated with [Claude Code](https://claude.com/claude-code)