### PR TITLE
feat: Add distributed tracing with session and request IDs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,6 +18,7 @@ from auth import (
     require_team_manager_or_admin,
 )
 from csrf_protection import provide_csrf_token
+from middleware import TraceMiddleware
 from models import (
     AdminPlayerTeamAssignment,
     AdminPlayerUpdate,
@@ -141,6 +142,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Add trace middleware for distributed logging (session_id, request_id)
+app.add_middleware(TraceMiddleware)
 
 # Initialize Supabase connection - use CLI for local development
 supabase_url = os.getenv('SUPABASE_URL', '')

--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -42,6 +42,8 @@ def setup_logging(service_name: str = "missing-table") -> None:
     # Configure structlog with JSON renderer for Loki
     structlog.configure(
         processors=[
+            # Merge context variables (session_id, request_id from middleware)
+            structlog.contextvars.merge_contextvars,
             # Add log level to event dict
             structlog.stdlib.add_log_level,
             # Add logger name to event dict
@@ -54,7 +56,7 @@ def setup_logging(service_name: str = "missing-table") -> None:
             structlog.processors.format_exc_info,
             # Decode unicode
             structlog.processors.UnicodeDecoder(),
-            # Add service name to all logs
+            # Add callsite info (filename, line number)
             structlog.processors.CallsiteParameterAdder(
                 parameters=[
                     structlog.processors.CallsiteParameter.FILENAME,

--- a/backend/middleware/__init__.py
+++ b/backend/middleware/__init__.py
@@ -1,0 +1,9 @@
+"""
+Backend Middleware
+
+Provides request processing middleware for the FastAPI application.
+"""
+
+from .trace_middleware import TraceMiddleware, get_trace_context
+
+__all__ = ["TraceMiddleware", "get_trace_context"]

--- a/backend/middleware/trace_middleware.py
+++ b/backend/middleware/trace_middleware.py
@@ -1,0 +1,138 @@
+"""
+Trace Middleware - Request Tracing for Distributed Logging
+
+Extracts session_id and request_id from HTTP headers and binds them
+to structlog context for all subsequent logging in the request.
+
+Headers:
+- X-Session-ID: Frontend session identifier (mt-sess-{uuid})
+- X-Request-ID: Per-request identifier (mt-req-{uuid})
+
+If headers are not provided, generates new identifiers.
+"""
+
+import time
+import uuid
+from contextvars import ContextVar
+from typing import Optional, Tuple
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Context variables for trace IDs - accessible throughout the request lifecycle
+_session_id: ContextVar[Optional[str]] = ContextVar("session_id", default=None)
+_request_id: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
+
+logger = structlog.get_logger(__name__)
+
+
+def generate_request_id() -> str:
+    """Generate a new request ID (8 hex chars for easy copy/paste)."""
+    return f"mt-req-{uuid.uuid4().hex[:8]}"
+
+
+def generate_session_id() -> str:
+    """Generate a new session ID (8 hex chars, used when frontend doesn't provide one)."""
+    return f"mt-sess-{uuid.uuid4().hex[:8]}"
+
+
+def get_trace_context() -> Tuple[Optional[str], Optional[str]]:
+    """
+    Get current trace context (session_id, request_id).
+
+    Returns:
+        Tuple of (session_id, request_id) from current context
+    """
+    return _session_id.get(), _request_id.get()
+
+
+def get_session_id() -> Optional[str]:
+    """Get current session ID from context."""
+    return _session_id.get()
+
+
+def get_request_id() -> Optional[str]:
+    """Get current request ID from context."""
+    return _request_id.get()
+
+
+class TraceMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that extracts trace IDs from request headers and binds
+    them to structlog context for distributed tracing.
+
+    Also logs request start/end with timing information.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        """Process request with trace context."""
+        start_time = time.perf_counter()
+
+        # Extract or generate trace IDs
+        session_id = request.headers.get("X-Session-ID") or generate_session_id()
+        request_id = request.headers.get("X-Request-ID") or generate_request_id()
+
+        # Store in context variables
+        session_token = _session_id.set(session_id)
+        request_token = _request_id.set(request_id)
+
+        # Bind to structlog context for all logging in this request
+        structlog.contextvars.bind_contextvars(
+            session_id=session_id,
+            request_id=request_id,
+        )
+
+        # Log request start
+        logger.info(
+            "request_started",
+            method=request.method,
+            path=request.url.path,
+            query=str(request.query_params) if request.query_params else None,
+            client_ip=request.client.host if request.client else None,
+        )
+
+        try:
+            response = await call_next(request)
+
+            # Calculate duration
+            duration_ms = (time.perf_counter() - start_time) * 1000
+
+            # Log request completion
+            logger.info(
+                "request_completed",
+                method=request.method,
+                path=request.url.path,
+                status_code=response.status_code,
+                duration_ms=round(duration_ms, 2),
+            )
+
+            # Add trace IDs to response headers for debugging
+            response.headers["X-Request-ID"] = request_id
+
+            return response
+
+        except Exception as e:
+            # Calculate duration even on error
+            duration_ms = (time.perf_counter() - start_time) * 1000
+
+            # Log request failure
+            logger.error(
+                "request_failed",
+                method=request.method,
+                path=request.url.path,
+                error_type=type(e).__name__,
+                error_message=str(e),
+                duration_ms=round(duration_ms, 2),
+                exc_info=True,
+            )
+            raise
+
+        finally:
+            # Reset context variables
+            _session_id.reset(session_token)
+            _request_id.reset(request_token)
+
+            # Clear structlog context
+            structlog.contextvars.unbind_contextvars("session_id", "request_id")

--- a/docs/02-development/README.md
+++ b/docs/02-development/README.md
@@ -16,6 +16,7 @@ This section covers daily development workflows, tools, and best practices for w
 | **[Environment Management](environment-management.md)** | Switching between local, dev, and prod environments |
 | **[Database Operations](database-operations.md)** | Backup, restore, and migration procedures |
 | **[Docker Guide](docker-guide.md)** | Building images, platform considerations |
+| **[Logging Standards](logging-standards.md)** | Frontend/backend logging, trace IDs, Grafana Loki |
 | **[API Development](api-development.md)** | Creating new API endpoints |
 
 ---

--- a/docs/02-development/logging-standards.md
+++ b/docs/02-development/logging-standards.md
@@ -1,0 +1,220 @@
+# Logging Standards
+
+This document defines logging standards for the Missing Table application, covering both frontend and backend. These standards ensure consistent, searchable logs in Grafana Loki.
+
+## Overview
+
+The application uses a **distributed tracing** approach:
+- **Session ID** (`mt-sess-*`): Persists for the browser session, correlates all actions by a single user session
+- **Request ID** (`mt-req-*`): Unique per API call, correlates frontend request with backend processing
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Browser Session                                                          │
+│ session_id: mt-sess-a1b2c3d4                                            │
+│                                                                          │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐                 │
+│  │ API Call 1  │    │ API Call 2  │    │ API Call 3  │                 │
+│  │ req: mt-req-│    │ req: mt-req-│    │ req: mt-req-│                 │
+│  │ x1y2z3      │    │ a4b5c6      │    │ d7e8f9      │                 │
+│  └──────┬──────┘    └──────┬──────┘    └──────┬──────┘                 │
+│         │                  │                  │                         │
+└─────────┼──────────────────┼──────────────────┼─────────────────────────┘
+          │                  │                  │
+          ▼                  ▼                  ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Backend API                                                              │
+│ Each request logged with session_id + request_id                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Trace ID Formats
+
+| ID Type | Format | Example | Persistence |
+|---------|--------|---------|-------------|
+| Session ID | `mt-sess-{8 hex}` | `mt-sess-2c83833c` | Browser session (sessionStorage) |
+| Request ID | `mt-req-{8 hex}` | `mt-req-54010322` | Single request |
+
+Short 8-character hex IDs (4.3 billion combinations) - easy to copy/paste for Grafana queries.
+
+## Frontend Logging
+
+### Tools
+- **Grafana Faro**: Automatic error tracking, Web Vitals, session management
+- **Custom trace context**: Session and request ID generation
+
+### Log Levels
+| Level | When to Use | Example |
+|-------|-------------|---------|
+| `error` | Unrecoverable failures | API call failed after retries |
+| `warn` | Recoverable issues | Token refresh needed |
+| `info` | Key user actions | Login, logout, form submission |
+| `debug` | Development only | State changes, computed values |
+
+### Required Context
+Every log should include:
+- `session_id`: From trace context
+- `request_id`: For API calls
+- `user_id`: When authenticated (via Faro user context)
+
+### Example Usage
+```javascript
+import { getSessionId, generateRequestId } from '@/utils/traceContext';
+import { getFaro } from '@/faro';
+
+// For API calls
+const requestId = generateRequestId();
+const response = await fetch(url, {
+  headers: {
+    'X-Session-ID': getSessionId(),
+    'X-Request-ID': requestId,
+  }
+});
+
+// Manual logging via Faro
+const faro = getFaro();
+if (faro) {
+  faro.api.pushLog(['User clicked submit'], {
+    context: {
+      session_id: getSessionId(),
+      action: 'form_submit',
+      form_name: 'login'
+    }
+  });
+}
+```
+
+### HTTP Headers
+Frontend sends these headers with every API request:
+- `X-Session-ID`: Session trace ID
+- `X-Request-ID`: Per-request trace ID
+
+## Backend Logging
+
+### Tools
+- **structlog**: Structured JSON logging
+- **Trace middleware**: Extracts and binds trace IDs from headers
+
+### Log Levels
+| Level | When to Use | Example |
+|-------|-------------|---------|
+| `ERROR` | Failures requiring attention | Database error, auth failure |
+| `WARNING` | Potential issues | Deprecated endpoint used |
+| `INFO` | Request lifecycle, key events | Request start/end, user actions |
+| `DEBUG` | Detailed debugging | Query parameters, internal state |
+
+### Required Context
+Every log automatically includes (via middleware):
+- `session_id`: From `X-Session-ID` header
+- `request_id`: From `X-Request-ID` header (or generated)
+- `user_id`: When authenticated
+- `service`: Service name (e.g., "backend")
+- `timestamp`: ISO format
+- `filename`, `lineno`: Source location
+
+### Error Logging Best Practices
+
+**Bad** - loses context and stack trace:
+```python
+logger.error(f"Error: {e}")
+logger.error(f"Failed to create match: {str(e)}")
+```
+
+**Good** - structured with full context:
+```python
+logger.error(
+    "match_creation_failed",
+    error_type=type(e).__name__,
+    error_message=str(e),
+    match_data={"home_team": home_team_id, "away_team": away_team_id},
+    exc_info=True  # Includes full stack trace
+)
+```
+
+### Event Naming Convention
+Use snake_case event names that describe what happened:
+- `request_started`, `request_completed`
+- `user_login_success`, `user_login_failed`
+- `match_created`, `match_creation_failed`
+- `database_query_slow`, `database_connection_error`
+
+### Example Usage
+```python
+from logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Info level - key events
+logger.info("match_created", match_id=123, home_team="FC Academy", away_team="City United")
+
+# Warning - recoverable issues
+logger.warning("token_refresh_required", user_id=user_id, token_age_seconds=3500)
+
+# Error - with full context
+try:
+    result = dao.create_match(data)
+except Exception as e:
+    logger.error(
+        "match_creation_failed",
+        error_type=type(e).__name__,
+        error_message=str(e),
+        match_data=data,
+        exc_info=True
+    )
+    raise
+```
+
+## Grafana Loki Queries
+
+### Find all logs for a session
+```logql
+{app="missing-table"} |= "mt-sess-a1b2c3d4"
+```
+
+### Find all logs for a specific request
+```logql
+{app="missing-table"} |= "mt-req-x1y2z3"
+```
+
+### Find errors with context
+```logql
+{app="missing-table"} | json | level="error"
+```
+
+### Trace a user's journey
+```logql
+{app="missing-table"} | json | session_id="mt-sess-a1b2c3d4" | line_format "{{.timestamp}} [{{.level}}] {{.event}}"
+```
+
+### Find slow requests
+```logql
+{app="missing-table"} | json | duration_ms > 1000
+```
+
+## File Locations
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| Frontend trace context | `frontend/src/utils/traceContext.js` | Generate session/request IDs |
+| Frontend Faro | `frontend/src/faro.js` | Observability SDK |
+| Backend logging config | `backend/logging_config.py` | structlog setup |
+| Backend trace middleware | `backend/middleware/trace_middleware.py` | Extract trace headers |
+
+## Checklist for New Code
+
+### Frontend
+- [ ] Include session_id in Faro logs
+- [ ] Generate request_id for API calls
+- [ ] Pass trace headers to backend
+- [ ] Use appropriate log level
+
+### Backend
+- [ ] Use structlog logger (not print or logging directly)
+- [ ] Use snake_case event names
+- [ ] Include relevant context as kwargs
+- [ ] For errors: include `error_type`, `error_message`, `exc_info=True`
+- [ ] Don't log sensitive data (passwords, tokens, PII)
+
+---
+
+*Last Updated: 2024-12-14*

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,5 +1,6 @@
 import { reactive, computed } from 'vue';
 import { addCSRFHeader, clearCSRFToken } from '../utils/csrf';
+import { getTraceHeaders } from '../utils/traceContext';
 import { getApiBaseUrl } from '../config/api';
 import {
   recordLogin,
@@ -92,6 +93,7 @@ export const useAuthStore = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...getTraceHeaders(),
         },
         body: JSON.stringify({
           username,
@@ -134,6 +136,7 @@ export const useAuthStore = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...getTraceHeaders(),
         },
         body: JSON.stringify({
           username,
@@ -174,6 +177,7 @@ export const useAuthStore = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...getTraceHeaders(),
         },
         body: JSON.stringify({ username, password }),
       });
@@ -347,6 +351,7 @@ export const useAuthStore = () => {
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
+          ...getTraceHeaders(),
         },
       });
 
@@ -377,6 +382,7 @@ export const useAuthStore = () => {
                 headers: {
                   Authorization: `Bearer ${newToken}`,
                   'Content-Type': 'application/json',
+                  ...getTraceHeaders(),
                 },
               }
             );
@@ -416,6 +422,7 @@ export const useAuthStore = () => {
     return {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      ...getTraceHeaders(), // Include session_id and request_id for distributed tracing
     };
   };
 
@@ -424,7 +431,8 @@ export const useAuthStore = () => {
     const startTime = performance.now();
     const method = options.method || 'GET';
     const token = localStorage.getItem('auth_token');
-    const defaultHeaders = {};
+    const traceHeaders = getTraceHeaders(); // Generate trace IDs for this request
+    const defaultHeaders = { ...traceHeaders };
 
     // Only set Content-Type for non-FormData requests
     // FormData needs the browser to set Content-Type with boundary automatically
@@ -519,6 +527,7 @@ export const useAuthStore = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...getTraceHeaders(),
         },
         body: JSON.stringify({ refresh_token: refreshToken }),
       });
