### PR TITLE
fix(helm): Add rollout annotations to force pod restart on deployment

### DIFF
--- a/helm/missing-table/templates/backend.yaml
+++ b/helm/missing-table/templates/backend.yaml
@@ -20,6 +20,10 @@ spec:
         app.kubernetes.io/name: {{ include "missing-table.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: backend
+      annotations:
+        # Force pod restart on each deployment (image tag stays same)
+        rollout/commitSha: {{ .Values.commitSha | default "unknown" | quote }}
+        rollout/buildId: {{ .Values.buildId | default "unknown" | quote }}
     spec:
       containers:
       - name: backend

--- a/helm/missing-table/templates/celery-worker.yaml
+++ b/helm/missing-table/templates/celery-worker.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/name: {{ include "missing-table.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: celery-worker
+      annotations:
+        # Force pod restart on each deployment (image tag stays same)
+        rollout/commitSha: {{ .Values.commitSha | default "unknown" | quote }}
+        rollout/buildId: {{ .Values.buildId | default "unknown" | quote }}
     spec:
       containers:
       - name: celery-worker

--- a/helm/missing-table/templates/frontend.yaml
+++ b/helm/missing-table/templates/frontend.yaml
@@ -20,6 +20,10 @@ spec:
         app.kubernetes.io/name: {{ include "missing-table.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: frontend
+      annotations:
+        # Force pod restart on each deployment (image tag stays same)
+        rollout/commitSha: {{ .Values.commitSha | default "unknown" | quote }}
+        rollout/buildId: {{ .Values.buildId | default "unknown" | quote }}
     spec:
       containers:
       - name: frontend


### PR DESCRIPTION
## Summary
- Add `rollout/commitSha` and `rollout/buildId` annotations to pod templates
- Forces Kubernetes to restart pods on each deployment

## Problem
The image tag stays the same (`:dev`) between deployments, so Kubernetes doesn't see a change in the deployment spec and skips pod restarts. This caused the frontend not to update after the last PR merge.

## Solution
Adding changing annotations to pod templates ensures Kubernetes sees a change in the deployment spec and triggers a rolling restart.

## Test plan
- [ ] Merge this PR
- [ ] Verify both backend and frontend pods restart with new deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)