### PR TITLE
feat: Add --from-prod database refresh workflow

### DIFF
--- a/.claude/memory/docker-platform-requirements.md
+++ b/.claude/memory/docker-platform-requirements.md
@@ -13,9 +13,9 @@ This causes the error: `no match for platform in manifest: not found`
 
 ```bash
 # For cloud deployment (GKE) - REQUIRED
-./build-and-push.sh backend dev      # Dev environment (AMD64, push)
+./build-and-push.sh backend prod     # Prod environment (AMD64, push)
 ./build-and-push.sh frontend prod    # Prod environment (AMD64, push)
-./build-and-push.sh all dev          # All services (AMD64, push)
+./build-and-push.sh all prod         # All services (AMD64, push)
 
 # For local development only
 ./build-and-push.sh backend local    # Current platform, no push
@@ -23,7 +23,7 @@ This causes the error: `no match for platform in manifest: not found`
 
 ## What the Script Does
 
-1. **Cloud builds (dev/prod)**:
+1. **Cloud builds (prod)**:
    - Builds for `linux/amd64` platform (GKE requirement)
    - Pushes to Artifact Registry
    - Uses `docker buildx build --platform linux/amd64`
@@ -52,16 +52,16 @@ docker buildx build --platform linux/amd64 \
 
 ```bash
 # 1. Restart deployment to pull new image
-kubectl rollout restart deployment/missing-table-backend -n missing-table-dev
+kubectl rollout restart deployment/missing-table-backend -n missing-table-prod
 
 # 2. Wait for rollout to complete
-kubectl rollout status deployment/missing-table-backend -n missing-table-dev --timeout=180s
+kubectl rollout status deployment/missing-table-backend -n missing-table-prod --timeout=180s
 
 # 3. Check pod status
-kubectl get pods -n missing-table-dev -l app.kubernetes.io/component=backend
+kubectl get pods -n missing-table-prod -l app.kubernetes.io/component=backend
 
 # 4. View logs
-kubectl logs -f -l app.kubernetes.io/component=backend -n missing-table-dev
+kubectl logs -f -l app.kubernetes.io/component=backend -n missing-table-prod
 ```
 
 ## Environment-Specific Registries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,8 @@ New schema changes go in additional timestamped migration files (e.g., `20260201
 ```bash
 # Full local DB setup from scratch (schema + seed + test users)
 ./scripts/setup-local-db.sh              # Without match data
-./scripts/setup-local-db.sh --restore    # With match data from backup
+./scripts/setup-local-db.sh --restore    # With match data from existing backup
+./scripts/setup-local-db.sh --from-prod  # Backup from prod first, then restore locally (RECOMMENDED)
 
 # Local Supabase
 cd supabase-local && npx supabase start|stop|status

--- a/backend/TESTING_GUIDE.md
+++ b/backend/TESTING_GUIDE.md
@@ -212,8 +212,8 @@ curl http://localhost:8000/health
 # Local Supabase
 npx supabase start
 
-# Or switch to dev environment
-./switch-env.sh dev
+# Or switch to prod environment
+./switch-env.sh prod
 ```
 
 ### "Test collection errors"

--- a/backend/docs/SUPABASE_SETUP.md
+++ b/backend/docs/SUPABASE_SETUP.md
@@ -28,7 +28,7 @@ Update your `.env` file with the actual values:
 SUPABASE_URL=https://your-actual-project-id.supabase.co
 SUPABASE_ANON_KEY=your-actual-anon-key
 SUPABASE_SERVICE_KEY=your-actual-service-role-key
-ENVIRONMENT=development
+ENVIRONMENT=local
 ```
 
 ## 4. Create Database Schema

--- a/backend/endpoints/version.py
+++ b/backend/endpoints/version.py
@@ -32,7 +32,7 @@ async def get_version():
     Environment Variables:
         - APP_VERSION: Semantic version (e.g., "1.0.0")
         - BUILD_ID: CI/CD build/workflow run ID
-        - ENVIRONMENT: Environment name (local, dev, production)
+        - ENVIRONMENT: Environment name (local, prod)
         - COMMIT_SHA: Git commit SHA
         - BUILD_DATE: ISO format build timestamp
     """

--- a/backend/queue_cli/core/config.py
+++ b/backend/queue_cli/core/config.py
@@ -24,7 +24,7 @@ class QueueConfig:
         Load configuration from environment variables.
 
         Args:
-            env: Environment name (local, dev, prod). Defaults to current environment.
+            env: Environment name (local, prod). Defaults to current environment.
 
         Returns:
             QueueConfig instance

--- a/backend/scripts/analyze_multi_league_clubs.py
+++ b/backend/scripts/analyze_multi_league_clubs.py
@@ -7,7 +7,7 @@ This helps determine which teams need to be split into parent club + child teams
 
 Usage:
     APP_ENV=local python scripts/analyze_multi_league_clubs.py
-    APP_ENV=dev python scripts/analyze_multi_league_clubs.py
+    APP_ENV=prod python scripts/analyze_multi_league_clubs.py
     python scripts/analyze_multi_league_clubs.py --env local --output report.json
 """
 

--- a/backend/scripts/audit_schema_versions.py
+++ b/backend/scripts/audit_schema_versions.py
@@ -2,12 +2,12 @@
 """
 Schema Version Audit Script
 
-Checks schema versions and migration status across all environments (local, dev, prod).
+Checks schema versions and migration status across all environments (local, prod).
 Identifies schema drift and missing migrations.
 
 Usage:
     APP_ENV=local python scripts/audit_schema_versions.py
-    APP_ENV=dev python scripts/audit_schema_versions.py
+    APP_ENV=prod python scripts/audit_schema_versions.py
     APP_ENV=prod python scripts/audit_schema_versions.py
 
 Or run for all environments:
@@ -160,13 +160,13 @@ def check_schema_version(client, env: str) -> dict:
 
 @app.command()
 def audit(
-    env: str = typer.Option(None, "--env", "-e", help="Environment to audit (local, dev, prod)"),
+    env: str = typer.Option(None, "--env", "-e", help="Environment to audit (local, prod)"),
     all_envs: bool = typer.Option(False, "--all", "-a", help="Audit all environments")
 ):
     """Audit schema versions across environments."""
 
     if all_envs:
-        environments = ["local", "dev", "prod"]
+        environments = ["local", "prod"]
     elif env:
         environments = [env]
     else:

--- a/backend/scripts/manage_users.py
+++ b/backend/scripts/manage_users.py
@@ -69,9 +69,9 @@ def validate_role(role: str) -> tuple[bool, str]:
 
 
 def load_environment():
-    """Load environment variables based on APP_ENV or default to dev."""
+    """Load environment variables based on APP_ENV or default to local."""
     load_dotenv()
-    app_env = os.getenv("APP_ENV", "dev")
+    app_env = os.getenv("APP_ENV", "local")
     env_file = f".env.{app_env}"
     if os.path.exists(env_file):
         load_dotenv(env_file, override=True)
@@ -583,7 +583,7 @@ def get_user_info(supabase, email):
 def list_command():
     """List all users in the system."""
     console.print("[bold cyan]🔐 User Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     load_environment()
     supabase = get_supabase_client()
@@ -608,7 +608,7 @@ def password_command(
 ):
     """Change a user's password."""
     console.print("[bold cyan]🔐 User Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     if not confirm and not Confirm.ask(f"⚠️  Change password for {email}?"):
         console.print("[yellow]❌ Password change cancelled[/yellow]")
@@ -645,7 +645,7 @@ def create_command(
 ):
     """Create a new user."""
     console.print("[bold cyan]🔐 User Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     # Validate role before proceeding
     is_valid, error_msg = validate_role(role)
@@ -684,7 +684,7 @@ def role_command(
 ):
     """Update a user's role (accepts username or email)."""
     console.print("[bold cyan]🔐 User Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     # Validate role before proceeding
     is_valid, error_msg = validate_role(role)
@@ -714,7 +714,7 @@ def role_command(
 def info_command(email: str = typer.Option(..., "--email", "-e", help="User email")):
     """Get detailed information about a user."""
     console.print("[bold cyan]🔐 User Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     load_environment()
     supabase = get_supabase_client()
@@ -784,7 +784,7 @@ def delete_command(
 ):
     """Delete a user by ID from both auth.users and user_profiles."""
     console.print("[bold red]🗑️  User Deletion Tool[/bold red]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     load_environment()
     supabase = get_supabase_client()
@@ -808,7 +808,7 @@ def team_command(
 ):
     """Assign a user to a team."""
     console.print("[bold cyan]👥 User Team Assignment Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     if not confirm and not Confirm.ask(f"⚠️  Assign {user} to team ID {team_id}?"):
         console.print("[yellow]❌ Team assignment cancelled[/yellow]")
@@ -832,7 +832,7 @@ def team_command(
 def teams_command():
     """List all teams in the system."""
     console.print("[bold cyan]🏆 Team Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     load_environment()
     supabase = get_supabase_client()
@@ -1149,7 +1149,7 @@ def roster_command(
 ):
     """Manage team rosters - add users to rosters, list rosters, remove players."""
     console.print("[bold cyan]⚽ Roster Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     load_environment()
     supabase = get_supabase_client()
@@ -1218,7 +1218,7 @@ def roster_command(
 def seasons_command():
     """List all seasons in the system."""
     console.print("[bold cyan]📅 Season Management Tool[/bold cyan]")
-    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'dev')}[/yellow]\n")
+    console.print(f"🌍 Environment: [yellow]{os.getenv('APP_ENV', 'local')}[/yellow]\n")
 
     load_environment()
     supabase = get_supabase_client()
@@ -1240,7 +1240,7 @@ def env_command():
     console.print("[bold cyan]🌍 Environment Configuration[/bold cyan]\n")
 
     # Get APP_ENV before loading
-    app_env = os.getenv("APP_ENV", "dev")
+    app_env = os.getenv("APP_ENV", "local")
 
     # Load environment
     load_environment()

--- a/backend/scripts/setup/populate_team_match_types.py
+++ b/backend/scripts/setup/populate_team_match_types.py
@@ -9,9 +9,9 @@ from supabase import Client, create_client
 
 
 def load_environment():
-    """Load environment variables based on APP_ENV or default to dev."""
+    """Load environment variables based on APP_ENV or default to local."""
     load_dotenv()
-    app_env = os.getenv("APP_ENV", "dev")
+    app_env = os.getenv("APP_ENV", "local")
     env_file = f".env.{app_env}"
     if os.path.exists(env_file):
         load_dotenv(env_file, override=True)

--- a/backend/scripts/sync_users_to_local.py
+++ b/backend/scripts/sync_users_to_local.py
@@ -147,14 +147,26 @@ def fetch_users_from_cloud(
     """Fetch users from cloud Supabase with optional filtering."""
     console.print("[cyan]Fetching users from cloud...[/cyan]")
 
-    response = supabase.auth.admin.list_users()
-    users_list = _get_users_list(response)
+    # Paginate through all auth users (default limit is 50)
+    users_list = []
+    page = 1
+    per_page = 100
+    while True:
+        response = supabase.auth.admin.list_users(page=page, per_page=per_page)
+        page_users = _get_users_list(response)
+        if not page_users:
+            break
+        users_list.extend(page_users)
+        console.print(f"[dim]  Fetched page {page}: {len(page_users)} users[/dim]")
+        if len(page_users) < per_page:
+            break
+        page += 1
 
     if not users_list:
         console.print("[yellow]No users found in cloud[/yellow]")
         return []
 
-    console.print(f"[dim]Found {len(users_list)} auth users[/dim]")
+    console.print(f"[dim]Found {len(users_list)} total auth users[/dim]")
 
     # Build user data with profiles
     users_data = []

--- a/backend/scripts/tsc_cleanup.py
+++ b/backend/scripts/tsc_cleanup.py
@@ -3,7 +3,7 @@
 TSC Test Data Cleanup Script
 
 Safely cleans up TSC test data by querying entities by name prefix.
-Works on any environment (local, dev, prod) without needing a registry file.
+Works on any environment (local, prod) without needing a registry file.
 
 Usage:
     # Clean up tsc_a_ data from production

--- a/backend/scripts/user-sync/README.md
+++ b/backend/scripts/user-sync/README.md
@@ -1,10 +1,10 @@
 # User Synchronization Between Environments
 
-This directory contains utilities to keep auth users synchronized between dev and production environments, ensuring test users can use the same credentials in both environments.
+This directory contains utilities to keep auth users synchronized between local and production environments, ensuring test users can use the same credentials in both environments.
 
 ## Problem
 
-Test users need to access both dev and production environments without maintaining separate credentials for each environment.
+Test users need to access both local and production environments without maintaining separate credentials for each environment.
 
 ## Solution
 
@@ -12,23 +12,23 @@ Use the `sync_users.py` script to synchronize users from one environment to anot
 
 ## Quick Start
 
-### Sync Dev Users to Production
+### Sync Local Users to Production
 
 ```bash
 # Dry run first (see what would happen)
 cd backend
