### PR TITLE
fix: Invalidate player cache after user deletion

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1705,6 +1705,11 @@ async def delete_user(
         # Explicitly delete from user_profiles (no FK cascade exists)
         auth_service_client.table("user_profiles").delete().eq("id", user_id).execute()
 
+        # Invalidate cached user list so subsequent queries reflect the deletion
+        from dao.base_dao import clear_cache
+
+        clear_cache("mt:dao:players:*")
+
         logger.info(f"User {user_id} deleted by admin {current_user.get('user_id')}")
         return {"message": "User deleted successfully"}
 


### PR DESCRIPTION
## Summary

- Invalidate Redis `mt:dao:players:*` cache after deleting a user in the `delete_user` endpoint
- The `get_all_user_profiles()` DAO method uses `@dao_cache("players:all")`, so without cache invalidation, `GET /api/auth/users` returns stale data after a DELETE

## Problem

The TSC cleanup step (`test_08b`) successfully deleted all 6 `tsc_ci_*` users (HTTP 200 from each DELETE), but `test_09_verify_cleanup` immediately re-queried users and found all 6 still present — because the GET endpoint served cached results from Redis.

## Test plan

- [x] `cd backend && uv run ruff check app.py` — no new lint issues
- [ ] Re-run TSC journey tests in GHA after deploy — cleanup verification should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)