### PR TITLE
fix: Disable Docker image security scans (GKE infrastructure offline)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,94 +11,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  trivy-scan:
-    name: Trivy Security Scan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build Docker images
-      run: |
-        docker compose build --no-cache
-
-    - name: Run Trivy vulnerability scanner (Backend)
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'missing-table-backend:latest'
-        format: 'sarif'
-        output: 'trivy-backend-results.sarif'
-        severity: 'CRITICAL,HIGH,MEDIUM'
-
-    - name: Upload Trivy scan results (Backend)
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-backend-results.sarif'
-        category: 'trivy-backend'
-
-    - name: Run Trivy vulnerability scanner (Frontend)
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'missing-table-frontend:latest'
-        format: 'sarif'
-        output: 'trivy-frontend-results.sarif'
-        severity: 'CRITICAL,HIGH,MEDIUM'
-
-    - name: Upload Trivy scan results (Frontend)
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-frontend-results.sarif'
-        category: 'trivy-frontend'
-
-    - name: Run Trivy filesystem scan
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-fs-results.sarif'
-        severity: 'CRITICAL,HIGH,MEDIUM'
-
-    - name: Upload Trivy filesystem results
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-fs-results.sarif'
-        category: 'trivy-filesystem'
-
-    - name: Run Trivy config scan
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'config'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-config-results.sarif'
-
-    - name: Upload Trivy config results
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-config-results.sarif'
-        category: 'trivy-config'
-
-    - name: Store scan artifacts
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: trivy-scan-results
-        path: |
-          trivy-*-results.sarif
-        retention-days: 30
+  # Docker image scanning disabled - GKE cluster and Artifact Registry deleted to save costs (2025-12-07)
+  # Keeping filesystem and config scans in dependency-scan job below
 
   secret-scan:
     name: Secret Scanning (Trivy)
@@ -134,6 +48,10 @@ jobs:
   dependency-scan:
     name: Dependency Scanning
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -172,6 +90,37 @@ jobs:
         uv pip install safety
         uv run safety check --json --output ../python-safety-results.json || true
 
+    - name: Run Trivy filesystem scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        format: 'sarif'
+        output: 'trivy-fs-results.sarif'
+        severity: 'CRITICAL,HIGH,MEDIUM'
+
+    - name: Upload Trivy filesystem results
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-fs-results.sarif'
+        category: 'trivy-filesystem'
+
+    - name: Run Trivy config scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'config'
+        scan-ref: '.'
+        format: 'sarif'
+        output: 'trivy-config-results.sarif'
+
+    - name: Upload Trivy config results
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-config-results.sarif'
+        category: 'trivy-config'
+
     - name: Store dependency scan results
       uses: actions/upload-artifact@v4
       if: always()
@@ -180,4 +129,6 @@ jobs:
         path: |
           npm-audit-results.json
           python-safety-results.json
+          trivy-fs-results.sarif
+          trivy-config-results.sarif
         retention-days: 30


### PR DESCRIPTION
## Summary
Removes Docker image scanning from the security workflow since the GKE infrastructure was shutdown to save costs.

### Problem
The `trivy-scan` job was failing on every push/PR because:
- ❌ `docker-compose.yml` was removed in recent cleanup (#119)
- ❌ GKE cluster deleted on 2025-12-07 to save costs
- ❌ Artifact Registry deleted
- ❌ No Docker infrastructure to scan

### Changes
**Removed:**
- ❌ `trivy-scan` job that built and scanned Docker images
- ❌ Backend/Frontend Docker image scanning

**Kept/Reorganized:**
- ✅ Secret scanning (Trivy) - still runs independently
- ✅ Dependency scanning (npm audit, Python safety)
- ✅ Filesystem scanning (moved to dependency-scan job)
- ✅ Config scanning (moved to dependency-scan job)

### Security Coverage Remains Strong
Even without Docker image scanning, we still have:
- 🔒 **Secret detection** - Gitleaks, detect-secrets, Trivy secrets
- 🔒 **Dependency vulnerabilities** - npm audit, Python safety
- 🔒 **Filesystem vulnerabilities** - Trivy filesystem scan
- 🔒 **Config issues** - Trivy config scan (Dockerfiles, K8s, etc.)
- 🔒 **Pre-commit hooks** - Local secret detection

### When to Re-enable
If/when GKE infrastructure is restarted, restore Docker image scanning by:
1. Recreating the `trivy-scan` job
2. Re-adding `docker-compose.yml`
3. See commit `b8898a4` for the old configuration

### Related
- Fixes failing workflow after #119 (Vite migration cleanup)
- Related to GKE shutdown documented in `docs/07-operations/GKE_SHUTDOWN_2025-12-07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>