-APP_ENV=dev uv run python scripts/user-sync/sync_users.py --to prod --dry-run
+APP_ENV=local uv run python scripts/user-sync/sync_users.py --to prod --dry-run
 
 # Actually sync with custom password
-APP_ENV=dev uv run python scripts/user-sync/sync_users.py --to prod --password "TestPass123!"
+APP_ENV=local uv run python scripts/user-sync/sync_users.py --to prod --password "TestPass123!"
 ```
 
-### Sync Production Users to Dev
+### Sync Production Users to Local
 
 ```bash
-# Sync prod → dev
+# Sync prod → local
 cd backend
-APP_ENV=prod uv run python scripts/user-sync/sync_users.py --to dev --password "TestPass123!"
+APP_ENV=prod uv run python scripts/user-sync/sync_users.py --to local --password "TestPass123!"
 ```
 
 ## How It Works
@@ -44,13 +44,13 @@ The script supports several password strategies:
 
 ### Option 1: Specify password via flag (Recommended)
 ```bash
-APP_ENV=dev uv run python scripts/user-sync/sync_users.py --to prod --password "TestPass123!"
+APP_ENV=local uv run python scripts/user-sync/sync_users.py --to prod --password "TestPass123!"
 ```
 
 ### Option 2: Set environment variable
 ```bash
 export SYNC_DEFAULT_PASSWORD="TestPass123!"
-APP_ENV=dev uv run python scripts/user-sync/sync_users.py --to prod
+APP_ENV=local uv run python scripts/user-sync/sync_users.py --to prod
 ```
 
 ### Option 3: Use default (not recommended)
@@ -89,20 +89,20 @@ This means:
 
 ### New Test User Flow
 
-1. **Create user in dev environment**
+1. **Create user in local environment**
    ```bash
-   # User signs up in dev via app
+   # User signs up in local via app
    # Email: alice@example.com
    ```
 
 2. **Sync to production**
    ```bash
    cd backend
-   APP_ENV=dev uv run python scripts/user-sync/sync_users.py --to prod --password "Test2025!"
+   APP_ENV=local uv run python scripts/user-sync/sync_users.py --to prod --password "Test2025!"
    ```
 
 3. **User can now log in to both environments**
-   - Dev: alice@example.com / (original password)
+   - Local: alice@example.com / (original password)
    - Prod: alice@example.com / Test2025!
 
 4. **User changes prod password via app**
@@ -110,14 +110,14 @@ This means:
 ### Onboarding Multiple Test Users
 
 ```bash
-# 1. Create all test users in dev environment (via app signup)
+# 1. Create all test users in local environment (via app signup)
 
 # 2. Sync all users to prod at once
 cd backend
-APP_ENV=dev uv run python scripts/user-sync/sync_users.py --to prod --password "Welcome2025!"
+APP_ENV=local uv run python scripts/user-sync/sync_users.py --to prod --password "Welcome2025!"
 
 # 3. Send welcome email with:
-#    - Dev URL: https://dev.missingtable.com
+#    - Local URL: http://localhost:8080
 #    - Prod URL: https://missingtable.com
 #    - Credentials: <email> / Welcome2025!
 #    - Instructions to change password
@@ -129,8 +129,8 @@ To backup current users (for reference or rollback):
 
 ```bash
 cd backend
-APP_ENV=dev uv run python scripts/user-sync/backup_auth_users.py
-# Creates: auth_users_dev_YYYYMMDD_HHMMSS.json
+APP_ENV=local uv run python scripts/user-sync/backup_auth_users.py
+# Creates: auth_users_local_YYYYMMDD_HHMMSS.json
 
 APP_ENV=prod uv run python scripts/user-sync/backup_auth_users.py
 # Creates: auth_users_prod_YYYYMMDD_HHMMSS.json
@@ -150,11 +150,11 @@ Backups are automatically gitignored and stored in `backend/` temporarily. Move 
 
 ### "Missing SUPABASE_URL or SUPABASE_SERVICE_KEY"
 
-Make sure you have both `.env.dev` and `.env.prod` files with Supabase credentials:
+Make sure you have both `.env.local` and `.env.prod` files with Supabase credentials:
 
 ```bash
-# backend/.env.dev
-SUPABASE_URL=https://xxx.supabase.co
+# backend/.env.local
+SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_SERVICE_KEY=xxx
 
 # backend/.env.prod

--- a/backend/scripts/user-sync/sync_users.py
+++ b/backend/scripts/user-sync/sync_users.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 """
-Sync users between dev and production environments.
+Sync users between local and production environments.
 
-This script ensures test users can use the same credentials in both dev and prod.
+This script ensures test users can use the same credentials in both local and prod.
 
 Usage:
-    # Sync from dev to prod (creates missing users in prod)
-    APP_ENV=dev python sync_users.py --to prod
+    # Sync from local to prod (creates missing users in prod)
+    APP_ENV=local python sync_users.py --to prod
 
-    # Sync from prod to dev (creates missing users in dev)
-    APP_ENV=prod python sync_users.py --to dev
+    # Sync from prod to local (creates missing users in local)
+    APP_ENV=prod python sync_users.py --to local
 
     # Dry run (see what would be synced without making changes)
-    APP_ENV=dev python sync_users.py --to prod --dry-run
+    APP_ENV=local python sync_users.py --to prod --dry-run
 
     # Set specific password for new users
-    APP_ENV=dev python sync_users.py --to prod --password "TestPass123!"
+    APP_ENV=local python sync_users.py --to prod --password "TestPass123!"
 """
 
 import argparse
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Source env from APP_ENV
-    source_env = os.getenv("APP_ENV", "dev")
+    source_env = os.getenv("APP_ENV", "local")
     target_env = args.to
 
     if source_env == target_env:

--- a/backend/scripts/utilities/search_matches.py
+++ b/backend/scripts/utilities/search_matches.py
@@ -12,7 +12,7 @@ Features:
 - Filter by Team (home or away)
 - Filter by Season (default: 2025-2026)
 - Beautiful rich table output
-- Environment-aware (local/dev/prod)
+- Environment-aware (local/prod)
 
 Usage:
     # Search with defaults (League matches, 2025-2026 season)

--- a/backend/scripts/utilities/verify_match_id.py
+++ b/backend/scripts/utilities/verify_match_id.py
@@ -12,11 +12,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from dao.match_dao import SupabaseConnection
 
-# Load dev environment (from backend root)
+# Load prod environment (from backend root)
 backend_root = Path(__file__).parent.parent.parent
-load_dotenv(backend_root / '.env.dev')
+load_dotenv(backend_root / '.env.prod')
 
-print("Connecting to dev database...")
+print("Connecting to prod database...")
 db = SupabaseConnection()
 
 # Check if match_id column exists

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -102,8 +102,8 @@ npx supabase status
 **Cloud Supabase (For integration testing):**
 
 ```bash
-# Switch to dev environment
-./switch-env.sh dev
+# Switch to prod environment
+./switch-env.sh prod
 
 # Apply migrations
 cd supabase-local && npx supabase db push --linked

--- a/backend/tests/tsc/test_99_cleanup.py
+++ b/backend/tests/tsc/test_99_cleanup.py
@@ -3,7 +3,7 @@ TSC Journey Tests - Phase 99: Cleanup.
 
 This phase cleans up all test entities by querying for entities with the
 tsc_a_ prefix. This approach is safer than ID-based cleanup because:
-- Works across environments (local, dev, prod)
+- Works across environments (local, prod)
 - Doesn't depend on a registry file
 - Idempotent - safe to run multiple times
 

--- a/docs/01-getting-started/local-development.md
+++ b/docs/01-getting-started/local-development.md
@@ -26,7 +26,7 @@ npm install -g supabase
 brew install gh
 ```
 
-### 2. Kubernetes Environment (Optional - for Helm deployments)
+### 2. Kubernetes Environment (Optional - for Redis caching and Helm deployments)
 
 ```bash
 # Install Rancher Desktop for Kubernetes
@@ -36,6 +36,8 @@ brew install gh
 # Install Helm (for Kubernetes deployments)
 brew install helm
 ```
+
+> **Want Redis caching?** See [Local K3s with Redis](../02-development/local-k3s-with-redis.md) for a complete guide on setting up local Kubernetes with Redis.
 
 ## Project Setup
 

--- a/docs/02-development/README.md
+++ b/docs/02-development/README.md
@@ -14,6 +14,7 @@ This section covers daily development workflows, tools, and best practices for w
 |----------|-------------|
 | **[Daily Workflow](daily-workflow.md)** | Common commands and development patterns |
 | **[Environment Management](environment-management.md)** | Switching between local, dev, and prod environments |
+| **[Local K3s with Redis](local-k3s-with-redis.md)** | Full local setup with Rancher Desktop and Redis caching |
 | **[Database Operations](database-operations.md)** | Backup, restore, and database management |
 | **[Schema Migrations](schema-migrations.md)** | Creating, testing, and deploying migrations |
 | **[Docker Guide](docker-guide.md)** | Building images, platform considerations |
@@ -46,10 +47,10 @@ cd frontend && npm run serve           # Frontend with HMR
 ./missing-table.sh stop     # Stop all services
 
 # Database Operations
-./scripts/db_tools.sh backup        # Create backup
-./scripts/db_tools.sh restore       # Restore from latest
-./scripts/db_tools.sh list          # List backups
-./scripts/db_tools.sh cleanup 5     # Keep 5 most recent
+./scripts/setup-local-db.sh --from-prod  # Refresh local from prod (RECOMMENDED)
+./scripts/db_tools.sh backup             # Create backup
+./scripts/db_tools.sh restore            # Restore from latest
+./scripts/db_tools.sh list               # List backups
 
 # Testing
 cd backend && uv run pytest                    # Backend tests
