### PR TITLE
fix: Apply initial filters in LeagueTable onMounted

### DIFF
--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -476,6 +476,13 @@ export default {
 
     onMounted(async () => {
       console.log('LeagueTable component mounted');
+      console.log('Initial props:', {
+        initialAgeGroupId: props.initialAgeGroupId,
+        initialLeagueId: props.initialLeagueId,
+        initialDivisionId: props.initialDivisionId,
+        filterKey: props.filterKey,
+      });
+
       await Promise.all([
         fetchAgeGroups(),
         fetchLeagues(),
@@ -485,8 +492,21 @@ export default {
       // Fetch divisions after leagues are loaded so we can filter by default league
       await fetchDivisions();
 
-      // For non-admins, auto-select based on their team's league and division
-      if (!authStore.isAdmin.value && authStore.userTeamId.value) {
+      // Apply initial filters from props if provided (e.g., from team card click)
+      if (props.filterKey > 0 && props.initialLeagueId) {
+        console.log('Applying initial filters from props');
+        if (props.initialAgeGroupId) {
+          selectedAgeGroupId.value = props.initialAgeGroupId;
+        }
+        if (props.initialLeagueId) {
+          selectedLeagueId.value = props.initialLeagueId;
+          filterDivisionsByLeague();
+        }
+        if (props.initialDivisionId) {
+          selectedDivisionId.value = props.initialDivisionId;
+        }
+      } else if (!authStore.isAdmin.value && authStore.userTeamId.value) {
+        // For non-admins without explicit filters, auto-select based on their team
         try {
           // Fetch the user's team to get its league and division
           const teams = await authStore.apiRequest(


### PR DESCRIPTION
## Summary
Fix age group filter not being applied when clicking team cards in FanProfile.

## Problem
From the console logs, we could see that:
1. FanProfile correctly extracted `{ageGroupId: 1, leagueId: 1, divisionId: 1}`
2. But LeagueTable fetched with `{ageGroupId: 2}` (the default U14)

The issue was that `onMounted()` called `fetchTableData()` with default values BEFORE the watcher on `filterKey` could apply the filters from props.

## Solution
Check for initial filter props in `onMounted()` and apply them BEFORE calling `fetchTableData()`.

## Test Plan
- [ ] Click on "IFA" (U13 • Northeast • Homegrown) team card
- [ ] Verify Table page shows Age Group: **U13** (not U14)
- [ ] Verify League: Academy, Division: Northeast are correct
- [ ] Check console log shows "Applying initial filters from props"

🤖 Generated with [Claude Code](https://claude.com/claude-code)