### PR TITLE
docs: Update DOKS references to LKE and values-prod.yaml

### DIFF
--- a/.claude/skills/commit-pr/SKILL.md
+++ b/.claude/skills/commit-pr/SKILL.md
@@ -13,8 +13,8 @@ Create commits and pull requests with awareness of the GitOps deployment pipelin
 **Merging a PR to main triggers automatic deployment:**
 
 1. GitHub Actions builds Docker images → pushes to GHCR
-2. GHA updates `helm/missing-table/values-doks.yaml` with new image tags
-3. Argo CD detects helm changes → syncs to DOKS cluster (~2-3 min)
+2. GHA updates `helm/missing-table/values-prod.yaml` with new image tags
+3. Argo CD detects helm changes → syncs to production cluster (~2-3 min)
 
 **No manual build/push needed.** Just merge the PR and Argo handles deployment.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           docker push ghcr.io/silverbeer/missing-table-frontend:${SHORT_SHA}
 
   # GitOps: Update Helm values with new image tags
-  # ArgoCD watches the repo and syncs changes to DOKS
+  # ArgoCD watches the repo and syncs changes to production
   update-helm-values:
     needs: build-and-push
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,7 @@ terraform/**/.terraform.tfstate.lock.info
 # Keep example files (*.example) but ignore actual values files
 helm/**/values-*.yaml
 !helm/**/values-*.yaml.example
-!helm/**/values-doks.yaml
+!helm/**/values-prod.yaml
 
 # Frontend build configuration
 # Keep example files but ignore actual build env files

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -374,7 +374,7 @@
         "filename": "docs/01-getting-started/local-development.md",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 91
       }
     ],
     "docs/02-development/MCP_SETUP.md": [
@@ -384,6 +384,15 @@
         "hashed_secret": "981eb7e146cab5b17b4c7f5f12af441d36d0cc36",
         "is_verified": false,
         "line_number": 21
+      }
+    ],
+    "docs/02-development/local-k3s-with-redis.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/02-development/local-k3s-with-redis.md",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 139
       }
     ],
     "docs/03-architecture/authentication.md": [
@@ -691,7 +700,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "helm/missing-table/values-prod.yaml",
-        "hashed_secret": "697dcad811043518dbf76a4ee1a186fdaee7571c",
+        "hashed_secret": "23da62dc837550f6b11e8593d4b76bc43e2a6a6d",
         "is_verified": false,
         "line_number": 10
       }
@@ -820,5 +829,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-29T02:00:14Z"
+  "generated_at": "2026-02-04T15:00:39Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,9 @@ docker-compose down
 
 ### Helm/Kubernetes
 ```bash
-# Production deploys via GitOps (ArgoCD watches values-doks.yaml)
+# Production deploys via GitOps (ArgoCD watches values-prod.yaml)
 # Manual helm commands for debugging only:
-helm upgrade missing-table ./missing-table --namespace missing-table -f ./missing-table/values-doks.yaml
+helm upgrade missing-table ./missing-table --namespace missing-table -f ./missing-table/values-prod.yaml
 ```
 
 **Full deployment docs**: [docs/05-deployment/README.md](docs/05-deployment/README.md)
@@ -165,20 +165,20 @@ helm upgrade missing-table ./missing-table --namespace missing-table -f ./missin
 
 ## Production Environment
 
-**DOKS (DigitalOcean Kubernetes Service)** - Current production platform.
+**LKE (Linode Kubernetes Engine)** - Current production platform.
 
 | Component | Details |
 |-----------|---------|