@@ -82,8 +83,15 @@ cd frontend && npm run lint                     # JavaScript linting
 # Morning setup
 git pull origin main
 ./switch-env.sh local
-supabase start
+cd supabase-local && npx supabase start && cd ..
+
+# Option A: Restore from existing backup
 ./scripts/db_tools.sh restore
+
+# Option B: Refresh from production (gets latest data)
+./scripts/setup-local-db.sh --from-prod
+
+# Start development
 ./missing-table.sh dev
 
 # During development
@@ -91,7 +99,6 @@ supabase start
 # - No need to restart services!
 
 # End of day
-./scripts/db_tools.sh backup  # Optional backup
 ./missing-table.sh stop
 ```
 
@@ -207,13 +214,13 @@ npm run build --report
 
 ### Environment Files
 
-**Backend** (`.env`, `.env.local`, `.env.dev`):
+**Backend** (`.env`, `.env.local`, `.env.prod`):
 ```bash
 SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_SERVICE_KEY=your_key
 ```
 
-**Frontend** (`.env.local`, `.env.development`):
+**Frontend** (`.env.local`, `.env.prod`):
 ```bash
 VUE_APP_API_URL=http://localhost:8000
 VUE_APP_SUPABASE_URL=http://127.0.0.1:54321

--- a/docs/02-development/daily-workflow.md
+++ b/docs/02-development/daily-workflow.md
@@ -51,15 +51,19 @@ cd frontend && npm run lint
 ### Database Backup & Restore
 
 ```bash
+# Refresh local database from production (RECOMMENDED)
+./scripts/setup-local-db.sh --from-prod
+
 # Database backup and restore utility
-./scripts/db_tools.sh restore        # Restore from latest backup (PREFERRED)
+./scripts/db_tools.sh restore        # Restore from latest backup
 ./scripts/db_tools.sh restore backup_file.json  # Restore from specific backup
 ./scripts/db_tools.sh backup         # Create new backup
+APP_ENV=prod ./scripts/db_tools.sh backup  # Create backup from prod
 ./scripts/db_tools.sh list           # List available backups
 ./scripts/db_tools.sh cleanup 5      # Keep only 5 most recent backups
 ```
 
-**IMPORTANT**: Always use `db_tools.sh restore` for database operations. Never use `supabase db reset` with seeds.
+**Recommended workflow**: Use `./scripts/setup-local-db.sh --from-prod` to get a complete refresh from production data.
 
 ### Supabase Commands
 
@@ -222,13 +226,18 @@ curl http://localhost:8000/health/full
 ```bash
 # Start local development
 ./switch-env.sh local
-supabase start
-./scripts/db_tools.sh restore    # Restore real data from latest backup
+cd supabase-local && npx supabase start && cd ..
+
+# Option A: Restore from existing local backup
+./scripts/db_tools.sh restore
+
+# Option B: Refresh from production (gets latest data)
+./scripts/setup-local-db.sh --from-prod
 
 # Your development work...
 
-# End of session (optional backup)
-./scripts/db_tools.sh backup     # Create backup of current state
+# End of session
+./missing-table.sh stop
 ```
 
 ### Testing New Features

--- a/docs/02-development/database-operations.md
+++ b/docs/02-development/database-operations.md
@@ -12,10 +12,12 @@ Overview of database management for the Missing Table project.
 ```bash
 # Full local DB setup from scratch (schema + seed + test users)
 ./scripts/setup-local-db.sh              # Without match data
-./scripts/setup-local-db.sh --restore    # With match data from backup
+./scripts/setup-local-db.sh --restore    # With match data from existing backup
+./scripts/setup-local-db.sh --from-prod  # Backup from prod first, then restore locally
 
 # Backup/Restore
-./scripts/db_tools.sh backup             # Create backup
+./scripts/db_tools.sh backup             # Create backup from current environment
+APP_ENV=prod ./scripts/db_tools.sh backup  # Create backup from production
 ./scripts/db_tools.sh restore            # Restore from latest backup
 ./scripts/db_tools.sh list               # List available backups
 
@@ -61,13 +63,26 @@ The `db_tools.sh reset` command includes a **4-hour safety guard**: it will refu
 
 ## Common Workflows
 
-### Starting Fresh
+### Starting Fresh (from existing backup)
 
 ```bash
 ./scripts/setup-local-db.sh --restore
 ```
 
 This runs `supabase db reset` (schema + seed), creates test users, and restores match data from the latest backup.
+
+### Refresh Local from Production
+
+```bash
+./scripts/setup-local-db.sh --from-prod
+```
+
+This is the **recommended workflow** for syncing your local database with production. It:
+1. Creates a fresh backup from prod
+2. Resets local database (schema + seed)
+3. Restores match/team data from the fresh backup
+4. Flushes Redis cache
+5. Seeds test users
 
 ### After Schema Changes
 

--- a/docs/02-development/local-k3s-with-redis.md
+++ b/docs/02-development/local-k3s-with-redis.md
@@ -1,0 +1,359 @@
+# Local K3s Development with Redis
+
+This guide explains how to set up a complete local development environment using Rancher Desktop (k3s) with Redis for caching.
+
+## Overview
+
+The local development stack consists of:
+- **Supabase** (PostgreSQL) - runs via Docker (supabase CLI)
+- **Redis** - runs in local k3s cluster for caching
+- **Backend** - runs locally with `uv run python app.py`
+- **Frontend** - runs locally with `npm run serve`
+
+## Prerequisites
+
+### 1. Install Required Tools
+
+```bash
+# Install Homebrew (if not already installed)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Core tools
+brew install git node python@3.13 helm
+
+# Python package manager
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Supabase CLI
+npm install -g supabase
+
+# Rancher Desktop - download from https://rancherdesktop.io/
+# After install, open Rancher Desktop and enable Kubernetes
+```
+
+### 2. Verify Rancher Desktop is Running
+
+```bash
+# Should show rancher-desktop context
+kubectl config get-contexts
+
+# Switch to rancher-desktop context
+kubectl config use-context rancher-desktop
+
+# Verify cluster is ready
+kubectl get nodes
+```
+
+## Quick Start
+
+If you just want to get everything running quickly:
+
+```bash
+# 1. Deploy Redis to k3s
+./scripts/deploy-local-redis.sh
+
+# 2. Start Supabase
+cd supabase-local && npx supabase start && cd ..
+
+# 3. Setup database (requires recent backup)
+./scripts/setup-local-db.sh --restore
+
+# 4. Start services with auto-reload
+./missing-table.sh dev
+```
+
+## Step-by-Step Setup
+
+### Step 1: Deploy Redis to Local K3s
+
+Create the namespace and deploy Redis:
+
+```bash
+# Create namespace
+kubectl create namespace missing-table --dry-run=client -o yaml | kubectl apply -f -
+
+# Deploy Redis using helm chart
+helm upgrade --install missing-table ./helm/missing-table \
+  --namespace missing-table \
+  --set redis.enabled=true \
+  --set backend.replicaCount=0 \
+  --set frontend.replicaCount=0 \
+  --set celeryWorker.enabled=false
+```
+
+Verify Redis is running:
+
+```bash
+# Check pod status
+kubectl get pods -n missing-table
+
+# Expected output:
+# NAME                                      READY   STATUS    RESTARTS   AGE
+# missing-table-redis-xxxxxxxxx-xxxxx       1/1     Running   0          1m
+
+# Test Redis connection
+kubectl exec -n missing-table svc/missing-table-redis -- redis-cli PING
+# Expected: PONG
+```
+
+### Step 2: Start Local Supabase
+
+```bash
+cd supabase-local
+npx supabase start
+cd ..
+```
+
+This starts:
+- **PostgreSQL**: localhost:54332
+- **API**: localhost:54321
+- **Studio**: localhost:54323
+
+### Step 3: Setup Database
+
+Create a backup first (if you have existing data):
+```bash
+./scripts/db_tools.sh backup
+```
+
+Then reset and seed the database:
+```bash
+# Without match data (reference data + test users only)
+./scripts/setup-local-db.sh
+
+# With match data from backup
+./scripts/setup-local-db.sh --restore
+```
+
+This script:
+1. Resets the database (applies schema + seed)
+2. Flushes Redis cache (if available)
+3. Seeds test users (tom, tom_ifa, tom_ifa_fan, tom_club)
+
+### Step 4: Configure Environment
+
+The backend needs to know where Redis is. Create/update `backend/.env.local`:
+
+```bash
+# Database (local Supabase)
+DATABASE_URL=postgresql://postgres:postgres@localhost:54332/postgres
+SUPABASE_URL=http://localhost:54321
+SUPABASE_SERVICE_KEY=<your-local-service-key>  # Get from: npx supabase status
+
+# Redis caching (via port-forward)
+CACHE_ENABLED=true
+REDIS_URL=redis://localhost:6379/0
+
+# Development settings
+APP_ENV=local
+LOG_LEVEL=debug
+```
+
+### Step 5: Start Port-Forward for Redis
+
+The `missing-table.sh` script handles this automatically, but you can also do it manually:
+
+```bash
+# Manual port-forward (runs in foreground)
+kubectl port-forward -n missing-table svc/missing-table-redis 6379:6379
+
+# Or use the service script which handles it in background
+./missing-table.sh start
+```
+
+### Step 6: Start Development Servers
+
+```bash
+# Option A: Use the service script (recommended)
+./missing-table.sh dev  # Starts with auto-reload
+
+# Option B: Start manually in separate terminals
+# Terminal 1 - Backend
+cd backend && APP_ENV=local uv run python app.py
+
+# Terminal 2 - Frontend
+cd frontend && npm run serve
+```
+
+## Verification
+
+### Check All Services
+
+```bash
+# Check service status
+./missing-table.sh status
+
+# Expected output:
+# Backend:  running (PID: xxxxx)
+# Frontend: running (PID: xxxxx)
+# Redis:    port-forward active (PID: xxxxx)
+```
+
+### Verify Redis Caching
+
+```bash
+# Check Redis has data (after making some API calls)
+kubectl exec -n missing-table svc/missing-table-redis -- redis-cli DBSIZE
+# Should show number of cached keys
+
+# View cache keys
+kubectl exec -n missing-table svc/missing-table-redis -- redis-cli KEYS "mt:dao:*"
+```
+
+### Test Endpoints
+
+- **Frontend**: http://localhost:8080
+- **Backend API**: http://localhost:8000
+- **API Docs**: http://localhost:8000/docs
+- **Supabase Studio**: http://localhost:54323
+
+## Common Commands
+
+### Service Management
+
+```bash
+./missing-table.sh start      # Start all services
+./missing-table.sh stop       # Stop all services
+./missing-table.sh restart    # Restart all services
+./missing-table.sh status     # Check service status
+./missing-table.sh dev        # Start with auto-reload (recommended)
+./missing-table.sh logs       # View service logs
+./missing-table.sh tail       # Follow logs in real-time
+```
+
+### Redis Commands
+
+```bash
+# Flush all cache (useful after DB changes)
+kubectl exec -n missing-table svc/missing-table-redis -- redis-cli FLUSHALL
+
+# Check Redis memory usage
+kubectl exec -n missing-table svc/missing-table-redis -- redis-cli INFO memory
+
+# Monitor Redis commands in real-time
+kubectl exec -n missing-table svc/missing-table-redis -- redis-cli MONITOR
+```
+
+### Database Commands
+
+```bash
+# Reset database
+./scripts/setup-local-db.sh
+
+# Backup database
+./scripts/db_tools.sh backup
+
+# Restore from backup
+./scripts/db_tools.sh restore
+
+# List backups
+./scripts/db_tools.sh list
+```
+
+## Troubleshooting
+
+### Redis Pod Not Starting
+
+```bash
+# Check pod events
+kubectl describe pod -n missing-table -l app.kubernetes.io/component=redis
+
+# Check storage (PVC might be stuck)
+kubectl get pvc -n missing-table
+```
+
+If PVC is stuck in Pending:
+```bash
+# Delete and recreate
+kubectl delete pvc -n missing-table --all
+helm upgrade --install missing-table ./helm/missing-table \
+  --namespace missing-table \
+  --set redis.enabled=true \
+  --set backend.replicaCount=0 \
+  --set frontend.replicaCount=0
+```
+
+### Port-Forward Dies
+
+The port-forward can timeout or die. Restart it:
+
+```bash
+# Kill existing port-forward
+pkill -f "port-forward.*missing-table-redis"
+
+# Restart services (will recreate port-forward)
+./missing-table.sh restart
+```
+
+### Rancher Desktop Not Responding
+
+```bash
+# Restart Rancher Desktop from menu bar
+# Or via command line:
+rdctl shutdown
+rdctl start
+```
+
+### Cache Not Working
+
+1. Verify `CACHE_ENABLED=true` in backend/.env.local
+2. Check Redis is accessible:
+   ```bash
+   redis-cli -h localhost -p 6379 PING
+   ```
+3. Check backend logs for cache messages:
+   ```bash
+   ./missing-table.sh logs | grep -i cache
+   ```
+
+### Database Connection Issues
+
+```bash
+# Verify Supabase is running
+cd supabase-local && npx supabase status
+
+# Check PostgreSQL connectivity
+PGPASSWORD=postgres psql -h localhost -p 54332 -U postgres -c "SELECT 1"
+```
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Local Development                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐     ┌──────────────┐     ┌──────────────┐    │
+│  │   Frontend   │────▶│   Backend    │────▶│  Supabase    │    │
+│  │  :8080       │     │   :8000      │     │  (Docker)    │    │
+│  └──────────────┘     └──────┬───────┘     │  :54321 API  │    │
+│                              │             │  :54332 DB   │    │
+│                              │             │  :54323 UI   │    │
+│                              ▼             └──────────────┘    │
+│                       ┌──────────────┐                          │
+│                       │    Redis     │                          │
+│                       │   (K3s)      │◀── port-forward :6379   │
+│                       │  caching     │                          │
+│                       └──────────────┘                          │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                 Rancher Desktop (K3s)                     │  │
+│  │  namespace: missing-table                                 │  │
+│  │  ├── missing-table-redis (Deployment)                    │  │
+│  │  ├── missing-table-redis (Service)                       │  │
+│  │  └── missing-table-redis-pvc (PersistentVolumeClaim)    │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Related Documentation
+
+- [Local Development Setup](../01-getting-started/local-development.md) - Basic setup without k3s
+- [Database Operations](./database-operations.md) - Backup/restore procedures
+- [Environment Management](./environment-management.md) - Switching between local/prod
+- [LOCAL_K3S_SETUP.md](../05-deployment/LOCAL_K3S_SETUP.md) - Messaging infrastructure (RabbitMQ/Celery)
+
+---
+
+**Last Updated**: 2026-02-03

--- a/docs/03-architecture/README.md
+++ b/docs/03-architecture/README.md
@@ -142,8 +142,7 @@ See: [Frontend Structure](frontend-structure.md)
 **Implementation**:
 ```bash
 ./switch-env.sh local  # Local Supabase
