### PR TITLE
fix: Use k8s.grafana.com annotations for Grafana Alloy scraping

### DIFF
--- a/helm/missing-table/templates/backend.yaml
+++ b/helm/missing-table/templates/backend.yaml
@@ -24,10 +24,10 @@ spec:
         # Force pod restart on each deployment (image tag stays same)
         rollout/commitSha: {{ .Values.commitSha | default "unknown" | quote }}
         rollout/buildId: {{ .Values.buildId | default "unknown" | quote }}
-        # Prometheus scraping - Grafana Alloy will autodiscover and scrape /metrics
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8000"
-        prometheus.io/path: "/metrics"
+        # Grafana Alloy autodiscovery annotations (k8s-monitoring chart v2)
+        k8s.grafana.com/scrape: "true"
+        k8s.grafana.com/metrics.portNumber: "8000"
+        k8s.grafana.com/metrics.path: "/metrics"
     spec:
       {{- if .Values.imageCredentials }}
       imagePullSecrets:


### PR DESCRIPTION
## Summary
- Fix Grafana Alloy autodiscovery by using correct annotation scheme
- k8s-monitoring Helm chart v2 expects `k8s.grafana.com/*` annotations, not `prometheus.io/*`

## Changes
- `k8s.grafana.com/scrape: "true"` (was `prometheus.io/scrape`)
- `k8s.grafana.com/metrics.portNumber: "8000"` (was `prometheus.io/port`)
- `k8s.grafana.com/metrics.path: "/metrics"` (was `prometheus.io/path`)

## Test plan
- [x] Manually patched deployment to verify Alloy discovers the backend pod
- [ ] Verify metrics appear in Grafana Cloud after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)