### PR TITLE
feat: Support custom display name for Google OAuth signup

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -316,8 +316,11 @@ export default {
 
     const handleGoogleSignUp = async () => {
       authStore.clearError();
-      // Pass the invite code through OAuth state parameter
-      const result = await authStore.signInWithGoogle(form.inviteCode);
+      // Pass the invite code and display name through localStorage
+      const result = await authStore.signInWithGoogle(
+        form.inviteCode,
+        form.displayName || null
+      );
       if (!result.success) {
         console.error('Google sign-up failed:', result.error);
       }


### PR DESCRIPTION
## Summary
- Users can enter a custom display name before Google OAuth signup
- The custom name is stored in localStorage and passed to the backend
- Backend prioritizes user's input over Google's profile metadata

## Changes
- `frontend/src/stores/auth.js`: Store/retrieve display_name in localStorage
- `frontend/src/components/LoginForm.vue`: Pass form.displayName to signInWithGoogle
- `backend/app.py`: Accept display_name in OAuthCallbackData, use if provided

## Display Name Priority
1. User's custom input from signup form
2. Google's full_name metadata  
3. Google's name metadata
4. Email prefix as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)