### PR TITLE
fix: Age group filter not applied when clicking team cards

### DIFF
--- a/frontend/src/components/profiles/FanProfile.vue
+++ b/frontend/src/components/profiles/FanProfile.vue
@@ -381,18 +381,37 @@ export default {
 
     const goToTeam = team => {
       // Extract filter IDs from team data
+      // The team object from get_club_teams includes:
+      // - age_groups: array of {id, name} (processed by backend)
+      // - team_mappings: raw data with nested age_groups and divisions
+      // - leagues: {id, name} from foreign key
+      // - league_id: direct column value
+
+      // Get age group ID - try processed array first, then raw team_mappings
+      const ageGroupId =
+        team.age_groups?.[0]?.id ||
+        team.team_mappings?.[0]?.age_groups?.id ||
+        null;
+
+      // Get league ID - try leagues object first, then direct column
+      const leagueId = team.leagues?.id || team.league_id || null;
+
+      // Get division ID from team_mappings
+      const divisionId = team.team_mappings?.[0]?.divisions?.id || null;
+
       const filters = {
-        ageGroupId: team.age_groups?.[0]?.id || null,
-        leagueId: team.leagues?.id || team.league_id || null,
-        divisionId: team.team_mappings?.[0]?.divisions?.id || null,
+        ageGroupId,
+        leagueId,
+        divisionId,
       };
 
-      console.log(
-        'Navigating to table with filters:',
-        filters,
-        'from team:',
-        team
-      );
+      console.log('Navigating to table with filters:', filters);
+      console.log('Team data:', {
+        age_groups: team.age_groups,
+        team_mappings: team.team_mappings,
+        leagues: team.leagues,
+        league_id: team.league_id,
+      });
 
       // Navigate to table with filters
       emit('navigate', 'table', filters);


### PR DESCRIPTION
## Summary
- Fix age group filter not being applied when clicking team cards in FanProfile
- Add fallback to extract ageGroupId from team_mappings if age_groups array is empty
- Add detailed console logging to debug filter extraction

## Problem
When a club fan clicks on a team card (e.g., "IFA" - U13 Homegrown), the Table page should navigate to the correct League, Division, and Age Group. The League and Division were working but the Age Group stayed at the default (U14) instead of changing to U13.

## Solution
Improved the filter extraction logic in `goToTeam()` to try multiple data sources:
- First tries `team.age_groups[0].id` (processed by backend)
- Falls back to `team.team_mappings[0].age_groups.id` (raw Supabase data)

## Test Plan
- [ ] Click on "IFA" (U13 • Northeast • Homegrown) team card
- [ ] Verify Table page shows Age Group: U13, League: Homegrown, Division: Northeast
- [ ] Check browser console for debug logging showing filter values

🤖 Generated with [Claude Code](https://claude.com/claude-code)