### PR TITLE
fix: Use PAT for GitOps commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,12 @@
     update-helm-values:
       needs: build-and-push
       runs-on: ubuntu-latest
-      permissions:
-        contents: write
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
           with:
-            token: ${{ secrets.GITHUB_TOKEN }}
+            # Use PAT to bypass branch protection for automated commits
+            token: ${{ secrets.GH_PAT }}
 
         - name: Update image tags in values.yaml
           run: |


### PR DESCRIPTION
## Summary
Use a Personal Access Token (PAT) instead of GITHUB_TOKEN to bypass branch protection for automated tag updates.

## Setup Required
Before merging, add the `GH_PAT` secret to the repository:
1. Create a Fine-grained PAT with `contents: write` for this repo
2. Add it as a repository secret named `GH_PAT`

## Test plan
- [ ] Create PAT and add as secret
- [ ] Merge this PR
- [ ] Make a code change and push to main
- [ ] Verify CI builds images and commits tag update successfully
- [ ] Verify ArgoCD syncs the new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)