### PR TITLE
fix: Enable CORS for clipboard capture to include team logos

### DIFF
--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -434,6 +434,8 @@ export default {
           backgroundColor: '#1e293b', // slate-800
           scale: 2, // Higher resolution
           logging: false,
+          useCORS: true, // Enable CORS for cross-origin images (logos)
+          allowTaint: false, // Don't taint canvas (safer)
         });
 
         canvas.toBlob(async blob => {


### PR DESCRIPTION
## Summary
- Added `useCORS: true` to html2canvas to capture cross-origin images (logos from Supabase storage)

## Test plan
- [x] Tested locally - logos now appear in clipboard copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)