-./switch-env.sh dev    # Cloud development
-./switch-env.sh prod   # Production
+./switch-env.sh prod   # Production (use with caution)
 ```
 
 ---

--- a/docs/05-deployment/production-runbook.md
+++ b/docs/05-deployment/production-runbook.md
@@ -415,15 +415,15 @@ kubectl rollout status deployment/missing-table-frontend -n missing-table-prod
 
 ### Database Migrations
 
-**⚠️ Always test migrations in dev environment first!**
+**⚠️ Always test migrations in local environment first!**
 
 ```bash
-# 1. Test migration in dev
-./switch-env.sh dev
+# 1. Test migration locally
+./switch-env.sh local
 npx supabase db push
 
 # 2. Verify migration works
-./scripts/health-check.sh dev
+./scripts/health-check.sh local
 
 # 3. After deploying code to prod, migration runs automatically
 # (Migrations are applied during Helm upgrade)

--- a/docs/06-security/secret-runtime.md
+++ b/docs/06-security/secret-runtime.md
@@ -17,7 +17,7 @@ The application uses **different secret loading strategies** depending on the en
 ### Local Development
 
 **How it works:**
-1. Developer creates `.env.local` or `.env.dev` from example
+1. Developer creates `.env.local` from example
 2. Backend uses `python-dotenv` to load from `.env` files
 3. Environment variables are read via `os.getenv()`
 
@@ -36,7 +36,6 @@ SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
 **Available .env files:**
 - `backend/.env` - Default (git tracked, no secrets)
 - `backend/.env.local` - Local Supabase (gitignored)
-- `backend/.env.dev` - Cloud dev environment (gitignored)
 - `backend/.env.prod` - Cloud prod environment (gitignored)
 - `backend/.env.example` - Template (git tracked)
 
@@ -142,7 +141,7 @@ The frontend is a **static Vue.js application**. Secrets are compiled into the J
 ### Local Development
 
 **How it works:**
-1. Developer creates `.env.local` or `.env.dev`
+1. Developer creates `.env.local`
 2. Vue CLI reads `.env` files during `npm run serve`
 3. Variables prefixed with `VUE_APP_` are compiled into the code
 4. No runtime environment variable loading
@@ -150,7 +149,6 @@ The frontend is a **static Vue.js application**. Secrets are compiled into the J
 **Available .env files:**
 - `frontend/.env` - Default development (git tracked, public values only)
 - `frontend/.env.local` - Local Supabase (gitignored)
-- `frontend/.env.dev` - Cloud dev environment (gitignored)
 - `frontend/.env.prod` - Cloud prod environment (gitignored)
 - `frontend/.env.production` - Production build config (gitignored)
 
@@ -421,7 +419,7 @@ kubectl rollout restart deployment/missing-table-frontend -n missing-table-dev
 
 ✅ **DO:**
 - Keep `.env` files in `.gitignore`
-- Use separate `.env.local`, `.env.dev`, `.env.prod`
+- Use separate `.env.local`, `.env.prod`
 - Store backups in password manager, not files
 - Use weak passwords for local-only services
 

--- a/docs/07-operations/database-backup.md
+++ b/docs/07-operations/database-backup.md
@@ -10,6 +10,9 @@ Use the convenient shell script for common operations:
 # Create a backup
 ./scripts/db_tools.sh backup
 
+# Create a backup from production
+APP_ENV=prod ./scripts/db_tools.sh backup
+
 # List available backups
 ./scripts/db_tools.sh list
 
@@ -26,6 +29,21 @@ Use the convenient shell script for common operations:
 # Clean up old backups (keep only 5 most recent)
 ./scripts/db_tools.sh cleanup 5
 ```
+
+### Refresh Local from Production (Recommended)
+
+The easiest way to sync your local database with production:
+
+```bash
+./scripts/setup-local-db.sh --from-prod
+```
+
+This single command:
+1. Creates a fresh backup from prod
+2. Resets local database (applies schema + seed)
+3. Restores match/team data from the fresh backup
+4. Flushes Redis cache
+5. Seeds test users (tom, tom_ifa, etc.)
 
 ## Backup System
 
@@ -172,6 +190,14 @@ git checkout feature-branch
 
 # 3. Reset database and restore real data for new branch
 ./scripts/db_tools.sh reset
+```
+
+**Scenario 4: Sync Local with Production Data**
+```bash
+# Single command to refresh local from prod
+./scripts/setup-local-db.sh --from-prod
+
+# This backs up from prod, resets local, restores data, and seeds test users
 ```
 
 ## File Structure

--- a/docs/08-integrations/google-oauth-setup.md
+++ b/docs/08-integrations/google-oauth-setup.md
@@ -136,15 +136,6 @@ Make sure local Supabase is running:
 cd supabase-local && npx supabase start
 ```
 
-### Cloud Development
-
-Update `frontend/.env.dev`:
-```bash
-# These should already be set
-VUE_APP_SUPABASE_URL=https://ppgxasqgqbnauvxozmjw.supabase.co
-VUE_APP_SUPABASE_ANON_KEY=your_anon_key
-```
-
 ### Production
 
 Update `frontend/.env.prod`:
@@ -161,8 +152,8 @@ Run the OAuth support migration to add required columns:
 # Local
 cd supabase-local && npx supabase db reset
 
-# Cloud (after testing locally)
-./switch-env.sh dev
+# Production (after testing locally)
+./switch-env.sh prod
 cd supabase-local && npx supabase db push --linked
 ```
 

--- a/docs/08-integrations/match-scraper.md
+++ b/docs/08-integrations/match-scraper.md
@@ -48,9 +48,9 @@ uv run python scripts/utilities/create_service_account_token.py --service-name m
 Add the generated token to your match-scraper environment:
 
 ```bash
-# In match-scraper .env.dev file
+# In match-scraper .env.local or .env.prod file
 MISSING_TABLE_API_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-MISSING_TABLE_API_BASE_URL=https://dev.missingtable.com
+MISSING_TABLE_API_BASE_URL=http://localhost:8080  # or https://missingtable.com for prod
 
 # Optional: Choose API mode (default is async)
 USE_ASYNC_API=true  # Recommended for bulk operations

--- a/docs/09-cicd/database-inspector-tool.md
+++ b/docs/09-cicd/database-inspector-tool.md
@@ -11,7 +11,7 @@ A powerful CLI tool for inspecting and troubleshooting database data directly vi
 ## Features
 
 - **Direct Database Access**: Connects directly to Supabase, bypassing backend DAOs for raw data inspection
-- **Environment Aware**: Automatically loads `.env.{APP_ENV}` files (local/dev/prod)
+- **Environment Aware**: Automatically loads `.env.{APP_ENV}` files (local/prod)
 - **Rich Terminal UI**: Beautiful tables and panels using the `rich` library
 - **Comprehensive Commands**: Browse age groups, divisions, teams, matches with filtering
 - **Duplicate Detection**: Identifies duplicate matches based on key criteria
@@ -177,10 +177,6 @@ The tool automatically loads environment variables from `.env.{APP_ENV}` files:
 export APP_ENV=local
 cd backend && uv run python inspect_db.py stats
 
-# Use with dev database
-export APP_ENV=dev
-cd backend && uv run python inspect_db.py stats
-
 # Use with prod database (use caution!)
 export APP_ENV=prod
 cd backend && uv run python inspect_db.py stats
@@ -188,7 +184,7 @@ cd backend && uv run python inspect_db.py stats
 
 Or use the environment switcher:
 ```bash
