### PR TITLE
feat: Add www.missingtable.com to ingress hosts

### DIFF
--- a/helm/missing-table/values-doks.yaml
+++ b/helm/missing-table/values-doks.yaml
@@ -35,10 +35,12 @@ ingress:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts:
     - missingtable.com
+    - www.missingtable.com
   tls:
     - secretName: missing-table-tls  #pragma: allowlist secret
       hosts:
         - missingtable.com
+        - www.missingtable.com
 
 imageCredentials:
   registry: ghcr.io


### PR DESCRIPTION
## Summary
- Add `www.missingtable.com` to ingress hosts list
- Add `www.missingtable.com` to TLS hosts for certificate coverage

## Context
The ingress was manually patched via `kubectl` to add `www.missingtable.com`. This PR codifies that change in the Helm values to maintain 100% IaC compliance.

## Testing
After merge, deploy with:
```bash
helm upgrade missing-table ./helm/missing-table -n missing-table --values ./helm/missing-table/values-doks.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)