### PR TITLE
fix: Address Supabase Security Advisor warnings

### DIFF
--- a/supabase-local/migrations/20251120155152_add_club_manager_role.sql
+++ b/supabase-local/migrations/20251120155152_add_club_manager_role.sql
@@ -1,0 +1,34 @@
+-- Migration: Add club_manager role and remove unused user role
+-- This migration updates the role system to support club-level management
+
+-- Drop the existing role check constraint
+ALTER TABLE user_profiles
+DROP CONSTRAINT IF EXISTS user_profiles_role_check;
+
+-- Add new constraint with club_manager role and without user role
+-- Keeping both hyphenated and underscored versions for backwards compatibility
+ALTER TABLE user_profiles
+ADD CONSTRAINT user_profiles_role_check
+CHECK (role IN (
+    'admin',
+    'club_manager',
+    'team-manager',
+    'team_manager',
+    'team-player',
+    'team_player',
+    'team-fan',
+    'team_fan'
+));
+
+-- Add comment documenting the role hierarchy
+COMMENT ON COLUMN user_profiles.role IS 'User role: admin > club_manager > team-manager > team-player/team-fan. Club managers can manage all teams in their assigned club.';
+
+-- Add club_id column to invitations table for club_manager invites
+ALTER TABLE invitations
+ADD COLUMN IF NOT EXISTS club_id INTEGER REFERENCES clubs(id);
+
+-- Add comment for club_id
+COMMENT ON COLUMN invitations.club_id IS 'Club ID for club_manager invites (mutually exclusive with team_id)';
+
+-- Update schema version
+SELECT add_schema_version('1.2.0', 'add_club_manager_role', 'Add club_manager role for club-level management, remove unused user role, add club_id to invitations');

--- a/supabase-local/migrations/20251121000001_club_manager_teams_rls.sql
+++ b/supabase-local/migrations/20251121000001_club_manager_teams_rls.sql
@@ -1,0 +1,33 @@
+-- Migration: Add RLS policies for club managers to manage teams
+-- This allows club managers to create and update teams within their assigned club
+
+-- Drop the existing admin-only policy for teams
+DROP POLICY IF EXISTS teams_admin_all ON teams;
+
+-- Create new policies that allow club managers to manage teams in their club
+
+-- INSERT policy: admins can insert any team, club_managers only their club
+CREATE POLICY teams_insert_policy ON teams FOR INSERT
+WITH CHECK (
+    -- Admins can insert any team
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+    OR
+    -- Club managers can only insert teams into their club
+    (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'club_manager')
+     AND club_id = (SELECT club_id FROM user_profiles WHERE id = auth.uid()))
+);
+
+-- UPDATE policy: admins can update any team, club_managers only their club's teams
+CREATE POLICY teams_update_policy ON teams FOR UPDATE
+USING (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+    OR
+    (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'club_manager')
+     AND club_id = (SELECT club_id FROM user_profiles WHERE id = auth.uid()))
+);
+
+-- DELETE policy: only admins can delete teams
+CREATE POLICY teams_delete_policy ON teams FOR DELETE
+USING (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+);

--- a/supabase-local/migrations/20251124000003_add_pro_academy_to_clubs.sql
+++ b/supabase-local/migrations/20251124000003_add_pro_academy_to_clubs.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- ADD PRO ACADEMY FLAG TO CLUBS
+-- ============================================================================
+-- Purpose: Add pro_academy column to clubs table to distinguish pro academies
+-- Impact: Enables Pro Academy badge display on club tiles
+-- Author: Claude Code
+-- Date: 2025-11-24
+-- ============================================================================
+
+ALTER TABLE clubs ADD COLUMN IF NOT EXISTS pro_academy BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN clubs.pro_academy IS 'Indicates if this club is a professional academy';
+
+-- ============================================================================
+-- UPDATE SCHEMA VERSION
+-- ============================================================================
+
+SELECT add_schema_version(
+    '1.4.2',
+    '20251124000003_add_pro_academy_to_clubs',
+    'Add pro_academy flag to clubs table'
+);