-| **Cluster** | DOKS managed by Terraform in [missingtable-platform-bootstrap](https://github.com/silverbeer/missingtable-platform-bootstrap) |
-| **GitOps** | ArgoCD watches `helm/missing-table/values-doks.yaml` |
+| **Cluster** | LKE managed by Terraform in [missingtable-platform-bootstrap](https://github.com/silverbeer/missingtable-platform-bootstrap) |
+| **GitOps** | ArgoCD watches `helm/missing-table/values-prod.yaml` |
 | **Images** | GHCR (`ghcr.io/silverbeer/missing-table-backend/frontend`) |
 | **Secrets** | External Secrets Operator → AWS Secrets Manager |
 | **Domains** | missingtable.com, www.missingtable.com, api.missingtable.com |
 | **Database** | Supabase (cloud-hosted) |
 
-**CI/CD Flow**: Push to main → CI builds images → Updates `values-doks.yaml` → ArgoCD syncs to DOKS
+**CI/CD Flow**: Push to main → CI builds images → Updates `values-prod.yaml` → ArgoCD syncs to LKE
 
-**Historical note**: GKE was shut down 2025-12-07, migrated to DOKS December 2025.
+**Historical note**: GKE shut down 2025-12-07, migrated to DOKS December 2025, migrated to LKE February 2026.
 
 ---
 
@@ -308,4 +308,4 @@ Backend-centered auth resolves k8s networking issues. All Supabase credentials s
 
 ---
 
-**Last Updated**: 2026-01-30
+**Last Updated**: 2026-02-04

--- a/docs/07-operations/DOKS_PRODUCTION.md
+++ b/docs/07-operations/DOKS_PRODUCTION.md
@@ -1,10 +1,10 @@
-# DOKS Production Environment
+# Production Environment
 
 ## Overview
 
-Missing Table production runs on **DigitalOcean Kubernetes Service (DOKS)**, managed via GitOps with ArgoCD.
+Missing Table production runs on **Linode Kubernetes Engine (LKE)**, managed via GitOps with ArgoCD.
 
-**Migrated from GKE**: December 2025 (see [GKE_SHUTDOWN_2025-12-07.md](./GKE_SHUTDOWN_2025-12-07.md) for historical reference)
+**Migration history**: GKE (shutdown 2025-12-07) → DOKS (December 2025) → LKE (February 2026)
 
 ---
 
@@ -15,12 +15,12 @@ GitHub (main branch)
     ↓
 CI Workflow (.github/workflows/ci.yml)
     ↓ builds images, pushes to GHCR
-    ↓ updates helm/missing-table/values-doks.yaml
+    ↓ updates helm/missing-table/values-prod.yaml
     ↓
-ArgoCD (watches values-doks.yaml)
+ArgoCD (watches values-prod.yaml)
     ↓ syncs to cluster
     ↓
-DOKS Cluster
+LKE Cluster
     ├── missing-table namespace
     │   ├── backend (FastAPI)
     │   ├── frontend (Vue/Nginx)
@@ -37,7 +37,7 @@ DOKS Cluster
 | Repository | Purpose |
 |------------|---------|
 | **missing-table** (this repo) | Application code, Helm charts, CI/CD |
-| **[missingtable-platform-bootstrap](https://github.com/silverbeer/missingtable-platform-bootstrap)** | Terraform IaC, ArgoCD config, DOKS provisioning |
+| **[missingtable-platform-bootstrap](https://github.com/silverbeer/missingtable-platform-bootstrap)** | Terraform IaC, ArgoCD config, LKE provisioning |
 
 ---
 
@@ -45,7 +45,7 @@ DOKS Cluster
 
 | File | Purpose |
 |------|---------|
-| `helm/missing-table/values-doks.yaml` | DOKS-specific Helm values (updated by CI) |
+| `helm/missing-table/values-prod.yaml` | Production Helm values (updated by CI) |
 | `.github/workflows/ci.yml` | CI pipeline that builds and updates tags |
 
 ---
@@ -82,15 +82,12 @@ Secrets include:
 
 1. Merge PR to `main`
 2. CI builds images, pushes to GHCR
-3. CI updates `values-doks.yaml` with new image tags
-4. ArgoCD detects changes and syncs to DOKS
+3. CI updates `values-prod.yaml` with new image tags
+4. ArgoCD detects changes and syncs to LKE
 
 ### Manual (Emergency only)
 
 ```bash
-# Get cluster credentials (requires doctl CLI configured)
-doctl kubernetes cluster kubeconfig save <cluster-name>
-
 # Check current state
 kubectl get pods -n missing-table
 kubectl get ingress -n missing-table
@@ -132,7 +129,7 @@ curl https://missingtable.com/
 
 ## Version Information
 
-Current version info is stored in `values-doks.yaml`:
+Current version info is stored in `values-prod.yaml`:
 
 ```yaml
 version: "X.Y.Z"     # Semantic version

--- a/helm/README.md
+++ b/helm/README.md
@@ -160,7 +160,7 @@ This chart is designed to work with ArgoCD for GitOps workflows. ArgoCD is manag
 
 - **ArgoCD installation**: Managed via Helm in Terraform (`clouds/digitalocean/environments/dev/main.tf`)
 - **Application manifests**: Defined as Terraform `kubectl_manifest` resources
-- **GitOps workflow**: ArgoCD syncs from `main` branch using `values-doks.yaml`
+- **GitOps workflow**: ArgoCD syncs from `main` branch using `values-prod.yaml`
 
 ### Benefits of Helm + ArgoCD
 

--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -1,4 +1,4 @@
-# DOKS environment configuration
+# Production environment configuration (LKE)
 # Secrets come from External Secrets Operator (AWS Secrets Manager)
 # Image tags and version info updated by CI workflow
 

--- a/readme.md
+++ b/readme.md
@@ -372,7 +372,7 @@ This repository contains:
 - **100% Infrastructure as Code** - All infrastructure defined in Terraform/OpenTofu
 - **ArgoCD** - GitOps-based continuous deployment
 - **Grafana Stack** - Full observability (Loki, Tempo, Grafana dashboards)
-- **DigitalOcean Kubernetes** - Production Kubernetes cluster
+- **Linode Kubernetes (LKE)** - Production Kubernetes cluster
 - **Helm Charts** - Application deployment configurations
 
 **Why separate repos?**


### PR DESCRIPTION
## Summary

- Updated all references from `values-doks.yaml` to `values-prod.yaml` (the file that actually exists and CI updates)
- Updated cloud provider references from DOKS (DigitalOcean) to LKE (Linode)
- Updated `.gitignore` whitelist entry
- Updated production operations doc content and values-prod.yaml header comment

### Files changed

- `CLAUDE.md` - Production environment section, helm commands
- `.claude/skills/commit-pr/SKILL.md` - Deployment pipeline description
- `.github/workflows/ci.yml` - Comment
- `.gitignore` - Whitelist entry
- `helm/README.md` - GitOps workflow reference
- `helm/missing-table/values-prod.yaml` - Header comment
- `readme.md` - Platform reference
- `docs/07-operations/DOKS_PRODUCTION.md` - Full content update

## Test plan

- [ ] Verify CI still updates `values-prod.yaml` correctly after merge
- [ ] No functional code changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)