### PR TITLE
feat: Improve club teams display with grouped layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -232,7 +232,12 @@
 
           <!-- Matches -->
           <div v-if="currentTab === 'scores'" class="p-4">
-            <MatchesView />
+            <MatchesView
+              :initial-age-group-id="matchesFilters.ageGroupId"
+              :initial-league-id="matchesFilters.leagueId"
+              :initial-division-id="matchesFilters.divisionId"
+              :filter-key="matchesFilters.key"
+            />
           </div>
 
           <!-- Add Match Form (auth required) -->
@@ -307,6 +312,12 @@ export default {
     const authStore = useAuthStore();
     const currentTab = ref('table');
     const tableFilters = ref({
+      ageGroupId: null,
+      leagueId: null,
+      divisionId: null,
+      key: 0, // Used to force re-render when filters change
+    });
+    const matchesFilters = ref({
       ageGroupId: null,
       leagueId: null,
       divisionId: null,
@@ -408,6 +419,16 @@ export default {
           key: tableFilters.value.key + 1, // Force re-render
         };
       }
+
+      // If filters provided and switching to scores/matches, apply them
+      if (tabId === 'scores' && filters) {
+        matchesFilters.value = {
+          ageGroupId: filters.ageGroupId || null,
+          leagueId: filters.leagueId || null,
+          divisionId: filters.divisionId || null,
+          key: matchesFilters.value.key + 1, // Force re-render
+        };
+      }
     };
 
     const submitInviteRequest = async () => {
@@ -506,6 +527,7 @@ export default {
       authStore,
       currentTab,
       tableFilters,
+      matchesFilters,
       availableTabs,
       showLoginModal,
       showInviteRequestModal,

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -1367,7 +1367,13 @@ export default {
     MatchEditModal,
     MatchDetailView,
   },
-  setup() {
+  props: {
+    initialAgeGroupId: { type: Number, default: null },
+    initialLeagueId: { type: Number, default: null },
+    initialDivisionId: { type: Number, default: null },
+    filterKey: { type: Number, default: 0 },
+  },
+  setup(props) {
     const authStore = useAuthStore();
     const teams = ref([]);
     const matches = ref([]);
@@ -2181,6 +2187,19 @@ export default {
         fetchLeagues(),
         fetchTeams(),
       ]);
+
+      // Apply initial filters from props if provided
+      if (props.filterKey > 0) {
+        if (props.initialAgeGroupId) {
+          selectedAgeGroupId.value = props.initialAgeGroupId;
+        }
+        if (props.initialLeagueId) {
+          selectedLeagueId.value = props.initialLeagueId;
+          // Switch to My Club tab when league is specified
+          selectedViewTab.value = 'myclub';
+        }
+      }
+
       // Fetch matches for the default "All Matches" tab with current week
       await fetchMatches();
     });


### PR DESCRIPTION
## Summary

Improves the Club Teams section on the Fan Profile page:

- **Grouped by League > Division > Age Group** - Teams are now organized hierarchically instead of a flat list
- **Table and Matches navigation links** - Each age group row has links to navigate to the Table and Matches tabs with pre-applied filters
- **Filter props for MatchesView** - Added support for initial filters similar to LeagueTable

## Changes

### FanProfile.vue
- Added `groupedTeams` computed property to organize teams by League > Division > Age Groups
- Added `goToTableWithFilters()` and `goToMatchesWithFilters()` navigation functions
- New hierarchical layout with league headers, division sections, and age group rows
- New CSS styles for the grouped layout

### MatchesView.vue
- Added filter props: `initialAgeGroupId`, `initialLeagueId`, `initialDivisionId`, `filterKey`
- Apply initial filters on component mount

### App.vue
- Added `matchesFilters` ref to track filter state for MatchesView
- Updated `handleSwitchTab` to handle filters for both 'table' and 'scores' tabs
- Pass filter props to MatchesView component

## Screenshots

Before: Flat list of teams
After: Hierarchical League > Division > Age Group with navigation links

## Test plan
- [ ] Login as IFA Club Fan
- [ ] Verify teams are grouped by League, then Division
- [ ] Click "Table" link for an age group - verify Table tab opens with correct filters
- [ ] Click "Matches" link for an age group - verify Matches tab opens with correct filters
- [ ] Verify responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)