### PR TITLE
fix: Use nginx CMD for frontend production image

### DIFF
--- a/helm/missing-table/values-doks.yaml
+++ b/helm/missing-table/values-doks.yaml
@@ -25,6 +25,9 @@ frontend:
     tag: "436e8ad" # frontend-tag
     pullPolicy: IfNotPresent
 
+  # Production image uses nginx, not npm - override default command
+  command: []
+
   # Vite + nginx: instant startup, no build at runtime
   livenessProbe:
     initialDelaySeconds: 10


### PR DESCRIPTION
## Problem
Frontend pod is crashing with:
```
exec: "npm": executable file not found in $PATH
```

The production Docker image uses nginx (not npm) to serve static files, but the Helm chart default values specify `npm run serve` as the command.

## Fix
Override `frontend.command` to empty array `[]` in values-doks.yaml so the image's built-in nginx CMD runs.

[skip ci]

🤖 Generated with [Claude Code](https://claude.com/claude-code)