### PR TITLE
fix: Allow user profiles to have both team_id and club_id

### DIFF
--- a/backend/scripts/manage_users.py
+++ b/backend/scripts/manage_users.py
@@ -459,7 +459,7 @@ def update_user_team(supabase, identifier, team_id):
             user_id = profile_response.data[0]["id"]
 
         # Get team info to verify it exists
-        team_response = supabase.table("teams").select("id, name, city").eq("id", team_id).execute()
+        team_response = supabase.table("teams").select("id, name, city, club_id").eq("id", team_id).execute()
 
         if not team_response.data:
             console.print(f"[red]❌ Team ID {team_id} not found[/red]")
@@ -475,8 +475,9 @@ def update_user_team(supabase, identifier, team_id):
         )
         current_profile = profile_response.data[0] if profile_response.data else {}
 
-        # Update team_id in user_profiles
-        update_response = supabase.table("user_profiles").update({"team_id": team_id}).eq("id", user_id).execute()
+        # Update team_id and club_id (derived from team's parent club) in user_profiles
+        update_data = {"team_id": team_id, "club_id": team_info.get("club_id")}
+        update_response = supabase.table("user_profiles").update(update_data).eq("id", user_id).execute()
 
         if update_response.data:
             console.print("\n[bold green]✅ Team assignment updated successfully![/bold green]")

--- a/supabase/migrations/20260130000000_allow_team_and_club_together.sql
+++ b/supabase/migrations/20260130000000_allow_team_and_club_together.sql
@@ -1,0 +1,24 @@
+-- Allow user_profiles to have both team_id and club_id
+--
+-- The old constraint (chk_team_or_club_not_both) enforced that a user could have
+-- either team_id OR club_id, but not both. This is incorrect: players belong to
+-- teams, and teams belong to clubs. Both should be set when the team has a parent club.
+
+-- Drop the overly restrictive constraint
+ALTER TABLE user_profiles
+DROP CONSTRAINT IF EXISTS chk_team_or_club_not_both;
+
+-- Backfill club_id for users who have a team_id but no club_id
+-- Derives the club from the team's parent club
+UPDATE user_profiles up
+SET club_id = t.club_id
+FROM teams t
+WHERE t.id = up.team_id
+  AND up.club_id IS NULL
+  AND t.club_id IS NOT NULL;
+
+-- Update column comment to reflect new behavior
+COMMENT ON COLUMN user_profiles.club_id IS 'Club ID derived from the user''s team, or set directly for club-level roles. Users with a team_id will typically also have club_id set to the team''s parent club.';
+
+-- Update schema version
+SELECT add_schema_version('1.6.0', 'allow_team_and_club_together', 'Drop chk_team_or_club_not_both constraint; backfill club_id from team parent club');


### PR DESCRIPTION
## Summary
- Drop the `chk_team_or_club_not_both` constraint which incorrectly prevented users from having both `team_id` and `club_id`. Players belong to teams, and teams belong to clubs — both should be stored on the profile.
- Migration backfills `club_id` for all existing users who have a `team_id` but NULL `club_id` (derived from `teams.club_id`)
- Update invite service to derive `club_id` from team's parent club for team-level invites
- Update `manage_users.py` team assignment to also set `club_id`

## Context
User gabe35 (team-player on IFA Homegrown U14) was seeing TSC League 1 on the Table tab and all clubs in the My Club dropdown because their `club_id` was NULL. The old constraint prevented setting both `team_id` and `club_id`.

## Test plan
- [ ] Run migration on dev database
- [ ] Verify gabe35 now has `club_id` set: `SELECT username, team_id, club_id FROM user_profiles WHERE username = 'gabe35'`
- [ ] Verify all team-players have club_id backfilled: `SELECT username, team_id, club_id FROM user_profiles WHERE role = 'team-player'`
- [ ] Create a new team-level invite and verify the invitation record includes `club_id`
- [ ] Sign up via invite and verify the new user profile has both `team_id` and `club_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)