### PR TITLE
fix: Pull latest main before updating tags in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,12 @@
           with:
             # Use PAT to bypass branch protection for automated commits
             token: ${{ secrets.GH_PAT }}
+            ref: main
+            fetch-depth: 0
+
+        - name: Pull latest changes
+          run: |
+            git pull origin main
 
         - name: Update image tags in values.yaml
           run: |


### PR DESCRIPTION
## Problem
CI failed with:
```
Updates were rejected because the remote contains work that you do not have locally
```

Race condition: PR #125 was merged while CI was running from PR #124.

## Fix
- Checkout `main` branch explicitly (not the triggering commit SHA)
- Pull latest changes before applying tag updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)