-./switch-env.sh dev
+./switch-env.sh local
 cd backend && uv run python inspect_db.py games --team IFA
 ```
 
@@ -229,9 +225,9 @@ cd backend && uv run python inspect_db.py matches --team "IFA" --age-group U13
 
 **Solution:**
 ```bash
-# Compare statistics
+# Compare statistics between local and prod
 ./switch-env.sh local && cd backend && uv run python inspect_db.py stats
-./switch-env.sh dev && cd backend && uv run python inspect_db.py stats
+./switch-env.sh prod && cd backend && uv run python inspect_db.py stats
 
 # Find all duplicates in production
 ./switch-env.sh prod && cd backend && uv run python inspect_db.py matches --duplicates

--- a/docs/CLUBS_ARCHITECTURE.md
+++ b/docs/CLUBS_ARCHITECTURE.md
@@ -337,11 +337,6 @@ cd supabase-local
 npx supabase db reset
 ./scripts/db_tools.sh restore
 
-# Dev environment
-./switch-env.sh dev
-cd supabase-local
-npx supabase db push --linked
-
 # Production (with backup!)
 ./switch-env.sh prod
 ./scripts/db_tools.sh backup prod

--- a/docs/LEAGUE_LAYER_INTERNAL_TOOLS_CHECKLIST.md
+++ b/docs/LEAGUE_LAYER_INTERNAL_TOOLS_CHECKLIST.md
@@ -665,11 +665,11 @@ def create_or_get_division(name: str, description: str = None) -> int:
 ```
 
 **Testing Match-Scraper Integration**:
-- [ ] 1. Deploy updated missing-table to dev
-- [ ] 2. Get Homegrown league ID from dev: `cd backend && APP_ENV=dev uv run python -c "from dao.enhanced_data_access_fixed import SportsDataAccess; dao = SportsDataAccess(); leagues = dao.get_all_leagues(); print([l for l in leagues if l['name']=='Homegrown'])"`
+- [ ] 1. Deploy updated missing-table to local or prod
+- [ ] 2. Get Homegrown league ID: `cd backend && APP_ENV=local uv run python -c "from dao.enhanced_data_access_fixed import SportsDataAccess; dao = SportsDataAccess(); leagues = dao.get_all_leagues(); print([l for l in leagues if l['name']=='Homegrown'])"`
 - [ ] 3. Update match-scraper config with league ID
 - [ ] 4. Update match-scraper division creation code
-- [ ] 5. Test scraper against dev environment
+- [ ] 5. Test scraper against local environment
 - [ ] 6. Verify divisions created with correct league_id
 
 ---

--- a/docs/TESTING_PARENT_CLUBS.md
+++ b/docs/TESTING_PARENT_CLUBS.md
@@ -1,6 +1,6 @@
-# Testing Parent Clubs in DEV
+# Testing Parent Clubs
 
-**Environment:** https://dev.missingtable.com
+**Environment:** Local (http://localhost:8080) or Prod (https://missingtable.com)
 **Date:** 2025-10-30
 **Status:** ✅ Ready for Testing
 
@@ -10,7 +10,7 @@
 
 ```bash
 cd backend
-export APP_ENV=dev
+export APP_ENV=local
 
 # Run interactive test
 python test_parent_clubs.py
@@ -92,7 +92,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ```bash
 cd backend
-export APP_ENV=dev
+export APP_ENV=local
 
 python -c "
 from dao.enhanced_data_access_fixed import SupabaseConnection, EnhancedSportsDAO
@@ -145,7 +145,7 @@ This simulates a real-world scenario where "IFA" has both Academy and Homegrown 
 
 3. **Link teams to parent (via database):**
    ```bash
-   cd backend && export APP_ENV=dev
+   cd backend && export APP_ENV=local
 
    python -c "
    from dao.enhanced_data_access_fixed import SupabaseConnection, EnhancedSportsDAO

--- a/docs/bugs/BUG-myclub-team-assignment.md
+++ b/docs/bugs/BUG-myclub-team-assignment.md
@@ -1,0 +1,93 @@
+# BUG: MyClub Tab Shows "No Team Assigned" Despite Player Being on Teams
+
+**Status**: Open
+**Discovered**: 2026-02-03
+**Severity**: Medium - affects team-player users viewing their team roster
+
+---
+
+## Summary
+
+When a player (e.g., `gabe35`) is added to teams via the admin/team-manager UI, the MyClub tab still shows "No Team Assigned". The team memberships are correctly stored in `player_team_history` but the frontend checks `user_profiles.team_id`, which is never updated by the "add player to team" flow.
+
+## Steps to Reproduce
+
+1. Log in as admin or team manager
+2. Add a player (e.g., gabe35) to a team (e.g., IFA Academy) via the roster manager
+3. Log in as the player (gabe35 / play123)
+4. Navigate to the MyClub tab
+5. **Expected**: Shows team roster for IFA Academy
+6. **Actual**: Shows "No Team Assigned"
+
+## Root Cause
+
+There is a disconnect between two systems:
+
+### Where team membership is stored (write path)
+The "add player to team" flow writes to `player_team_history`:
+```
+player_team_history:
+  player_id = <user UUID>
+  team_id = 123 (IFA Academy)
+  season_id = 3
+  is_current = true
+```
+
+### Where team membership is read (read path)
+`TeamRosterRouter.vue` checks `user_profiles.team_id`:
+```javascript
+// frontend/src/components/profiles/TeamRosterRouter.vue:98
+const hasTeam = computed(() => {
+  return !!authStore.state.profile?.team_id;
+});
+```
+
+The `user_profiles.team_id` field is **only** set during the invite-code signup flow (`backend/app.py:385-396`), not when a player is added to a team through the roster manager.
+
+## Data Evidence (from prod, 2026-02-03)
+
+**gabe35's user_profiles:**
+- `team_id`: NULL
+- `club_id`: NULL
+- `role`: team-player
+
+**gabe35's player_team_history (2 entries):**
+- team_id=123 (IFA Academy), season_id=3, is_current=true
+- team_id=184 (IFA Elite Futsal 2012 White), season_id=3, is_current=true
+
+## Proposed Fix
+
+### Option A: Fix the read path (Recommended)
+
+Update the MyClub tab to use `player_team_history` as the source of truth instead of (or in addition to) `user_profiles.team_id`.
+
+**Files to change:**
+1. **Backend** - Add endpoint or extend `/api/auth/me` to return team memberships from `player_team_history` where `is_current = true`
+2. **Frontend** - `frontend/src/components/profiles/TeamRosterRouter.vue` - Check `player_team_history` data instead of only `user_profiles.team_id`
+
+**Why this is better:** A player can be on multiple teams (gabe35 is on 2). `user_profiles.team_id` is a single integer and can't represent multiple team memberships.
+
+### Option B: Fix the write path
+
+Update the "add player to team" flow to also set `user_profiles.team_id`. This is simpler but doesn't handle the multiple-teams case well.
+
+### Option C: Both
+
+Use `player_team_history` as primary source of truth for the MyClub tab, and also keep `user_profiles.team_id` in sync as a convenience/primary-team field.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `frontend/src/components/profiles/TeamRosterRouter.vue` | MyClub tab - checks `team_id` (line 98) |
+| `frontend/src/stores/auth.js` | Stores profile from `/api/auth/me` |
+| `backend/app.py` | `/api/auth/me` endpoint (line ~1529) |
+| `backend/dao/player_dao.py` | `get_user_profile_with_relationships()` (line 27) |
+| `backend/services/invite_service.py` | Only place that sets `user_profiles.team_id` (during invite redemption) |
+| `supabase-local/migrations/00000000000000_schema.sql` | Schema for `player_team_history` and `user_profiles` |
+
+## Additional Context
+
+- `user_profiles.team_id` is set correctly when a user signs up via an invite code (the signup flow in `app.py:385-396` copies `team_id` from the invitation)
+- The roster manager adds players to teams via `player_team_history` but never touches `user_profiles.team_id`
+- Test users (tom_ifa, tom_ifa_fan) have `team_id` set because they're created by `seed_test_users.sh` which directly sets it

--- a/k3s/worker/README.md
+++ b/k3s/worker/README.md
@@ -51,12 +51,12 @@ kubectl logs -n match-scraper -l app=missing-table-worker --tail=50 -f
 kubectl exec -n match-scraper rabbitmq-0 -- rabbitmqctl list_queues
 ```
 
-## Switching Environments (Dev ↔ Prod)
+## Switching Environments (Local ↔ Prod)
 
 ### Using Helper Script (Recommended)
 ```bash
-# Switch to dev
-./k3s/worker/switch-worker-env.sh dev
+# Switch to local
+./k3s/worker/switch-worker-env.sh local
 
 # Switch to prod
 ./k3s/worker/switch-worker-env.sh prod
@@ -209,7 +209,7 @@ kubectl rollout status deployment/missing-table-celery-worker -n match-scraper
 - `CELERY_BROKER_URL` - Celery broker URL (same as RabbitMQ)
 - `REDIS_URL` - Redis connection string
 - `SUPABASE_URL` - Supabase project URL
-- `ENVIRONMENT` - dev or production
+- `ENVIRONMENT` - local or production
 - `LOG_LEVEL` - Logging level (INFO, DEBUG, WARNING)
 
 **From Secret:**

--- a/k3s/worker/STATUS.md
+++ b/k3s/worker/STATUS.md
@@ -4,11 +4,11 @@
 
 ## Current Configuration
 
-- **Environment**: Dev (Supabase)
+- **Environment**: Local (Supabase)
 - **Replicas**: 2
 - **Result Backend**: RPC (no Redis required)
 - **Message Broker**: RabbitMQ (local k3s)
-- **Database**: Dev Supabase
+- **Database**: Local Supabase
 
 ## Component Health
 
@@ -17,7 +17,7 @@
 ✅ RabbitMQ Connection:       Connected
 ✅ Queue Consumers:           2 workers on 'matches' queue
 ✅ Result Backend:            RPC (lightweight)
-✅ Database Connection:       Dev Supabase
+✅ Database Connection:       Local Supabase
 ```
 
 ## Quick Commands
@@ -113,7 +113,7 @@ python main.py scrape --league "MLS Next" --season "2024-2025"
 ### Database connection errors
 1. Check Supabase URL: `kubectl get configmap -n match-scraper missing-table-worker-config -o yaml`
 2. Verify credentials: `kubectl get secret -n match-scraper missing-table-worker-secrets -o yaml`
-3. Switch environment: `./k3s/worker/switch-worker-env.sh dev`
+3. Switch environment: `./k3s/worker/switch-worker-env.sh local`
 
 ### Need to switch to prod
 ```bash

--- a/k3s/worker/switch-worker-env.sh
+++ b/k3s/worker/switch-worker-env.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Switch Celery worker environment between dev and prod
+# Switch Celery worker environment between local and prod
 #
 # This script makes it easy to point your local k3s Celery workers
-# at either the dev or prod Supabase database.
+# at either the local or prod Supabase database.
 #
 # Usage:
