### PR TITLE
feat: Add user journey tests workflow for production

### DIFF
--- a/.github/workflows/quality-journey.yml
+++ b/.github/workflows/quality-journey.yml
@@ -1,0 +1,118 @@
+name: User Journey Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - 'production'
+
+env:
+  PYTHON_VERSION: '3.13'
+  S3_BUCKET: 'quality-missingtable-com'
+  CLOUDFRONT_DISTRIBUTION_ID: 'E15AUGI7OKJ99L'
+
+jobs:
+  journey-tests:
+    name: Run User Journey Tests
+    runs-on: [self-hosted, quality-runner]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify Allure CLI
+        run: |
+          allure --version
+
+      - name: Setup Python with uv
+        run: |
+          cd backend
+          uv python install 3.13
+          uv sync --python 3.13
+
+      - name: Run TSC Journey Tests
+        id: journey-tests
+        env:
+          BASE_URL: https://api.missingtable.com
+          TSC_PREFIX: tsc_ci_
+          TSC_EXISTING_ADMIN_USERNAME: ${{ secrets.TSC_ADMIN_USERNAME }}
+          TSC_EXISTING_ADMIN_PASSWORD: ${{ secrets.TSC_ADMIN_PASSWORD }}
+        run: |
+          cd backend
+          mkdir -p allure-results
+          uv run pytest tests/tsc/ \
+            -v \
+            --alluredir=allure-results \
+            --ignore=tests/tsc/test_99_cleanup.py \
+            || echo "TESTS_FAILED=true" >> $GITHUB_ENV
+        continue-on-error: true
+
+      - name: Run Cleanup (always)
+        if: always()
+        env:
+          BASE_URL: https://api.missingtable.com
+          TSC_PREFIX: tsc_ci_
+          TSC_EXISTING_ADMIN_USERNAME: ${{ secrets.TSC_ADMIN_USERNAME }}
+          TSC_EXISTING_ADMIN_PASSWORD: ${{ secrets.TSC_ADMIN_PASSWORD }}
+        run: |
+          cd backend
+          uv run pytest tests/tsc/test_99_cleanup.py -v --alluredir=allure-results
+
+      - name: Generate Allure Report
+        if: always()
+        run: |
+          cd backend
+          allure generate allure-results -o allure-report --clean
+
+      - name: Add dashboard navigation to report
+        if: always()
+        run: |
+          BANNER='<div style="background:#2563eb;color:white;padding:8px 16px;font-family:-apple-system,BlinkMacSystemFont,sans-serif;font-size:14px;position:fixed;top:0;left:0;right:0;z-index:9999;display:flex;align-items:center;gap:8px;"><a href="https://quality.missingtable.com" style="color:white;text-decoration:none;display:flex;align-items:center;gap:8px;"><span style="font-size:18px;">←</span> Back to Quality Dashboard</a></div><div style="height:40px;"></div>'
+          sed -i "s|<body>|<body>${BANNER}|" backend/allure-report/index.html
+
+      - name: Upload to S3
+        if: always()
+        run: |
+          # Upload latest journey report
+          aws s3 sync backend/allure-report/ s3://${S3_BUCKET}/latest/missing-table/prod/journey/ \
+            --delete \
+            --cache-control "max-age=300"
+
+          # Archive run report
+          RUN_DATE=$(date -u +"%Y-%m-%d")
+          aws s3 sync backend/allure-report/ s3://${S3_BUCKET}/runs/missing-table/prod/${RUN_DATE}/${{ github.run_id }}/journey/ \
+            --cache-control "max-age=31536000"
+
+      - name: Invalidate CloudFront
+        if: always()
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} \
+            --paths "/latest/missing-table/prod/journey/*"
+
+      - name: Summary
+        if: always()
+        run: |
+          # Extract test stats from Allure summary
+          PASSED=$(python3 -c "import json; print(json.load(open('backend/allure-report/widgets/summary.json'))['statistic']['passed'])" 2>/dev/null || echo "N/A")
+          TOTAL=$(python3 -c "import json; print(json.load(open('backend/allure-report/widgets/summary.json'))['statistic']['total'])" 2>/dev/null || echo "N/A")
+
+          echo "### User Journey Tests Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** production (api.missingtable.com)" >> $GITHUB_STEP_SUMMARY
+          echo "**Test Prefix:** tsc_ci_" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Results:** ${PASSED}/${TOTAL} tests passed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Reports:**" >> $GITHUB_STEP_SUMMARY
+          echo "- [User Journey Report](https://quality.missingtable.com/latest/missing-table/prod/journey/)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Quality Dashboard](https://quality.missingtable.com)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail if tests failed
+        if: env.TESTS_FAILED == 'true'
+        run: exit 1

--- a/backend/api_client/client.py
+++ b/backend/api_client/client.py
@@ -498,6 +498,11 @@ class MissingTableClient:
         response = self._request("PUT", "/api/auth/users/role", json_data=role_update.model_dump(exclude_none=True))
         return response.json()
 
+    def delete_user(self, user_id: str) -> dict[str, Any]:
+        """Delete a user by ID (admin only)."""
+        response = self._request("DELETE", f"/api/auth/users/{user_id}")
+        return response.json()
+
     # Utility endpoints
 
     def health_check(self) -> dict[str, Any]:

--- a/backend/tests/fixtures/tsc/client.py
+++ b/backend/tests/fixtures/tsc/client.py
@@ -666,3 +666,13 @@ class TSCClient:
     def delete_league(self, league_id: int) -> dict[str, Any]:
         """Delete a league."""
         return self._client.delete_league(league_id)
