### PR TITLE
fix: Fix deployment verification polling wrong JSON field

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -348,13 +348,13 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-quality
           aws-region: us-east-1
 
-      - name: Wait for deployment
+      - name: Verify deployment is live
         run: |
-          echo "Waiting for deployment of commit ${{ github.event.workflow_run.head_sha }}"
+          echo "Polling /api/version until deployed commit matches ${{ github.event.workflow_run.head_sha }}"
           EXPECTED_SHA="${{ github.event.workflow_run.head_sha }}"
 
           for i in {1..30}; do
-            DEPLOYED_SHA=$(curl -s https://api.missingtable.com/api/version | jq -r '.commitSha' 2>/dev/null || echo "")
+            DEPLOYED_SHA=$(curl -s https://api.missingtable.com/api/version | jq -r '.commit_sha' 2>/dev/null || echo "")
 
             if [ "$DEPLOYED_SHA" = "$EXPECTED_SHA" ]; then
               echo "✅ Deployment confirmed: $DEPLOYED_SHA"


### PR DESCRIPTION
## Summary

- **Fix jq field name**: `/api/version` returns `commit_sha` (snake_case) but the workflow was reading `.commitSha` (camelCase), so the poll always returned `null` and timed out
- **Rename step** from "Wait for deployment" to "Verify deployment is live" to clarify it's polling, not deploying

## Root Cause

```bash
# What the workflow did:
curl -s https://api.missingtable.com/api/version | jq -r '.commitSha'
# → null

# What it should do:
curl -s https://api.missingtable.com/api/version | jq -r '.commit_sha'
# → 407eeac6d28fef34dc7a27d9faa3465aa07eb30c
```

## Test plan

- [ ] Merge and observe next CI → quality workflow_run: deployment verification step should detect the deployed commit SHA and exit early instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)