### PR TITLE
feat: Add sport_type to leagues and fix Last 5 Matches order

### DIFF
--- a/backend/dao/team_dao.py
+++ b/backend/dao/team_dao.py
@@ -33,7 +33,8 @@ class TeamDAO(BaseDAO):
             *,
             leagues!teams_league_id_fkey (
                 id,
-                name
+                name,
+                sport_type
             ),
             team_mappings (
                 age_groups (
@@ -46,7 +47,8 @@ class TeamDAO(BaseDAO):
                     league_id,
                     leagues!divisions_league_id_fkey (
                         id,
-                        name
+                        name,
+                        sport_type
                     )
                 )
             )
@@ -71,9 +73,10 @@ class TeamDAO(BaseDAO):
                         age_groups.append(age_group)
                         if tag.get("divisions"):
                             division = tag["divisions"]
-                            # Add league_name to division for easy access in frontend
+                            # Add league_name and sport_type to division for easy access in frontend
                             if division.get("leagues"):
                                 division["league_name"] = division["leagues"]["name"]
+                                division["sport_type"] = division["leagues"].get("sport_type", "soccer")
                             divisions_by_age_group[age_group["id"]] = division
             team["age_groups"] = age_groups
             team["divisions_by_age_group"] = divisions_by_age_group

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -277,7 +277,7 @@
           </div>
         </div>
 
-        <!-- Display Filtered Matchs -->
+        <!-- Display Filtered Matches -->
         <div v-if="sortedGames.length > 0">
           <div class="mb-4">
             <!-- All Matches: Show week range -->
@@ -290,7 +290,7 @@
             <!-- My Club: Show team name and league info -->
             <div v-else>
               <h3 class="text-lg font-semibold mb-2">
-                Matchs for {{ getSelectedTeamName() }}
+                Matches for {{ getSelectedTeamName() }}
               </h3>
 
               <!-- League Information -->
@@ -337,9 +337,12 @@
 
             <!-- Season Segments - Stack on mobile -->
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-              <!-- Fall Segment - Only show if Fall matches exist -->
+              <!-- Fall Segment - Only show if Fall matches exist and not a Futsal league -->
               <div
-                v-if="seasonStats.hasFallGames"
+                v-if="
+                  seasonStats.hasFallGames &&
+                  selectedTeamLeagueInfo?.sportType !== 'futsal'
+                "
                 class="p-4 bg-blue-50 rounded-lg border border-blue-100"
               >
                 <h4 class="font-medium text-blue-700 mb-2">Fall Segment</h4>
@@ -359,9 +362,12 @@
                 </div>
               </div>
 
-              <!-- Spring Segment - Only show if Spring matches exist -->
+              <!-- Spring Segment - Only show if Spring matches exist and not a Futsal league -->
               <div
-                v-if="seasonStats.hasSpringGames"
+                v-if="
+                  seasonStats.hasSpringGames &&
+                  selectedTeamLeagueInfo?.sportType !== 'futsal'
+                "
                 class="p-4 bg-green-50 rounded-lg border border-green-100"
               >
                 <h4 class="font-medium text-green-700 mb-2">Spring Segment</h4>
@@ -381,12 +387,12 @@
                 </div>
               </div>
 
-              <!-- Last 5 Matchs - Only show if matches exist -->
+              <!-- Last 5 Matches - Only show if matches exist -->
               <div
                 v-if="seasonStats.matchesPlayed > 0"
                 class="p-4 bg-purple-50 rounded-lg border border-purple-100"
               >
-                <h4 class="font-medium text-purple-700 mb-2">Last 5 Matchs</h4>
+                <h4 class="font-medium text-purple-700 mb-2">Last 5 Matches</h4>
                 <div class="flex space-x-2 justify-center sm:justify-start">
                   <template v-if="seasonStats.lastFive.length > 0">
                     <span
@@ -1896,6 +1902,7 @@ export default {
           ageGroup: ageGroup.name,
           division: division.name,
           league: division.league_name || 'Unknown League',
+          sportType: division.sport_type || 'soccer',
         };
       }
 
@@ -2100,8 +2107,8 @@ export default {
         }
       });
 
-      // Take the last 5 matches and reverse to show most recent first
-      stats.lastFive = allResults.slice(-5).reverse();
+      // Take the last 5 matches in chronological order (oldest → newest, left → right)
+      stats.lastFive = allResults.slice(-5);
 
       // Calculate final stats
       stats.goalDifference = stats.goalsFor - stats.goalsAgainst;

--- a/supabase-local/migrations/00000000000000_schema.sql
+++ b/supabase-local/migrations/00000000000000_schema.sql
@@ -741,6 +741,7 @@ CREATE TABLE public.leagues (
     name character varying(100) NOT NULL,
     description text,
     is_active boolean DEFAULT true,
+    sport_type character varying(20) DEFAULT 'soccer' NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );

--- a/supabase-local/migrations/20260201000000_add_sport_type_to_leagues.sql
+++ b/supabase-local/migrations/20260201000000_add_sport_type_to_leagues.sql
@@ -1,0 +1,9 @@
+-- Add sport_type column to leagues table
+-- Allows distinguishing between soccer and futsal leagues
+-- so the UI can adapt (e.g., hide Fall/Spring segments for futsal)
+
+ALTER TABLE public.leagues
+ADD COLUMN IF NOT EXISTS sport_type character varying(20) DEFAULT 'soccer' NOT NULL;
+
+-- Mark existing futsal leagues
+UPDATE public.leagues SET sport_type = 'futsal' WHERE LOWER(name) LIKE '%futsal%';


### PR DESCRIPTION
## Summary
- Add `sport_type` column to leagues table to distinguish soccer vs futsal
- Hide Fall/Spring segment cards for Futsal leagues (winter sport, segments don't apply)
- Fix Last 5 Matches display to show chronological order (oldest→newest, left to right)
- Fix "Matchs" typo → "Matches" in multiple places

## Changes
- **Migration**: New `20260201000000_add_sport_type_to_leagues.sql` adds `sport_type VARCHAR(20)` column
- **Backend**: `team_dao.py` now includes `sport_type` in league queries and enriches division objects
- **Frontend**: `MatchesView.vue` conditionally hides Fall/Spring segments for futsal, fixes Last 5 order
- **Scripts**: `setup-local-db.sh` now flushes Redis cache and sets `sport_type='futsal'` after restore

## Test plan
- [ ] Login and navigate to Matches → My Club
- [ ] Select a Futsal team (e.g., IFA Elite Futsal 2012 White) — verify no Fall/Spring segments shown
- [ ] Select a non-Futsal team (e.g., IFA Homegrown) — verify Fall/Spring segments still shown
- [ ] Verify Last 5 Matches shows chronological order (oldest on left, newest on right)
- [ ] Verify "Matches" spelling is correct throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)