### PR TITLE
feat: Migrate quality workflows to GitHub-hosted runners with OIDC

### DIFF
--- a/.github/workflows/quality-journey.yml
+++ b/.github/workflows/quality-journey.yml
@@ -16,15 +16,30 @@ env:
   S3_BUCKET: 'quality-missingtable-com'
   CLOUDFRONT_DISTRIBUTION_ID: 'E15AUGI7OKJ99L'
 
+permissions:
+  id-token: write   # Required for OIDC
+  contents: read
+
 jobs:
   journey-tests:
     name: Run User Journey Tests
-    runs-on: [self-hosted, quality-runner]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-quality
+          aws-region: us-east-1
+
+      - name: Install Allure CLI
+        run: |
+          curl -fsSL https://github.com/allure-framework/allure2/releases/download/2.30.0/allure-2.30.0.tgz | tar -xz
+          echo "$PWD/allure-2.30.0/bin" >> $GITHUB_PATH
 
       - name: Extract build info
         id: build-info
@@ -42,11 +57,20 @@ jobs:
         run: |
           allure --version
 
-      - name: Setup Python with uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
         run: |
           cd backend
-          uv python install 3.13
-          uv sync --python 3.13
+          uv sync
 
       - name: Run TSC Journey Tests
         id: journey-tests

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,14 +19,29 @@ env:
   S3_BUCKET: 'quality-missingtable-com'
   CLOUDFRONT_DISTRIBUTION_ID: 'E15AUGI7OKJ99L'
 
+permissions:
+  id-token: write   # Required for OIDC
+  contents: read
+
 jobs:
   publish-quality:
     name: Run Tests & Publish
-    runs-on: [self-hosted, quality-runner]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-quality
+          aws-region: us-east-1
+
+      - name: Install Allure CLI
+        run: |
+          curl -fsSL https://github.com/allure-framework/allure2/releases/download/2.30.0/allure-2.30.0.tgz | tar -xz
+          echo "$PWD/allure-2.30.0/bin" >> $GITHUB_PATH
 
       - name: Extract build info
         id: build-info
@@ -44,11 +59,20 @@ jobs:
         run: |
           allure --version
 
-      - name: Setup Python with uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
         run: |
           cd backend
-          uv python install 3.13
-          uv sync --python 3.13
+          uv sync
 
       - name: Run backend unit tests with coverage and Allure
         id: backend-tests
@@ -68,6 +92,13 @@ jobs:
         run: |
           cd backend
           allure generate allure-results -o allure-report --clean
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Run frontend unit tests with coverage
         id: frontend-tests


### PR DESCRIPTION
## Summary

- Replace self-hosted EC2 runners (`quality-runner`) with GitHub-hosted `ubuntu-latest`
- Add AWS OIDC authentication instead of long-lived credentials
- Install Allure CLI dynamically (was pre-installed on EC2)
- Use proper GitHub Actions for Python/Node.js/uv setup

## Why

The EC2 runner was an Ansible learning project but running an EC2 instance 24/7 for occasional CI runs is wasteful. GitHub-hosted runners are:
- ✅ Always available
- ✅ No infrastructure to manage
- ✅ Free for public repos (2,000 minutes/month for private)

## AWS Setup Required

Before merging, set up OIDC in AWS:

### 1. Create OIDC Identity Provider
```bash
aws iam create-open-id-connect-provider \
  --url https://token.actions.githubusercontent.com \
  --client-id-list sts.amazonaws.com \
  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
```

### 2. Create IAM Role with Trust Policy
Create role `github-actions-quality` with this trust policy:
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::YOUR_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
        },
        "StringLike": {
          "token.actions.githubusercontent.com:sub": "repo:silverbeer/missing-table:*"
        }
      }
    }
  ]
}
```

### 3. Attach Permissions Policy
The role needs permissions for:
- `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` on `quality-missingtable-com` bucket
- `cloudfront:CreateInvalidation` on distribution `E15AUGI7OKJ99L`

### 4. Add GitHub Secret
Add `AWS_ACCOUNT_ID` secret to the repository with your AWS account ID.

## Test plan

- [ ] Set up AWS OIDC provider and IAM role
- [ ] Add `AWS_ACCOUNT_ID` secret to GitHub
- [ ] Manually trigger `quality.yml` workflow and verify it runs on GitHub-hosted runner
- [ ] Verify reports are uploaded to S3 and CloudFront is invalidated
- [ ] Manually trigger `quality-journey.yml` and verify same

🤖 Generated with [Claude Code](https://claude.com/claude-code)