### PR TITLE
feat: Add Google login for returning OAuth users

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -104,7 +104,41 @@
         </div>
       </form>
 
-      <!-- Social Login Option (only show on invite signup with valid invite code) -->
+      <!-- Google Login Option (show on regular login form) -->
+      <div v-if="!showInviteSignup" class="social-login">
+        <div class="divider">
+          <span>or continue with</span>
+        </div>
+
+        <button
+          @click="handleGoogleLogin"
+          :disabled="authStore.state.loading"
+          class="google-btn"
+          data-testid="google-login-button"
+        >
+          <svg class="google-icon" viewBox="0 0 24 24">
+            <path
+              fill="#4285F4"
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            />
+            <path
+              fill="#34A853"
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            />
+            <path
+              fill="#EA4335"
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            />
+          </svg>
+          <span>Continue with Google</span>
+        </button>
+      </div>
+
+      <!-- Google Sign Up Option (show on invite signup with valid invite code) -->
       <div v-if="showInviteSignup && inviteInfo" class="social-login">
         <div class="divider">
           <span>or sign up with</span>
@@ -314,6 +348,16 @@ export default {
       }
     });
 
+    const handleGoogleLogin = async () => {
+      authStore.clearError();
+      // No invite code for login - just redirect to Google
+      const result = await authStore.signInWithGoogle(null, null);
+      if (!result.success) {
+        console.error('Google login failed:', result.error);
+      }
+      // User will be redirected to Google, then back to /auth/callback
+    };
+
     const handleGoogleSignUp = async () => {
       authStore.clearError();
       // Pass the invite code and display name through localStorage
@@ -404,6 +448,7 @@ export default {
       validateInviteCode,
       formatInviteMessage,
       handleSubmit,
+      handleGoogleLogin,
       handleGoogleSignUp,
       completeProfile,
     };


### PR DESCRIPTION
## Summary
- Adds "Continue with Google" button to the login form for returning OAuth users
- Users who signed up with Google can now log back in using their Google account
- Previously the Google button only appeared on the signup form (with invite code)

## Changes
**Backend (`backend/app.py`):**
- Make `invite_code` optional in OAuth callback endpoint
- Add login flow (no invite_code) that finds existing user by email
- Add validation that prevents password users from using OAuth login

**Frontend (`frontend/src/stores/auth.js`):**
- Update `signInWithGoogle` to work without invite code (for login)
- Update `handleOAuthCallback` to handle both login and signup flows
- Store flow type in localStorage to distinguish login vs signup

**Frontend (`frontend/src/components/LoginForm.vue`):**
- Add "Continue with Google" button to login form
- Keep "Sign up with Google" button on invite signup form

## How It Works

**LOGIN flow (returning users):**
1. User clicks "Continue with Google" on login form
2. Redirect to Google for authentication
3. Backend finds existing profile by email
4. Returns user profile → Login success

**SIGNUP flow (new users with invite):**
1. User enters invite code on signup form
2. User clicks "Sign up with Google"
3. Backend validates invite, creates profile with invite's role/team
4. Returns user profile → Signup success

## Test Plan
- [ ] Log in with pytom13@gmail.com using "Continue with Google" on login form
- [ ] Verify it redirects to Google and back
- [ ] Verify login succeeds and shows Fan Profile
- [ ] Test error handling for non-existent Google accounts
- [ ] Test error handling for password users trying OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)