### PR TITLE
perf: Lazy-load teams in LoginForm to avoid unnecessary API call

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -182,7 +182,7 @@
 </template>
 
 <script>
-import { ref, reactive, onMounted } from 'vue';
+import { ref, reactive, onMounted, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 
@@ -246,6 +246,9 @@ export default {
     };
 
     const fetchTeams = async () => {
+      // Only fetch if not already loaded
+      if (teams.value.length > 0) return;
+
       try {
         const response = await fetch(`${getApiBaseUrl()}/api/teams`);
         const data = await response.json();
@@ -254,6 +257,13 @@ export default {
         console.error('Error fetching teams:', error);
       }
     };
+
+    // Lazy-load teams only when a team-related role is selected
+    watch(selectedRole, newRole => {
+      if (newRole === 'team-manager' || newRole === 'team-player') {
+        fetchTeams();
+      }
+    });
 
     const handleSubmit = async () => {
       authStore.clearError();
@@ -302,8 +312,6 @@ export default {
     };
 
     onMounted(() => {
-      fetchTeams();
-
       // Check for invite code in URL query parameter
       const urlParams = new URLSearchParams(window.location.search);
       const inviteCode = urlParams.get('code');


### PR DESCRIPTION
## Summary
- Fix unnecessary `/api/teams` call when loading the login form
- Teams are now lazy-loaded only when needed (when user selects team-manager or team-player role)

## Problem
When opening the login form, `/api/teams` was being fetched immediately on component mount, even for simple logins where team data isn't needed.

## Solution
- Removed `fetchTeams()` from `onMounted` hook
- Added a `watch` on `selectedRole` that fetches teams only when:
  - Role is `team-manager` or `team-player`
  - Teams haven't already been loaded (avoids duplicate requests)

## Test plan
- [x] Open login form - no `/api/teams` call
- [x] Click login - no `/api/teams` call
- [x] Frontend linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)