@@ -551,6 +560,7 @@ export const useAuthStore = () => {
 
     let headers = {
       Authorization: `Bearer ${token}`,
+      ...getTraceHeaders(), // Include trace IDs for distributed tracing
       ...options.headers,
     };
 
@@ -577,6 +587,7 @@ export const useAuthStore = () => {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
+            ...getTraceHeaders(),
           },
         }
       );

--- a/frontend/src/utils/traceContext.js
+++ b/frontend/src/utils/traceContext.js
@@ -1,0 +1,111 @@
+/**
+ * Trace Context - Session and Request ID Management
+ *
+ * Provides distributed tracing support for correlating frontend actions
+ * with backend processing in Grafana Loki.
+ *
+ * Session ID: Persists for browser session, correlates all user actions
+ * Request ID: Unique per API call, correlates single request through backend
+ */
+
+const SESSION_ID_KEY = 'mt_session_id';
+
+/**
+ * Generate a short unique ID (8 hex characters)
+ * 8 chars = 4.3 billion combinations, plenty for session/request scope
+ * @returns {string} Short hex ID
+ */
+function generateShortId() {
+  // Use crypto.randomUUID if available, take first 8 chars
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID().replace(/-/g, '').substring(0, 8);
+  }
+
+  // Fallback for older browsers
+  return 'xxxxxxxx'.replace(/x/g, () => {
+    return ((Math.random() * 16) | 0).toString(16);
+  });
+}
+
+/**
+ * Get or create the session ID
+ * Session ID persists across page loads but not browser sessions
+ *
+ * @returns {string} Session ID in format "mt-sess-{8 hex chars}"
+ */
+export function getSessionId() {
+  // Check sessionStorage first
+  let sessionId = sessionStorage.getItem(SESSION_ID_KEY);
+
+  if (!sessionId) {
+    sessionId = `mt-sess-${generateShortId()}`;
+    sessionStorage.setItem(SESSION_ID_KEY, sessionId);
+
+    // Log session start for debugging
+    console.log('[TraceContext] New session started:', sessionId);
+  }
+
+  return sessionId;
+}
+
+/**
+ * Generate a unique request ID for an API call
+ *
+ * @returns {string} Request ID in format "mt-req-{8 hex chars}"
+ */
+export function generateRequestId() {
+  return `mt-req-${generateShortId()}`;
+}
+
+/**
+ * Get trace headers to include in API requests
+ *
+ * @returns {Object} Headers object with X-Session-ID and X-Request-ID
+ */
+export function getTraceHeaders() {
+  return {
+    'X-Session-ID': getSessionId(),
+    'X-Request-ID': generateRequestId(),
+  };
+}
+
+/**
+ * Create a fetch wrapper that automatically includes trace headers
+ *
+ * @param {string} url - Request URL
+ * @param {Object} options - Fetch options
+ * @returns {Promise<Response>} Fetch response
+ */
+export async function tracedFetch(url, options = {}) {
+  const traceHeaders = getTraceHeaders();
+
+  const mergedOptions = {
+    ...options,
+    headers: {
+      ...traceHeaders,
+      ...options.headers,
+    },
+  };
+
+  return fetch(url, mergedOptions);
+}
+
+/**
+ * Get current trace context for logging
+ * Use this when manually logging events via Faro
+ *
+ * @param {string} [requestId] - Optional specific request ID
+ * @returns {Object} Trace context for logging
+ */
+export function getTraceContext(requestId = null) {
+  return {
+    session_id: getSessionId(),
+    request_id: requestId || generateRequestId(),
+  };
+}
+
+// Initialize session ID on module load
+// This ensures consistent session tracking from first API call
+if (typeof window !== 'undefined') {
+  getSessionId();
+}


