### PR TITLE
fix: Add ESLint globals for Vitest test files

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,23 @@
       "ecmaVersion": "latest",
       "sourceType": "module"
     },
-    "rules": {}
+    "rules": {},
+    "overrides": [
+      {
+        "files": ["src/__tests__/**/*.js"],
+        "globals": {
+          "describe": "readonly",
+          "it": "readonly",
+          "expect": "readonly",
+          "vi": "readonly",
+          "beforeEach": "readonly",
+          "afterEach": "readonly",
+          "beforeAll": "readonly",
+          "afterAll": "readonly",
+          "test": "readonly"
+        }
+      }
+    ]
   },
   "browserslist": [
     "> 1%",

--- a/frontend/src/__tests__/components/LoginForm.spec.js
+++ b/frontend/src/__tests__/components/LoginForm.spec.js
@@ -353,7 +353,10 @@ describe('LoginForm', () => {
       await flushPromises();
 
       // After signup succeeds, login should be called
-      expect(mockAuthStore.login).toHaveBeenCalledWith('newuser', 'password123');
+      expect(mockAuthStore.login).toHaveBeenCalledWith(
+        'newuser',
+        'password123'
+      );
     });
   });
 
@@ -441,7 +444,9 @@ describe('LoginForm', () => {
     it('calls signInWithGoogle when clicking Google button', async () => {
       const wrapper = mountLoginForm();
 
-      await wrapper.find('[data-testid="google-login-button"]').trigger('click');
+      await wrapper
+        .find('[data-testid="google-login-button"]')
+        .trigger('click');
       await flushPromises();
 
       // For login flow, signInWithGoogle is called with null (no invite code)


### PR DESCRIPTION
## Summary

Fixes the ESLint linting error introduced in #160 where Vitest globals (`beforeEach`, etc.) were not recognized in test files.

## Changes

- Add ESLint `overrides` section in `package.json` to define Vitest globals for test files
- Apply prettier formatting to `LoginForm.spec.js`

## Root Cause

The ESLint configuration didn't know about Vitest's global functions (`describe`, `it`, `expect`, `beforeEach`, etc.) which are injected when `globals: true` is set in vitest.config.js.

## Fix

Added an ESLint override for `src/__tests__/**/*.js` files that declares these as readonly globals:
- `describe`, `it`, `test`
- `expect`, `vi`
- `beforeEach`, `afterEach`, `beforeAll`, `afterAll`

## Test plan

- [x] `npm run lint` passes locally
- [x] `npm run test:run` passes (19 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)