### PR TITLE
feat: Improve My Club tab with Club dropdown and rich team display

### DIFF
--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -30,6 +30,8 @@ export const useAuthStore = () => {
   const isAuthenticated = computed(() => !!state.session);
   const isAdmin = computed(() => state.profile?.role === 'admin');
   const isClubManager = computed(() => state.profile?.role === 'club_manager');
+  const isClubFan = computed(() => state.profile?.role === 'club_fan');
+  const hasClubAccess = computed(() => !!state.profile?.club_id);
   const isTeamManager = computed(
     () =>
       state.profile?.role === 'team-manager' ||
@@ -774,6 +776,8 @@ export const useAuthStore = () => {
     isAuthenticated,
     isAdmin,
     isClubManager,
+    isClubFan,
+    hasClubAccess,
     isTeamManager,
     isPlayer,
     canBrowseAll,


### PR DESCRIPTION
## Summary
- Add Club dropdown to My Club tab (pre-selected for club fans, browsable for all)
- Add rich Team dropdown format: "Team Name (League - Division)"
- Sort teams by league name for better grouping (e.g., Futsal teams together)
- Fix filtering for club fans who have `club_id` but no `team_id`

## Changes

### Auth Store (`frontend/src/stores/auth.js`)
- Added `isClubFan` computed property
- Added `hasClubAccess` computed property

### MatchesView (`frontend/src/components/MatchesView.vue`)
- Added Club dropdown with all clubs, pre-selected for club fans
- Added Team dropdown with rich format showing League and Division
- Teams sorted by league name, then by team name
- Auto-selects matching team when navigating from FanProfile
- Shows prompt to select club when none selected

## Test plan
- [ ] Login as club fan user
- [ ] Navigate to Matches page, click "My Club" tab
- [ ] Verify club is pre-selected in dropdown
- [ ] Verify Team dropdown shows "Team Name (League - Division)" format
- [ ] Verify teams are grouped by league (Futsal teams together, etc.)
- [ ] Select a team and verify matches load correctly
- [ ] Navigate from FanProfile "Matches" link and verify team auto-selects

🤖 Generated with [Claude Code](https://claude.com/claude-code)