-#   ./switch-worker-env.sh dev     # Switch to dev Supabase
+#   ./switch-worker-env.sh local   # Switch to local Supabase
 #   ./switch-worker-env.sh prod    # Switch to prod Supabase
 #   ./switch-worker-env.sh status  # Show current environment
 
@@ -75,7 +75,7 @@ show_status() {
         log_warning "No workers deployed"
         echo ""
         echo "To deploy workers, run:"
-        echo "  ./switch-worker-env.sh dev"
+        echo "  ./switch-worker-env.sh local"
         echo ""
         return
     fi
@@ -186,9 +186,9 @@ main() {
     local command=${1:-help}
 
     case "$command" in
-        dev)
+        local)
             check_context
-            deploy_env "dev"
+            deploy_env "local"
             ;;
         prod)
             check_context
@@ -199,15 +199,15 @@ main() {
             show_status
             ;;
         help|--help|-h)
-            echo "Usage: $0 {dev|prod|status}"
+            echo "Usage: $0 {local|prod|status}"
             echo ""
             echo "Commands:"
-            echo "  dev     - Switch workers to dev Supabase database"
+            echo "  local   - Switch workers to local Supabase database"
             echo "  prod    - Switch workers to prod Supabase database"
             echo "  status  - Show current environment and worker status"
             echo ""
             echo "Examples:"
-            echo "  $0 dev      # Switch to dev"
+            echo "  $0 local    # Switch to local"
             echo "  $0 prod     # Switch to prod"
             echo "  $0 status   # Check current status"
             echo ""
@@ -215,7 +215,7 @@ main() {
         *)
             log_error "Unknown command: $command"
             echo ""
-            echo "Usage: $0 {dev|prod|status}"
+            echo "Usage: $0 {local|prod|status}"
             echo "Run '$0 help' for more information"
             exit 1
             ;;