### PR DESCRIPTION
## Summary

Implement end-to-end request tracing for better observability in Grafana Loki:

- **Session ID** (`mt-sess-{8 hex}`): Persists for browser session, correlates all user actions
- **Request ID** (`mt-req-{8 hex}`): Unique per API call, traces single request through backend

Short 8-character hex IDs for easy copy/paste in Grafana queries.

## Changes

### Frontend
- Add `traceContext.js` utility for ID generation
- Add `X-Session-ID` and `X-Request-ID` headers to all API calls in `auth.js`

### Backend  
- Add `TraceMiddleware` to extract trace headers
- Bind IDs to structlog context for all logs
- Log `request_started`/`request_completed` with timing
- Return `X-Request-ID` in response headers

### Documentation
- Add `docs/02-development/logging-standards.md` with:
  - Logging best practices
  - Trace ID formats
  - Grafana Loki query examples

## Usage

```logql
# Find all logs for a session
{app="missing-table-backend"} |= "mt-sess-a1b2c3d4"

# Find all logs for a request
{app="missing-table-backend"} |= "mt-req-e5f6g7h8"
```

## Test Plan
- [x] Verify trace headers appear in browser DevTools
- [x] Verify backend logs include session_id and request_id
- [x] Verify X-Request-ID returned in response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)