### PR TITLE
fix: Filter unrelated clubs/leagues for non-admin users

### DIFF
--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -322,6 +322,29 @@ export default {
       }
     };
 
+    // Filter leagues to only those where the user's club has teams
+    const filterLeaguesByClub = () => {
+      const clubId = authStore.userClubId.value;
+      if (authStore.isAdmin.value || !clubId) return;
+
+      const clubLeagueIds = new Set(
+        teams.value
+          .filter(t => t.club_id === clubId && t.league_id)
+          .map(t => t.league_id)
+      );
+
+      if (clubLeagueIds.size > 0) {
+        leagues.value = leagues.value.filter(l => clubLeagueIds.has(l.id));
+        // Re-select default if current selection was filtered out
+        if (!leagues.value.find(l => l.id === selectedLeagueId.value)) {
+          const homegrown = leagues.value.find(l => l.name === 'Homegrown');
+          selectedLeagueId.value = homegrown
+            ? homegrown.id
+            : leagues.value[0]?.id || null;
+        }
+      }
+    };
+
     const filterDivisionsByLeague = () => {
       console.log('Filtering divisions by league:', {
         selectedLeagueId: selectedLeagueId.value,
@@ -489,6 +512,10 @@ export default {
         fetchSeasons(),
         fetchTeams(),
       ]);
+
+      // Filter leagues to user's club before selecting defaults
+      filterLeaguesByClub();
+
       // Fetch divisions after leagues are loaded so we can filter by default league
       await fetchDivisions();
 

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -86,6 +86,14 @@ export const useAuthStore = () => {
       if (!profile.team && profile.current_teams?.length > 0) {
         profile.team = profile.current_teams[0].team;
       }
+      // Derive club_id from current_teams for roster-managed players
+      // whose user_profiles.club_id was never set
+      if (!profile.club_id && profile.current_teams?.length > 0) {
+        const club = profile.current_teams[0].team?.club;
+        if (club?.id) {
+          profile.club_id = club.id;
+        }
+      }
       localStorage.setItem('auth_profile', JSON.stringify(profile));
     } else {
       localStorage.removeItem('auth_profile');

--- a/supabase-local/migrations/20260204000000_backfill_player_club_ids.sql
+++ b/supabase-local/migrations/20260204000000_backfill_player_club_ids.sql
@@ -1,0 +1,13 @@
+-- Backfill club_id for roster-managed players
+-- Players added via the roster manager (POST /api/admin/players/{player_id}/teams)
+-- get player_team_history entries but their user_profiles.club_id is never set.
+-- This causes them to see unrelated clubs/leagues in the UI.
+
+UPDATE user_profiles up
+SET club_id = t.club_id
+FROM player_team_history pth
+JOIN teams t ON pth.team_id = t.id
+WHERE up.id = pth.player_id
+  AND up.club_id IS NULL
+  AND pth.is_current = true
+  AND t.club_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Non-admin users (e.g. roster-managed player `gabe35`) were seeing **all** leagues and clubs globally (including TSC League 1, tsc_ci_league, Toms Soccer Club) instead of only those relevant to their club (IFA Club)
- Root cause: roster assignment endpoint (`POST /api/admin/players/{player_id}/teams`) never set `user_profiles.club_id`, and frontend had no club-based filtering
- Adds database migration to backfill `club_id`, backend fix for future assignments, frontend auth store derivation, and league/club filtering in Table and Matches tabs

## Changes

| File | Change |
|------|--------|
| `supabase-local/migrations/20260204000000_backfill_player_club_ids.sql` | Backfill `club_id` from `player_team_history` for roster-managed players |
| `backend/app.py` | Set `club_id` on `user_profiles` when assigning player to team |
| `frontend/src/stores/auth.js` | Derive `club_id` from `current_teams[0].team.club` when null |
| `frontend/src/components/LeagueTable.vue` | Filter leagues to only those where user's club has teams |
| `frontend/src/components/MatchesView.vue` | Filter club selector to clubs sharing leagues with user's club |

Admins continue to see all leagues and clubs (no filtering applied).

## Test plan

- [ ] Run migration on local DB, verify `SELECT club_id FROM user_profiles WHERE username = 'gabe35'` returns IFA Club's ID
- [ ] Login as `gabe35`: Table tab should only show Homegrown, Academy, Kick Futsal leagues (NOT TSC League 1, tsc_ci_league)
- [ ] Login as `gabe35`: Matches > My Club club selector should NOT show Toms Soccer Club
- [ ] Login as admin: should still see ALL leagues and ALL clubs
- [ ] Frontend lint passes, backend ruff check passes
- [ ] All 150 frontend tests pass, backend tests pass (2 pre-existing failures in test_team_dao.py unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)