+
+    # User management (admin only)
+
+    def get_users(self) -> list[dict[str, Any]]:
+        """Get all users (admin only)."""
+        return self._client.get_users()
+
+    def delete_user(self, user_id: str) -> dict[str, Any]:
+        """Delete a user (admin only)."""
+        return self._client.delete_user(user_id)

--- a/backend/tests/fixtures/tsc/config.py
+++ b/backend/tests/fixtures/tsc/config.py
@@ -126,3 +126,7 @@ PYTEST_CONFIG = TSCConfig(prefix="tsc_a_")
 
 # Configuration for Bruno (tsc_b_ prefix)
 BRUNO_CONFIG = TSCConfig(prefix="tsc_b_")
+
+# Configuration for CI/Production tests (tsc_ci_ prefix)
+# Used by GitHub Actions workflow to run against production
+CI_CONFIG = TSCConfig(prefix="tsc_ci_")

--- a/backend/tests/tsc/conftest.py
+++ b/backend/tests/tsc/conftest.py
@@ -86,10 +86,13 @@ def tsc_config() -> TSCConfig:
     """
     TSC configuration fixture.
 
-    Returns configuration with tsc_a_ prefix for pytest.
-    BASE_URL can be set via environment variable.
+    Returns configuration with configurable prefix (default: tsc_a_).
+    Environment variables:
+    - TSC_PREFIX: Override the test data prefix (e.g., tsc_ci_ for CI)
+    - BASE_URL: Override the API base URL
     """
-    return TSCConfig(prefix="tsc_a_")
+    prefix = os.getenv("TSC_PREFIX", "tsc_a_")
+    return TSCConfig(prefix=prefix)
 
 
 @pytest.fixture(scope="module")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -92,6 +92,32 @@ wheels = [
 ]
 
 [[package]]
+name = "allure-pytest"
+version = "2.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "allure-python-commons" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/55/b73c5256d36c4c843a475762eebc90b104527766d4c7e4c4b4d9ed94f118/allure_pytest-2.15.3.tar.gz", hash = "sha256:b6576f8258de44f48ec59cfaee73cdbd1142c2ad6cfdc82d894fd1db8abf22e9", size = 17685, upload-time = "2025-12-30T05:21:55.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/1c/a50b21ce93ee95fa198683e09cb709d05079a5b2970cb304f2a5a1986afb/allure_pytest-2.15.3-py3-none-any.whl", hash = "sha256:66711efdc44c7c0d629f4eeab73ca20932f8786c251d61e242449f7b4ec18ca2", size = 12451, upload-time = "2025-12-30T05:21:54.776Z" },
+]
+
+[[package]]
+name = "allure-python-commons"
+version = "2.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/93/609cf76e204567cb618b59208f34468bbd434f34fcdce3d193d8f927abcd/allure_python_commons-2.15.3.tar.gz", hash = "sha256:b42a96d6076fb323c9e43645dfb84c0574f6bad0a0e005d92564015cd172d564", size = 15208, upload-time = "2025-12-30T05:21:46.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/2e/a823ab87aa8ed064d7efc817d79eb5f013465514f8d74487f1519849049f/allure_python_commons-2.15.3-py3-none-any.whl", hash = "sha256:50e9b346d8a060c84af8d19f221bd9da6e1aa0002a4e7f770e151167365219d0", size = 16212, upload-time = "2025-12-30T05:21:45.861Z" },
+]
+
+[[package]]
 name = "amqp"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2021,6 +2047,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "allure-pytest" },
     { name = "bandit" },
     { name = "coverage" },
     { name = "datamodel-code-generator" },
@@ -2104,6 +2131,7 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "allure-pytest", specifier = ">=2.13.0" },
     { name = "bandit", specifier = ">=1.8.0" },
     { name = "coverage", specifier = ">=7.6.4" },
     { name = "datamodel-code-generator", specifier = ">=0.25.0" },


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow to run TSC user journey tests against production
- Adds user deletion API endpoint for automated cleanup
- Adds CI-specific test prefix (`tsc_ci_`) to avoid conflicts with local testing
- Updates dashboard generator to support journey test reports

## How It Works

1. **Manual dispatch** - Trigger from Actions tab → "User Journey Tests"
2. **Runs against production** - Uses `api.missingtable.com` with `tsc_ci_` prefix
3. **Full cleanup** - Always runs (even on failure) to delete all test data
4. **Reports** - Uploads Allure report to `quality.missingtable.com/latest/missing-table/prod/journey/`

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/quality-journey.yml` | New workflow for journey tests |
| `backend/app.py` | Add `DELETE /api/auth/users/{user_id}` endpoint |
| `backend/api_client/client.py` | Add `delete_user()` method |
| `backend/tests/fixtures/tsc/client.py` | Add `get_users()` and `delete_user()` |
| `backend/tests/fixtures/tsc/config.py` | Add `CI_CONFIG` with `tsc_ci_` prefix |
| `backend/tests/tsc/conftest.py` | Add `TSC_PREFIX` env var support |
| `backend/tests/tsc/test_99_cleanup.py` | Add user cleanup step |
| `scripts/generate-quality-dashboard.py` | Add `--journey-allure-dir` argument |

## Test Plan

- [ ] Merge PR
- [ ] Manually trigger "User Journey Tests" workflow
- [ ] Verify tests run and cleanup completes
- [ ] Check report at https://quality.missingtable.com/latest/missing-table/prod/journey/

🤖 Generated with [Claude Code](https://claude.com/claude-code)