### PR TITLE
fix: Team managers can now create player/fan invites

### DIFF
--- a/backend/api/invites.py
+++ b/backend/api/invites.py
@@ -293,7 +293,7 @@ async def create_team_fan_invite(
     current_user=Depends(get_current_user_required)
 ):
     """Create a team fan invitation (team manager) - DEPRECATED: Use club-fan instead"""
-    if current_user['role'] not in ['admin', 'team_manager']:
+    if current_user['role'] not in ['admin', 'team-manager', 'team_manager']:
         raise HTTPException(status_code=403, detail="Unauthorized")
     
     supabase = service_client
@@ -305,21 +305,21 @@ async def create_team_fan_invite(
         raise HTTPException(status_code=400, detail=f"User ID not found in current_user: {current_user}")
     
     # Check if team manager can manage this team
-    if current_user['role'] == 'team_manager':
+    if current_user['role'] in ['team_manager', 'team-manager']:
         can_manage = team_manager_service.can_manage_team(
             user_id,
             request.team_id,
             request.age_group_id
         )
-        
+
         if not can_manage:
             raise HTTPException(
-                status_code=403, 
+                status_code=403,
                 detail="You can only create invites for teams you manage"
             )
-    
+
     invite_service = InviteService(supabase)
-    
+
     try:
         invitation = invite_service.create_invitation(
             invited_by_user_id=user_id,
@@ -340,7 +340,7 @@ async def create_team_player_invite(
     current_user=Depends(get_current_user_required)
 ):
     """Create a team player invitation (team manager)"""
-    if current_user['role'] not in ['admin', 'team_manager']:
+    if current_user['role'] not in ['admin', 'team-manager', 'team_manager']:
         raise HTTPException(status_code=403, detail="Unauthorized")
     
     supabase = service_client
@@ -352,21 +352,21 @@ async def create_team_player_invite(
         raise HTTPException(status_code=400, detail=f"User ID not found in current_user: {current_user}")
     
     # Check if team manager can manage this team
-    if current_user['role'] == 'team_manager':
+    if current_user['role'] in ['team_manager', 'team-manager']:
         can_manage = team_manager_service.can_manage_team(
             user_id,
             request.team_id,
             request.age_group_id
         )
-        
+
         if not can_manage:
             raise HTTPException(
-                status_code=403, 
+                status_code=403,
                 detail="You can only create invites for teams you manage"
             )
-    
+
     invite_service = InviteService(supabase)
-    
+
     try:
         invitation = invite_service.create_invitation(
             invited_by_user_id=user_id,
@@ -432,7 +432,7 @@ async def cancel_invitation(
 @router.get("/team-manager/assignments", )
 async def get_team_manager_assignments(current_user=Depends(get_current_user_required)):
     """Get team assignments for the current user"""
-    if current_user['role'] not in ['admin', 'team_manager']:
+    if current_user['role'] not in ['admin', 'team-manager', 'team_manager']:
         raise HTTPException(status_code=403, detail="Unauthorized")
     
     supabase = service_client

--- a/backend/tests/tsc/test_02_team_manager.py
+++ b/backend/tests/tsc/test_02_team_manager.py
@@ -189,14 +189,12 @@ class TestTeamManagerJourney:
         self,
         tsc_client: TSCClient,
         entity_registry: EntityRegistry,
-        existing_admin_credentials: tuple[str, str],
     ):
-        """Create invite for player (admin creates since team manager lacks permission)."""
-        # Use admin to create player invite
-        username, password = existing_admin_credentials
-        tsc_client.login(username, password)
+        """Create invite for player (team manager creates for their team)."""
+        # Re-login as team manager (may have been logged out by previous tests)
+        tsc_client.login_team_manager()
 
-        result = tsc_client.create_team_player_invite_admin(
+        result = tsc_client.create_team_player_invite(
             team_id=entity_registry.premier_team_id
         )
         assert "invite_code" in result
@@ -206,14 +204,12 @@ class TestTeamManagerJourney:
         self,
         tsc_client: TSCClient,
         entity_registry: EntityRegistry,
-        existing_admin_credentials: tuple[str, str],
     ):
-        """Create invite for team fan (admin creates since team manager lacks permission)."""
-        # Use admin to create team fan invite
-        username, password = existing_admin_credentials
-        tsc_client.login(username, password)
+        """Create invite for team fan (team manager creates for their team)."""
+        # Re-login as team manager
+        tsc_client.login_team_manager()
 
-        result = tsc_client.create_team_fan_invite_admin(
+        result = tsc_client.create_team_fan_invite(
             team_id=entity_registry.premier_team_id
         )
         assert "invite_code" in result


### PR DESCRIPTION
## Summary
- Fixed bug where team managers couldn't create player or team_fan invites even after signing up via a team_manager invite
- Two root causes were identified and fixed:
  1. **Missing team_manager_assignments entry**: When a team_manager invite is redeemed, no entry was being created in `team_manager_assignments` table, so the `can_manage_team()` check always failed
  2. **Role name mismatch**: API endpoints checked for `team_manager` (underscore) but database stores `team-manager` (hyphen)

## Changes
- `services/invite_service.py`: 
  - Added `_create_team_manager_assignment()` method
  - Modified `redeem_invitation()` to call this method for team_manager invites
  - Added `invited_by_user_id` to `validate_invite_code()` return value
- `api/invites.py`: Accept both `team-manager` and `team_manager` role names
- `tests/tsc/test_02_team_manager.py`: Updated tests to use team_manager endpoints instead of admin workaround

## Test plan
- [x] All 56 TSC journey tests pass
- [x] Verified `team_manager_assignments` entry is created on invite redemption
- [x] Team manager can create player invites via `/api/invites/team-manager/team-player`
- [x] Team manager can create team fan invites via `/api/invites/team-manager/team-fan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)