### PR TITLE
feat: Add dedicated Contract Tests workflow

### DIFF
--- a/.github/workflows/quality-contract.yml
+++ b/.github/workflows/quality-contract.yml
@@ -1,0 +1,156 @@
+name: Contract Tests
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: '3.13'
+  S3_BUCKET: 'quality-missingtable-com'
+  CLOUDFRONT_DISTRIBUTION_ID: 'E15AUGI7OKJ99L'
+
+permissions:
+  id-token: write   # Required for OIDC
+  contents: read
+
+jobs:
+  contract-tests:
+    name: Contract Tests (Post-Deployment)
+    runs-on: ubuntu-latest
+    # Only run when CI workflow completes successfully (skip on failure)
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-quality
+          aws-region: us-east-1
+
+      - name: Verify deployment is live
+        if: github.event_name == 'workflow_run'
+        run: |
+          echo "Polling /api/version until deployed commit matches ${{ github.event.workflow_run.head_sha }}"
+          EXPECTED_SHA="${{ github.event.workflow_run.head_sha }}"
+
+          for i in {1..30}; do
+            DEPLOYED_SHA=$(curl -s https://api.missingtable.com/api/version | jq -r '.commit_sha' 2>/dev/null || echo "")
+
+            if [ "$DEPLOYED_SHA" = "$EXPECTED_SHA" ]; then
+              echo "✅ Deployment confirmed: $DEPLOYED_SHA"
+              exit 0
+            fi
+
+            echo "Waiting... (attempt $i/30, expected: ${EXPECTED_SHA:0:7}, current: ${DEPLOYED_SHA:0:7})"
+            sleep 10
+          done
+
+          echo "⚠️ Deployment not detected within 5 minutes"
+          echo "Expected: $EXPECTED_SHA"
+          echo "Current: $DEPLOYED_SHA"
+          echo "Proceeding with contract tests anyway..."
+
+      - name: Install Allure CLI
+        run: |
+          curl -fsSL https://github.com/allure-framework/allure2/releases/download/2.30.0/allure-2.30.0.tgz | tar -xz
+          echo "$PWD/allure-2.30.0/bin" >> $GITHUB_PATH
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          cd backend
+          uv sync
+
+      - name: Run contract tests against production
+        id: contract-tests
+        env:
+          API_BASE_URL: https://api.missingtable.com
+          ADMIN_TEST_USERNAME: ${{ secrets.TSC_ADMIN_USERNAME }}
+          ADMIN_TEST_PASSWORD: ${{ secrets.TSC_ADMIN_PASSWORD }}
+        run: |
+          cd backend
+          mkdir -p contract-allure-results
+          uv run pytest tests/contract/ -m contract \
+            --no-cov \
+            --alluredir=contract-allure-results \
+            -v
+        continue-on-error: true
+
+      - name: Generate contract Allure report
+        run: |
+          cd backend
+          allure generate contract-allure-results -o contract-allure-report --clean
+
+      - name: Extract build info
+        id: build-info
+        run: |
+          APP_VERSION=$(cat VERSION 2>/dev/null || echo "0.0.0")
+          VERSION="${APP_VERSION}.${{ github.run_number }}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "branch=main" >> $GITHUB_OUTPUT
+
+      - name: Add dashboard navigation to report
+        env:
+          BUILD_VERSION: ${{ steps.build-info.outputs.version }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          COMMIT_SHORT="${COMMIT_SHA:0:7}"
+          BANNER="<div style=\"background:#2563eb;color:white;padding:8px 16px;font-family:-apple-system,BlinkMacSystemFont,sans-serif;font-size:14px;position:fixed;top:0;left:0;right:0;z-index:9999;display:flex;align-items:center;justify-content:space-between;\"><a href=\"https://quality.missingtable.com\" style=\"color:white;text-decoration:none;display:flex;align-items:center;gap:8px;\"><span style=\"font-size:18px;\">←</span> Back to Quality Dashboard</a><span style=\"opacity:0.9;\">Build ${BUILD_VERSION} · main · ${COMMIT_SHORT} (post-deploy)</span></div><div style=\"height:40px;\"></div>"
+          sed -i "s|<body>|<body>${BANNER}|" backend/contract-allure-report/index.html
+
+      - name: Upload contract report to S3
+        run: |
+          # Upload latest contract report
+          aws s3 sync backend/contract-allure-report/ s3://${S3_BUCKET}/latest/missing-table/prod/contract/ \
+            --delete \
+            --cache-control "max-age=300"
+
+          # Archive contract report
+          RUN_DATE=$(date -u +"%Y-%m-%d")
+          aws s3 sync backend/contract-allure-report/ s3://${S3_BUCKET}/runs/missing-table/prod/${RUN_DATE}/${{ github.run_id }}/contract/ \
+            --cache-control "max-age=31536000"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} \
+            --paths "/latest/missing-table/prod/contract/*"
+
+      - name: Summary
+        run: |
+          CT_PASSED=$(python3 -c "import json; print(json.load(open('backend/contract-allure-report/widgets/summary.json'))['statistic']['passed'])" 2>/dev/null || echo "N/A")
+          CT_TOTAL=$(python3 -c "import json; print(json.load(open('backend/contract-allure-report/widgets/summary.json'))['statistic']['total'])" 2>/dev/null || echo "N/A")
+
+          echo "### Contract Tests (Post-Deployment)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Triggered by:** CI workflow on main branch" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${{ github.event.workflow_run.head_sha || github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Test Suite | Tests |" >> $GITHUB_STEP_SUMMARY
+          echo "|------------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Contract | ${CT_PASSED}/${CT_TOTAL} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View Contract Report](https://quality.missingtable.com/latest/missing-table/prod/contract/)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Check contract test results
+        if: steps.contract-tests.outcome == 'failure'
+        run: |
+          echo "⚠️ Contract tests failed - check report for details"
+          exit 1


### PR DESCRIPTION
## Summary

- **Split contract tests** from `quality.yml` into a new `quality-contract.yml` workflow so each has a distinct name in the Actions UI

## Before (confusing)

The Actions list showed "Publish Quality Reports" twice per push to main — once for coverage (push trigger), once for contract tests (workflow_run trigger) — with different jobs skipped in each run.

## After (clear)

| Workflow | Trigger | Purpose |
|----------|---------|---------|
| **Publish Quality Reports** | Push (any branch) | Unit tests with coverage + Allure, publish to dashboard |
| **Contract Tests** | workflow_run (after CI on main) + manual | Post-deployment contract tests against production |

## Test plan

- [ ] Push to feature branch: "Publish Quality Reports" runs; "Contract Tests" does not
- [ ] Merge to main: "Publish Quality Reports" runs; after CI completes, "Contract Tests" triggers and verifies deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)