--- a/supabase-local/migrations/20251214000001_fix_rls_security_warnings.sql
+++ b/supabase-local/migrations/20251214000001_fix_rls_security_warnings.sql
@@ -1,0 +1,112 @@
+-- Migration: Fix Supabase Security Advisor Warnings
+-- Description: Addresses 4 security warnings from Supabase Security Advisor:
+--   1. Policy Exists RLS Disabled - user_profiles (policies exist but RLS disabled)
+--   2. Security Definer View - teams_with_details (owned by postgres, no explicit security)
+--   3. RLS Disabled in Public - schema_version (no RLS on public table)
+--   4. RLS Disabled in Public - user_profiles (same as #1)
+
+-- ============================================================================
+-- FIX 1: Enable RLS on user_profiles
+-- Policies already exist (from migration 011), just need to enable RLS
+-- The is_admin() function is SECURITY DEFINER which prevents recursion
+-- ============================================================================
+
+ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Also need to add a policy for service_role to insert profiles (for handle_new_user trigger)
+-- Check if it exists first to make idempotent
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policy
+        WHERE polrelid = 'public.user_profiles'::regclass
+        AND polname = 'service_role_insert_profiles'
+    ) THEN
+        CREATE POLICY "service_role_insert_profiles" ON user_profiles
+            FOR INSERT
+            TO service_role
+            WITH CHECK (true);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policy
+        WHERE polrelid = 'public.user_profiles'::regclass
+        AND polname = 'service_role_manage_profiles'
+    ) THEN
+        CREATE POLICY "service_role_manage_profiles" ON user_profiles
+            FOR ALL
+            TO service_role
+            USING (true)
+            WITH CHECK (true);
+    END IF;
+END $$;
+
+-- ============================================================================
+-- FIX 2: Recreate teams_with_details view with explicit SECURITY INVOKER
+-- This explicitly tells Postgres to use the querying user's permissions
+-- ============================================================================
+
+-- Drop and recreate with explicit security setting
+DROP VIEW IF EXISTS teams_with_details;
+
+CREATE VIEW teams_with_details
+WITH (security_invoker = true)
+AS
+SELECT
+    t.id,
+    t.name AS team_name,
+    t.city,
+    t.academy_team,
+    c.id AS club_id,
+    c.name AS club_name,
+    c.city AS club_city,
+    l.id AS league_id,
+    l.name AS league_name,
+    l.description AS league_description,
+    t.created_at,
+    t.updated_at
+FROM teams t
+LEFT JOIN clubs c ON t.club_id = c.id
+JOIN leagues l ON t.league_id = l.id;
+
+COMMENT ON VIEW teams_with_details IS
+'Convenient view showing teams with their club and league information. Uses SECURITY INVOKER to respect RLS.';
+
+-- Re-grant access to the view
+GRANT SELECT ON teams_with_details TO authenticated;
+GRANT SELECT ON teams_with_details TO anon;
+
+-- ============================================================================
+-- FIX 3: Enable RLS on schema_version table
+-- This is a metadata table - should be readable by everyone but writable only by migrations
+-- ============================================================================
+
+ALTER TABLE schema_version ENABLE ROW LEVEL SECURITY;
+
+-- Allow everyone to read schema version (it's public metadata)
+CREATE POLICY "anon_read_schema_version" ON schema_version
+    FOR SELECT
+    TO anon
+    USING (true);
+
+CREATE POLICY "authenticated_read_schema_version" ON schema_version
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+-- Only service_role can insert (used by migrations)
+CREATE POLICY "service_role_manage_schema_version" ON schema_version
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ============================================================================
+-- UPDATE SCHEMA VERSION
+-- ============================================================================
+
+SELECT add_schema_version(
+    '1.7.0',
+    '20251214000001_fix_rls_security_warnings',
+    'Fix Supabase Security Advisor warnings: enable RLS on user_profiles and schema_version, add SECURITY INVOKER to teams_with_details view'
+);


### PR DESCRIPTION
## Summary

Fixes 4 security warnings from Supabase Security Advisor:

| Issue | Entity | Fix |
|-------|--------|-----|
| Policy Exists RLS Disabled | `user_profiles` | Enable RLS (policies already exist) |
| Security Definer View | `teams_with_details` | Recreate with `SECURITY INVOKER` |
| RLS Disabled in Public | `schema_version` | Enable RLS + add read policies |
| RLS Disabled in Public | `user_profiles` | Same as first |

## Changes

**New migration:** `20251214000001_fix_rls_security_warnings.sql`
- Enables RLS on `user_profiles` table
- Enables RLS on `schema_version` table with public read policies
- Recreates `teams_with_details` view with explicit `SECURITY INVOKER`

**Synced migrations** (were in `supabase/` but missing from git):
- `20251120155152_add_club_manager_role.sql`
- `20251121000001_club_manager_teams_rls.sql`
- `20251124000003_add_pro_academy_to_clubs.sql`

## Test plan

- [x] Tested on local database with full `supabase db reset`
- [x] All migrations apply cleanly
- [x] Verified RLS enabled on `user_profiles` and `schema_version`
- [x] Verified `teams_with_details` uses SECURITY INVOKER
- [x] REST API queries work correctly with new RLS policies
- [ ] Apply to cloud dev database after merge

## Post-merge

After merging, apply migration to cloud dev:
```bash
./switch-env.sh dev
cd supabase-local && npx supabase db push --linked
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)