### PR TITLE
fix: Use get_match_by_id for match detail API to include club data

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1495,12 +1495,8 @@ async def get_match(
 ):
     """Get a specific match by ID (requires authentication)."""
     try:
-        # Get all matches and filter by ID
-        client_ip = get_client_ip(request)
-        matches = match_dao.get_all_matches(client_ip=client_ip)
-
-        # Find the match with matching ID
-        match = next((m for m in matches if m.get("id") == match_id), None)
+        # Use get_match_by_id for efficient single-match lookup with club data
+        match = match_dao.get_match_by_id(match_id)
 
         if not match:
             raise HTTPException(status_code=404, detail=f"Match with ID {match_id} not found")


### PR DESCRIPTION
## Summary
- Fixed the `/api/matches/{match_id}` endpoint to return club branding data
- The endpoint was using `get_all_matches()` which doesn't include club data
- Changed to use `get_match_by_id()` which has the proper club join for team logos

## Problem
The MatchDetailView component couldn't display club logos because the API wasn't returning club data. The `home_team_club` and `away_team_club` fields were always `null`.

## Solution
Use the existing `get_match_by_id()` method which already has the club data join:
```python
home_team:teams!matches_home_team_id_fkey(
    id, name,
    club:clubs(id, name, logo_url, primary_color, secondary_color)
)
```

## Test plan
- [ ] View a match detail for a team with a club logo (e.g., IFA)
- [ ] Verify club logo displays in the scoreboard component

🤖 Generated with [Claude Code](https://claude.com/claude-code)