### PR TITLE
ci: Enforce frontend lint checks (remove continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@
             npm ci
 
         - name: Run frontend lint
-          continue-on-error: true
           run: |
             cd frontend
             npm run lint


### PR DESCRIPTION
## Summary

Removes `continue-on-error: true` from the frontend lint step to raise the quality bar.

**Frontend is ready:**
- ✅ `npm run lint` - passes
- ✅ `npm run format:check` - passes

**Backend stays lenient (for now):**
- ❌ `ruff check .` - 1363 errors (675 print statements, 281 line-too-long, etc.)
- ❌ `mypy .` - 1 error (module name conflict)

## What this changes

| Step | Before | After |
|------|--------|-------|
| Run Ruff (Python lint) | `continue-on-error: true` | `continue-on-error: true` (unchanged) |
| Run MyPy (Python type check) | `continue-on-error: true` | `continue-on-error: true` (unchanged) |
| Run frontend lint | `continue-on-error: true` | **Removed** - will fail CI |

## Impact

PRs with frontend lint/format errors will now fail CI, preventing merge until fixed.

## Test plan

- [ ] CI passes on this PR (proves frontend lint is clean)
- [ ] Future PRs with lint errors should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)