--- a/missing-table.sh
+++ b/missing-table.sh
@@ -538,28 +538,15 @@ show_status() {
 
     # Determine database connection based on environment
     if [ "$current_env" = "local" ]; then
-        # Check if Supabase is running locally
-        if curl -s http://127.0.0.1:54331/health > /dev/null 2>&1; then
-            local supabase_url="http://127.0.0.1:54331"
-            local studio_url="http://127.0.0.1:54333"
+        # Check if Supabase is running locally (Kong API on 54321)
+        if curl -s http://127.0.0.1:54321/health > /dev/null 2>&1; then
+            local supabase_url="http://127.0.0.1:54321"
+            local studio_url="http://127.0.0.1:54323"
             echo -e "  Database: ${GREEN}Local Supabase${NC} ($supabase_url)"
             echo -e "  Studio UI: ${GREEN}$studio_url${NC}"
         else
             echo -e "  Database: ${RED}Local Supabase (not running)${NC}"
             echo -e "  ${BLUE}Tip:${NC} Start with 'npx supabase start'"
-        fi
-    elif [ "$current_env" = "dev" ]; then
-        echo -e "  Database: ${GREEN}Cloud Supabase (dev)${NC}"
-        # Extract Supabase URL from .env.dev if it exists
-        if [ -f "backend/.env.dev" ]; then
-            local supabase_url=$(grep "^SUPABASE_URL=" backend/.env.dev 2>/dev/null | cut -d '=' -f2)
-            if [ -n "$supabase_url" ]; then
-                # Extract project ref from URL (e.g., ppgxasqgqbnauvxozmjw from https://ppgxasqgqbnauvxozmjw.supabase.co)
-                local project_ref=$(echo "$supabase_url" | sed -n 's|https://\([^.]*\)\.supabase\.co|\1|p')
-                if [ -n "$project_ref" ]; then
-                    echo -e "  Studio UI: ${GREEN}https://supabase.com/dashboard/project/$project_ref${NC}"
-                fi
-            fi
         fi
     elif [ "$current_env" = "prod" ]; then
         echo -e "  Database: ${GREEN}Cloud Supabase (prod)${NC}"
@@ -576,7 +563,7 @@ show_status() {
     fi
 
     # Show how to switch environments
-    echo -e "  ${BLUE}Tip:${NC} Use './switch-env.sh <local|dev|prod>' to change environment"
+    echo -e "  ${BLUE}Tip:${NC} Use './switch-env.sh <local|prod>' to change environment"
 
     # Backend status
     echo -e "\n${YELLOW}Backend (Port $BACKEND_PORT):${NC}"

--- a/readme.md
+++ b/readme.md
@@ -400,7 +400,7 @@ cd frontend && npm test         # Frontend tests
 
 # Environment Switching
 ./switch-env.sh local    # Local development
-./switch-env.sh dev      # Cloud development
+./switch-env.sh prod     # Production (use with caution)
 ```
 
 **Full command reference** → [Daily Workflow Guide](docs/02-development/daily-workflow.md)

--- a/scripts/README_SCHEMA_SYNC.md
+++ b/scripts/README_SCHEMA_SYNC.md
@@ -1,18 +1,18 @@
 # Schema Sync Tooling
 
-This directory contains tooling for syncing database schemas between environments (dev and prod).
+This directory contains tooling for syncing database schemas between environments (local and prod).
 
 ## Overview
 
-When the production database schema evolves (new columns, indexes, constraints), the dev environment may fall out of sync. These tools help keep dev and prod schemas aligned.
+When the production database schema evolves (new columns, indexes, constraints), the local environment may fall out of sync. These tools help keep local and prod schemas aligned.
 
 ## Tools
 
 ### 1. Schema Sync Scripts
 
 **Location:**
-- `scripts/sync_dev_schema.sql` - SQL migration for adding missing columns
-- `backend/sync_dev_schema.py` - Python script to execute the migration
+- `scripts/sync_local_schema.sql` - SQL migration for adding missing columns
+- `backend/sync_local_schema.py` - Python script to execute the migration
 
 **Purpose:** Adds missing scraper integration fields to the matches table:
 - `mls_match_id` - MLS Next match identifier
@@ -27,12 +27,12 @@ When the production database schema evolves (new columns, indexes, constraints),
 ```bash
 # From backend directory
 cd backend
-uv run python sync_dev_schema.py
+uv run python sync_local_schema.py
 ```
 
 **Output:**
 ```
-🔄 Syncing dev schema with prod...
+🔄 Syncing local schema with prod...
 📝 Connecting to database...
 📝 Executing schema migration SQL...
 ✅ Schema migration completed successfully!
@@ -52,8 +52,8 @@ uv run python sync_dev_schema.py
 ### Check Database Schema
 
 ```bash
-# Switch to dev environment
-./switch-env.sh dev
+# Switch to local environment
+./switch-env.sh local
 
 # Check database stats
 cd backend
@@ -63,11 +63,11 @@ uv run python inspect_db.py stats
 ### Check API Schema
 
 ```bash
-# Compare prod vs dev API schemas
+# Compare prod vs local API schemas
 curl -s "https://missingtable.com/api/matches?limit=1" | \
   python3 -c "import sys, json; print(sorted(json.load(sys.stdin)[0].keys()))"
 
-curl -s "https://dev.missingtable.com/api/matches?limit=1" | \
+curl -s "http://localhost:8080/api/matches?limit=1" | \
   python3 -c "import sys, json; print(sorted(json.load(sys.stdin)[0].keys()))"
 ```
 
@@ -76,8 +76,8 @@ Both should return identical column lists.
 ## When to Use
 
 Use these tools when:
-1. **After applying new migrations to prod** - Sync dev to match
-2. **Dev database is rebuilt** - Restore schema compatibility
+1. **After applying new migrations to prod** - Sync local to match
+2. **Local database is rebuilt** - Restore schema compatibility
 3. **Schema drift detected** - Bring environments back in sync
 
 ## Related Documentation
@@ -89,12 +89,12 @@ Use these tools when:
 ## Notes
 
 - The Python script requires `psycopg2` dependency (included in backend requirements)
-- Requires dev environment credentials in `backend/.env.dev`
+- Requires local environment credentials in `backend/.env.local`
 - Uses transactions - rolls back on error
 - Idempotent - safe to run multiple times (uses `IF NOT EXISTS`)
 
 ## Created
 
 - **Date:** 2025-10-24
-- **Purpose:** Sync match-scraper integration fields to dev environment
-- **Related Issue:** Dev database was missing 7 columns that production had
+- **Purpose:** Sync match-scraper integration fields to local environment
+- **Related Issue:** Local database was missing 7 columns that production had

--- a/scripts/db_tools.sh
+++ b/scripts/db_tools.sh
@@ -40,13 +40,14 @@ check_recent_backup() {
     fi
 
     # Find backup files modified within the last 4 hours
+    # Only match timestamp-formatted backups (database_backup_[0-9]*.json)
     local recent_backups
-    recent_backups=$(find "$backup_dir" -maxdepth 1 -name "database_backup_*.json" -mmin -${max_age_minutes} 2>/dev/null | sort -r | head -1)
+    recent_backups=$(find "$backup_dir" -maxdepth 1 -name "database_backup_[0-9]*.json" -mmin -${max_age_minutes} 2>/dev/null | sort -r | head -1)
 
     if [ -z "$recent_backups" ]; then
         # Find the most recent backup to show how old it is
         local latest_backup
-        latest_backup=$(ls -t "$backup_dir"/database_backup_*.json 2>/dev/null | head -1)
+        latest_backup=$(ls -t "$backup_dir"/database_backup_[0-9]*.json 2>/dev/null | head -1)
         if [ -n "$latest_backup" ]; then
             local file_age_seconds
             file_age_seconds=$(( $(date +%s) - $(stat -f %m "$latest_backup") ))

--- a/scripts/deploy-local-redis.sh
+++ b/scripts/deploy-local-redis.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+##############################################################################
+# Deploy Redis to Local K3s (Rancher Desktop)
+##############################################################################
+# Deploys Redis for local development caching.
+#
+# Usage:
+#   ./scripts/deploy-local-redis.sh          # Deploy Redis
+#   ./scripts/deploy-local-redis.sh --delete # Remove Redis deployment
+#
+# Prerequisites:
+#   - Rancher Desktop running with Kubernetes enabled
+#   - kubectl configured with rancher-desktop context
+#   - helm installed
+##############################################################################
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+NAMESPACE="missing-table"
+RELEASE_NAME="missing-table"
+K8S_CONTEXT="rancher-desktop"
+
+# Parse arguments
+DELETE_MODE=false
+for arg in "$@"; do
+    case $arg in
+        --delete)
+            DELETE_MODE=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--delete]"
+            echo ""
+            echo "Options:"
+            echo "  --delete    Remove Redis deployment from k3s"
+            echo "  --help      Show this help message"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown argument: $arg${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Local Redis Deployment${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+##############################################################################
+# Check prerequisites
+##############################################################################
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if ! command -v kubectl &> /dev/null; then
+    echo -e "${RED}kubectl not found. Please install kubectl.${NC}"
+    exit 1
+fi
+
+if ! command -v helm &> /dev/null; then
+    echo -e "${RED}helm not found. Please install helm: brew install helm${NC}"
+    exit 1
+fi
+
+# Check if rancher-desktop context exists
+if ! kubectl config get-contexts "$K8S_CONTEXT" &> /dev/null; then
+    echo -e "${RED}Context '$K8S_CONTEXT' not found.${NC}"
+    echo -e "${YELLOW}Is Rancher Desktop running with Kubernetes enabled?${NC}"
+    exit 1
+fi
+
+# Check if cluster is accessible
+if ! kubectl --context="$K8S_CONTEXT" cluster-info &> /dev/null; then
+    echo -e "${RED}Cannot connect to cluster. Is Rancher Desktop running?${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Prerequisites OK${NC}"
+echo ""
+
+##############################################################################
+# Delete mode
+##############################################################################
+if [ "$DELETE_MODE" = true ]; then
+    echo -e "${YELLOW}Removing Redis deployment...${NC}"
+
+    # Uninstall helm release
+    if helm --kube-context="$K8S_CONTEXT" list -n "$NAMESPACE" | grep -q "$RELEASE_NAME"; then
+        helm --kube-context="$K8S_CONTEXT" uninstall "$RELEASE_NAME" -n "$NAMESPACE"
+        echo -e "${GREEN}Helm release uninstalled${NC}"
+    else
+        echo -e "${YELLOW}Helm release not found, skipping${NC}"
+    fi
+
+    # Delete PVC (optional - keeps data if not deleted)
+    read -p "Delete persistent volume claim (loses cached data)? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        kubectl --context="$K8S_CONTEXT" delete pvc -n "$NAMESPACE" -l app.kubernetes.io/component=redis --ignore-not-found
+        echo -e "${GREEN}PVC deleted${NC}"
+    fi
+
+    echo -e "${GREEN}Redis deployment removed${NC}"
+    exit 0
+fi
+
+##############################################################################
+# Deploy Redis
+##############################################################################
+echo -e "${BLUE}Deploying Redis to local K3s...${NC}"
+
+# Create namespace if it doesn't exist
+kubectl --context="$K8S_CONTEXT" create namespace "$NAMESPACE" --dry-run=client -o yaml | \
+    kubectl --context="$K8S_CONTEXT" apply -f -
+
+# Deploy using helm
+# Only enable Redis, disable other components
+helm --kube-context="$K8S_CONTEXT" upgrade --install "$RELEASE_NAME" "$PROJECT_ROOT/helm/missing-table" \
+    --namespace "$NAMESPACE" \
+    --set redis.enabled=true \
+    --set redis.persistence.storageClass=local-path \
+    --set backend.replicaCount=0 \
+    --set frontend.replicaCount=0 \
+    --set celeryWorker.enabled=false \
+    --wait \
+    --timeout 2m
+
+echo -e "${GREEN}Helm deployment complete${NC}"
+echo ""
+
+##############################################################################
+# Wait for Redis to be ready
+##############################################################################
+echo -e "${YELLOW}Waiting for Redis pod to be ready...${NC}"
+
+kubectl --context="$K8S_CONTEXT" wait --for=condition=ready pod \
+    -l app.kubernetes.io/component=redis \
+    -n "$NAMESPACE" \
+    --timeout=120s
+
+echo -e "${GREEN}Redis pod is ready${NC}"
+echo ""
+
+##############################################################################
+# Verify deployment
+##############################################################################
+echo -e "${BLUE}Verifying Redis deployment...${NC}"
+
+# Test Redis connection
+if kubectl --context="$K8S_CONTEXT" exec -n "$NAMESPACE" svc/missing-table-redis -- redis-cli PING | grep -q "PONG"; then
+    echo -e "${GREEN}Redis is responding to PING${NC}"
+else
+    echo -e "${RED}Redis is not responding${NC}"
+    exit 1
+fi
+
+echo ""
+
+##############################################################################
+# Summary
+##############################################################################
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}Redis Deployment Complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo -e "${BLUE}Redis is running in:${NC}"
+echo "  Namespace: $NAMESPACE"
+echo "  Service:   missing-table-redis"
+echo "  Port:      6379"
+echo ""
+echo -e "${BLUE}To access Redis from your local machine:${NC}"
+echo "  kubectl port-forward -n $NAMESPACE svc/missing-table-redis 6379:6379"
+echo ""
+echo -e "${BLUE}Or use the service script which handles port-forward automatically:${NC}"
+echo "  ./missing-table.sh start"
+echo ""
+echo -e "${BLUE}Useful Redis commands:${NC}"
+echo "  # Test connection"
+echo "  kubectl exec -n $NAMESPACE svc/missing-table-redis -- redis-cli PING"
+echo ""
+echo "  # Flush all cache"
+echo "  kubectl exec -n $NAMESPACE svc/missing-table-redis -- redis-cli FLUSHALL"
+echo ""
+echo "  # Check cached keys"
+echo "  kubectl exec -n $NAMESPACE svc/missing-table-redis -- redis-cli KEYS '*'"
+echo ""

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -49,8 +49,8 @@ get_base_url() {
     local env=$1
 
     case "$env" in
-        dev)
-            echo "https://dev.missingtable.com"
+        local)
+            echo "http://localhost:8080"
             ;;
         prod|production)
             echo "https://missingtable.com"
@@ -64,14 +64,14 @@ get_base_url() {
             echo "Usage: $0 <environment|url>"
             echo ""
             echo "Environments:"
-            echo "  dev         - Dev environment (https://dev.missingtable.com)"
+            echo "  local       - Local environment (http://localhost:8080)"
             echo "  prod        - Production environment (https://missingtable.com)"
             echo "  <url>       - Custom URL (http://... or https://...)"
             echo ""
             echo "Examples:"
-            echo "  $0 dev"
+            echo "  $0 local"
             echo "  $0 prod"
-            echo "  $0 https://dev.missingtable.com"
+            echo "  $0 https://missingtable.com"
             exit 1
             ;;
     esac
@@ -236,7 +236,7 @@ interactive_mode() {
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
     echo "Select environment to check:"
-    echo "  1) Dev (https://dev.missingtable.com)"
+    echo "  1) Local (http://localhost:8080)"
     echo "  2) Production (https://missingtable.com)"
     echo "  3) Custom URL"
     echo "  4) Exit"
@@ -245,7 +245,7 @@ interactive_mode() {
 
     case $choice in
         1)
-            ENVIRONMENT="dev"
+            ENVIRONMENT="local"
             ;;
         2)
             ENVIRONMENT="prod"

--- a/scripts/setup-local-db.sh
+++ b/scripts/setup-local-db.sh
@@ -7,11 +7,19 @@
 # What it does:
 #   1. Resets local Supabase database (applies schema.sql + seed.sql)
 #   2. Optionally restores match/team data from a backup
-#   3. Seeds test users (tom, tom_ifa, tom_ifa_fan, tom_club)
+#   3. Optionally syncs users from prod (with role-based passwords)
+#   4. Seeds test users (tom, tom_ifa, tom_ifa_fan, tom_club)
 #
 # Usage:
 #   ./scripts/setup-local-db.sh              # Reset + seed reference data + test users
 #   ./scripts/setup-local-db.sh --restore    # Also restore match/team data from backup
+#   ./scripts/setup-local-db.sh --from-prod  # Full refresh: backup + restore + sync users
+#
+# User passwords when synced from prod (based on role):
+#   admin        -> admin123
+#   team_manager -> team123
+#   team_player  -> play123
+#   team_fan     -> fan123
 #
 # Prerequisites:
 #   - Local Supabase must be running: cd supabase-local && npx supabase start
@@ -32,24 +40,36 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 RESTORE_DATA=false
+FROM_PROD=false
 
 # Parse arguments
 for arg in "$@"; do
     case $arg in
+        --from-prod)
+            FROM_PROD=true
+            RESTORE_DATA=true  # --from-prod implies --restore
+            ;;
         --restore)
             RESTORE_DATA=true
             ;;
         --help|-h)
-            echo "Usage: $0 [--restore]"
+            echo "Usage: $0 [--restore] [--from-prod]"
             echo ""
             echo "Options:"
             echo "  --restore    Restore match/team data from backup after schema reset"
+            echo "  --from-prod  Full refresh from prod: backup, restore data, AND sync users"
             echo "  --help       Show this help message"
+            echo ""
+            echo "User passwords (when synced from prod):"
+            echo "  admin        -> admin123"
+            echo "  team_manager -> team123"
+            echo "  team_player  -> play123"
+            echo "  team_fan     -> fan123"
             exit 0
             ;;
         *)
             echo -e "${RED}Unknown argument: $arg${NC}"
-            echo "Usage: $0 [--restore]"
+            echo "Usage: $0 [--restore] [--from-prod]"
             exit 1
             ;;
     esac
@@ -58,7 +78,21 @@ done
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Local Database Setup${NC}"
 echo -e "${BLUE}========================================${NC}"
+if [ "$FROM_PROD" = true ]; then
+    echo -e "${YELLOW}Mode: Fresh backup from prod + restore${NC}"
+fi
 echo ""
+
+##############################################################################
+# Step 0: If --from-prod, create fresh backup first
+##############################################################################
+if [ "$FROM_PROD" = true ]; then
+    echo -e "${BLUE}Step 0: Creating fresh backup from prod...${NC}"
+    cd "$PROJECT_ROOT"
+    APP_ENV=prod bash "$SCRIPT_DIR/db_tools.sh" backup
+    echo -e "${GREEN}Backup from prod complete${NC}"
+    echo ""
+fi
 
 ##############################################################################
 # Step 1: Check prerequisites
@@ -75,12 +109,21 @@ if ! command -v uv &> /dev/null; then
     exit 1
 fi
 
-# Check if Supabase is running
-if ! PGPASSWORD=postgres psql -h 127.0.0.1 -p 54332 -U postgres -d postgres -c "SELECT 1" &>/dev/null; then
+# Check if Supabase is running using docker exec (works without local psql)
+DB_CONTAINER=""
+for container in "supabase_db_supabase-local" "supabase_db_missing-table" "supabase_db_backend"; do
+    if docker exec "$container" psql -U postgres -c "SELECT 1" &>/dev/null; then
+        DB_CONTAINER="$container"
+        break
+    fi
+done
+
+if [ -z "$DB_CONTAINER" ]; then
     echo -e "${RED}Local Supabase is not running.${NC}"
     echo -e "${YELLOW}Start it with: cd supabase-local && npx supabase start${NC}"
     exit 1
 fi
+echo -e "${GREEN}Found Supabase container: $DB_CONTAINER${NC}"
 
 echo -e "${GREEN}Prerequisites OK${NC}"
 echo ""
@@ -88,35 +131,45 @@ echo ""
 ##############################################################################
 # Step 2: Check for recent backup (less than 4 hours old)
 ##############################################################################
-echo -e "${YELLOW}Checking for recent backup...${NC}"
-
-BACKUP_DIR="$PROJECT_ROOT/backups"
-MAX_AGE_MINUTES=240  # 4 hours
-
-recent_backup=""
-if [ -d "$BACKUP_DIR" ]; then
-    recent_backup=$(find "$BACKUP_DIR" -maxdepth 1 -name "database_backup_*.json" -mmin -${MAX_AGE_MINUTES} 2>/dev/null | sort -r | head -1)
-fi
-
-if [ -z "$recent_backup" ]; then
-    echo -e "${RED}No backup less than 4 hours old found. Aborting reset.${NC}"
-    latest_backup=$(ls -t "$BACKUP_DIR"/database_backup_*.json 2>/dev/null | head -1)
-    if [ -n "$latest_backup" ]; then
-        file_age_seconds=$(( $(date +%s) - $(stat -f %m "$latest_backup") ))
-        hours=$(( file_age_seconds / 3600 ))
-        minutes=$(( (file_age_seconds % 3600) / 60 ))
-        echo -e "${RED}Latest backup is ${hours}h ${minutes}m old: $(basename "$latest_backup")${NC}"
-    else
-        echo -e "${RED}No backups found at all in $BACKUP_DIR${NC}"
-    fi
+# Skip this check if --from-prod was used (we just created a fresh backup)
+if [ "$FROM_PROD" = true ]; then
+    echo -e "${GREEN}Fresh backup created from prod - skipping age check${NC}"
     echo ""
-    echo "Create a backup first:"
-    echo "  ./scripts/db_tools.sh backup"
-    exit 1
-fi
+else
+    echo -e "${YELLOW}Checking for recent backup...${NC}"
 
-echo -e "${GREEN}Recent backup found: $(basename "$recent_backup")${NC}"
-echo ""
+    BACKUP_DIR="$PROJECT_ROOT/backups"
+    MAX_AGE_MINUTES=240  # 4 hours
+
+    # Only match timestamp-formatted backups (database_backup_[0-9]*.json)
+    recent_backup=""
+    if [ -d "$BACKUP_DIR" ]; then
+        recent_backup=$(find "$BACKUP_DIR" -maxdepth 1 -name "database_backup_[0-9]*.json" -mmin -${MAX_AGE_MINUTES} 2>/dev/null | sort -r | head -1)
+    fi
+
+    if [ -z "$recent_backup" ]; then
+        echo -e "${RED}No backup less than 4 hours old found. Aborting reset.${NC}"
+        latest_backup=$(ls -t "$BACKUP_DIR"/database_backup_[0-9]*.json 2>/dev/null | head -1)
+        if [ -n "$latest_backup" ]; then
+            file_age_seconds=$(( $(date +%s) - $(stat -f %m "$latest_backup") ))
+            hours=$(( file_age_seconds / 3600 ))
+            minutes=$(( (file_age_seconds % 3600) / 60 ))
+            echo -e "${RED}Latest backup is ${hours}h ${minutes}m old: $(basename "$latest_backup")${NC}"
+        else
+            echo -e "${RED}No backups found at all in $BACKUP_DIR${NC}"
+        fi
+        echo ""
+        echo "Create a backup first:"
+        echo "  ./scripts/db_tools.sh backup"
+        echo ""
+        echo "Or use --from-prod to backup from production:"
+        echo "  $0 --from-prod"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Recent backup found: $(basename "$recent_backup")${NC}"
+    echo ""
+fi
 
 ##############################################################################
 # Step 3: Reset database (applies schema + seed)
@@ -134,12 +187,13 @@ if [ "$RESTORE_DATA" = true ]; then
     echo -e "${BLUE}Step 2: Restoring match/team data from backup...${NC}"
     cd "$PROJECT_ROOT"
     if [ -f "$SCRIPT_DIR/db_tools.sh" ]; then
-        bash "$SCRIPT_DIR/db_tools.sh" restore
+        # CRITICAL: Explicitly set APP_ENV=local to prevent accidental prod writes
+        APP_ENV=local bash "$SCRIPT_DIR/db_tools.sh" restore
         echo -e "${GREEN}Data restore complete${NC}"
 
         # Fix sport_type for Futsal leagues (backup may not have this set)
         echo -e "${YELLOW}Setting sport_type for Futsal leagues...${NC}"
-        PGPASSWORD=postgres psql -h 127.0.0.1 -p 54332 -U postgres -d postgres \
+        docker exec "$DB_CONTAINER" psql -U postgres -d postgres \
             -c "UPDATE public.leagues SET sport_type = 'futsal' WHERE LOWER(name) LIKE '%futsal%' AND sport_type != 'futsal';" \
             2>/dev/null && echo -e "${GREEN}Futsal leagues updated${NC}" || echo -e "${YELLOW}Could not update Futsal leagues${NC}"
     else
@@ -174,9 +228,28 @@ fi
 echo ""
 
 ##############################################################################
-# Step 4: Seed test users
+# Step 4: Sync users from prod (only when --from-prod)
 ##############################################################################
-echo -e "${BLUE}Step 4: Seeding test users...${NC}"
+if [ "$FROM_PROD" = true ]; then
+    echo -e "${BLUE}Step 4: Syncing users from prod...${NC}"
+    cd "$PROJECT_ROOT/backend"
+    if [ -f "scripts/sync_users_to_local.py" ]; then
+        # Sync all non-test users from prod with force to overwrite existing
+        uv run python scripts/sync_users_to_local.py sync --from prod --force
+        echo -e "${GREEN}Users synced from prod${NC}"
+    else
+        echo -e "${YELLOW}sync_users_to_local.py not found, skipping user sync${NC}"
+    fi
+    echo ""
+else
+    echo -e "${YELLOW}Step 4: Skipping user sync (only with --from-prod)${NC}"
+    echo ""
+fi
+
+##############################################################################
+# Step 5: Seed test users
+##############################################################################
+echo -e "${BLUE}Step 5: Seeding test users...${NC}"
 cd "$PROJECT_ROOT"
 if [ -f "$SCRIPT_DIR/seed_test_users.sh" ]; then
     bash "$SCRIPT_DIR/seed_test_users.sh" local
@@ -198,6 +271,9 @@ echo "  - Schema applied (all tables, functions, RLS policies)"
 echo "  - Reference data seeded (age_groups, seasons, match_types, leagues, divisions)"
 if [ "$RESTORE_DATA" = true ]; then
     echo "  - Match/team data restored from backup"
+fi
+if [ "$FROM_PROD" = true ]; then
+    echo "  - Users synced from prod (with role-based passwords)"
 fi
 echo "  - Test users created (tom, tom_ifa, tom_ifa_fan, tom_club)"
 echo ""

--- a/scripts/setup_environment_users.sh
+++ b/scripts/setup_environment_users.sh
@@ -39,11 +39,10 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # Check if environment is specified
 if [ -z "$1" ]; then
     print_error "Usage: $0 <environment>"
-    echo "  Environments: local, dev, prod"
+    echo "  Environments: local, prod"
     echo ""
     echo "Example:"
     echo "  $0 local   # Setup users for local development"
-    echo "  $0 dev     # Setup users for cloud dev environment"
     echo "  $0 prod    # Setup users for production environment"
     exit 1
 fi
@@ -51,9 +50,9 @@ fi
 ENVIRONMENT=$1
 
 # Validate environment
-if [[ ! "$ENVIRONMENT" =~ ^(local|dev|prod)$ ]]; then
+if [[ ! "$ENVIRONMENT" =~ ^(local|prod)$ ]]; then
     print_error "Invalid environment: $ENVIRONMENT"
-    echo "  Valid environments: local, dev, prod"
+    echo "  Valid environments: local, prod"
     exit 1
 fi
 

--- a/setup-cloud-credentials.sh
+++ b/setup-cloud-credentials.sh
@@ -32,9 +32,9 @@ echo "This script will help you configure your cloud Supabase credentials."
 echo "You'll need to get these values from your Supabase dashboard."
 echo ""
 
-# Check if .env.dev files exist
-backend_env="$SCRIPT_DIR/backend/.env.dev"
-frontend_env="$SCRIPT_DIR/frontend/.env.dev"
+# Check if .env.prod files exist
+backend_env="$SCRIPT_DIR/backend/.env.prod"
+frontend_env="$SCRIPT_DIR/frontend/.env.prod"
 
 if [ ! -f "$backend_env" ] || [ ! -f "$frontend_env" ]; then
     print_error "Environment files not found. Please run the migration setup first."
@@ -95,7 +95,7 @@ echo "Enter your Database Connection String (URI format):"
 echo "Should look like: postgresql://postgres.[project-id]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres"
 read -p "Database URL: " database_url
 
-# Update backend .env.dev
+# Update backend .env.prod
 echo ""
 print_header "Updating Backend Configuration"
 
@@ -115,7 +115,7 @@ rm "$backend_env.tmp"
 
 print_success "Backend configuration updated"
 
-# Update frontend .env.dev
+# Update frontend .env.prod
 print_header "Updating Frontend Configuration"
 
 # Create backup
@@ -138,7 +138,7 @@ print_header "Testing Configuration"
 echo "Testing Supabase connection..."
 cd "$SCRIPT_DIR/backend" || exit 1
 
-export APP_ENV=dev
+export APP_ENV=prod
 
 if uv run python -c "
 from dao.enhanced_data_access_fixed import SupabaseConnection
@@ -158,7 +158,7 @@ echo ""
 print_header "Next Steps"
 
 echo "1. Apply database migrations to your cloud database:"
-echo "   ./switch-env.sh dev"
+echo "   ./switch-env.sh prod"
 echo "   npx supabase db push"
 echo ""
 echo "2. Migrate your data to the cloud:"
@@ -173,6 +173,6 @@ print_success "Cloud credentials configuration complete!"
 
 echo ""
 print_warning "Security Note:"
-echo "- Your credentials are now stored in .env.dev files"
+echo "- Your credentials are now stored in .env.prod files"
 echo "- These files should NOT be committed to git"
 echo "- Backups of original files were created with .backup suffix"

--- a/switch-env.sh
+++ b/switch-env.sh
@@ -158,8 +158,8 @@ show_status() {
     # Check if Supabase is running for local env
     if [ "$current_env" = "local" ]; then
         echo ""
-        if curl -s http://127.0.0.1:54331/health > /dev/null 2>&1; then
-            print_success "  Local Supabase is running on port 54331"
+        if curl -s http://127.0.0.1:54321/health > /dev/null 2>&1; then
+            print_success "  Local Supabase is running on port 54321"
         else
             print_warning "  Local Supabase is not running. Run 'npx supabase start' to start it."
         fi


### PR DESCRIPTION
## Summary

- **Single-command local DB refresh**: `./scripts/setup-local-db.sh --from-prod` backs up prod, resets local schema, restores data, flushes Redis, syncs users (with role-based passwords), and seeds test users
- **Fix backup/restore reliability**: Correct glob patterns, FK ordering, missing tables, APP_ENV guard to prevent accidental prod writes
- **Add backup safety check**: Warns when database has tables not covered by the backup list
- **Fix user sync pagination**: Supabase `list_users()` defaults to 50; now paginates to get all users
- **Consolidate .env.dev → .env.prod** references across docs and scripts
- **Document MyClub bug**: `player_team_history` vs `user_profiles.team_id` disconnect (see `docs/bugs/BUG-myclub-team-assignment.md`)

## Test plan

- [ ] Run `./scripts/setup-local-db.sh --from-prod` end-to-end
- [ ] Verify backup picks latest timestamped file (not old manually-named ones)
- [ ] Verify restore clears tables in correct FK dependency order
- [ ] Verify all tables are included in backup (check for warnings about missing tables)
- [ ] Verify users are synced and can log in with role-based passwords
- [ ] Verify APP_ENV=local guard prevents accidental prod writes during restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)