### PR TITLE
feat: Playoff goals leaderboard with match type filter

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2823,15 +2823,17 @@ async def get_goals_leaderboard(
     league_id: int | None = Query(None, description="Filter by league ID"),
     division_id: int | None = Query(None, description="Filter by division ID"),
     age_group_id: int | None = Query(None, description="Filter by age group ID"),
+    match_type_id: int | None = Query(None, description="Filter by match type ID (e.g. 4 for Playoff)"),
     limit: int = Query(50, description="Maximum results", ge=1, le=100),
 ):
-    """Get goals leaderboard - top scorers filtered by season/league/division/age group."""
+    """Get goals leaderboard - top scorers filtered by season/league/division/age group/match type."""
     try:
         leaderboard = player_stats_dao.get_goals_leaderboard(
             season_id=season_id,
             league_id=league_id,
             division_id=division_id,
             age_group_id=age_group_id,
+            match_type_id=match_type_id,
             limit=limit,
         )
 
@@ -2841,6 +2843,7 @@ async def get_goals_leaderboard(
             league_id=league_id,
             division_id=division_id,
             age_group_id=age_group_id,
+            match_type_id=match_type_id,
             limit=limit,
             rows_returned=len(leaderboard),
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -148,7 +148,7 @@ fixable = ["ALL"]
 unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "ARG", "E501"]
+"tests/*" = ["S101", "ARG", "E501", "T201"]  # Tests: assert, unused args, line length, print OK
 "**/migrations/*" = ["E501"]
 "scripts/*" = ["S113", "S310", "S603", "S607", "T201", "E501"]  # Admin scripts: timeouts, subprocess, URL, print OK
 "manage_*.py" = ["S113", "E501"]  # CLI tools: timeouts OK

--- a/backend/tests/fixtures/tsc/entities.py
+++ b/backend/tests/fixtures/tsc/entities.py
@@ -70,6 +70,9 @@ class EntityRegistry:
     # Track player linked via invite (for verification after signup)
     linked_player_id: int | None = None
 
+    # Playoff match ID (for Phase 5 leaderboard tests)
+    playoff_match_id: int | None = None
+
     def add_match(self, match_id: int) -> None:
         """Track a created match."""
         if match_id not in self.match_ids:
@@ -146,6 +149,7 @@ class EntityRegistry:
             "user_ids": self.user_ids,
             "roster_entries": self.roster_entries,
             "linked_player_id": self.linked_player_id,
+            "playoff_match_id": self.playoff_match_id,
         }
 
     @classmethod
@@ -166,4 +170,5 @@ class EntityRegistry:
         registry.user_ids = data.get("user_ids", [])
         registry.roster_entries = data.get("roster_entries", [])
         registry.linked_player_id = data.get("linked_player_id")
+        registry.playoff_match_id = data.get("playoff_match_id")
         return registry

--- a/backend/tests/tsc/test_05_playoff_leaderboard.py
+++ b/backend/tests/tsc/test_05_playoff_leaderboard.py
@@ -1,0 +1,255 @@
+"""
+TSC Journey Tests - Phase 5: Playoff Goals Leaderboard.
+
+This phase tests the playoff goals leaderboard feature:
+- Admin creates a playoff match (match_type_id=4)
+- Admin live-scores the match with player goals
+- Fan verifies the goals leaderboard filters by match type
+
+Depends on Phase 0 (admin setup) and Phase 2 (roster creation).
+
+Run: pytest tests/tsc/test_05_playoff_leaderboard.py -v
+"""
+
+
+from tests.fixtures.tsc import EntityRegistry, TSCClient, TSCConfig
+
+PLAYOFF_MATCH_TYPE_ID = 4
+
+
+class TestPlayoffGoalsLeaderboard:
+    """Phase 5: Playoff match live-scoring and leaderboard verification."""
+
+    # === Setup: Admin creates and live-scores a playoff match ===
+
+    def test_01_login_admin(
+        self,
+        tsc_client: TSCClient,
+        existing_admin_credentials: tuple[str, str],
+    ):
+        """Login as admin to create playoff match."""
+        username, password = existing_admin_credentials
+        result = tsc_client.login(username, password)
+
+        assert "access_token" in result or "session" in result
+        print(f"Logged in as admin: {username}")
+
+    def test_02_complete_live_league_match(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Complete the league match left in LIVE status by Phase 2."""
+        assert len(entity_registry.match_ids) > 0, "Matches required (run Phase 2)"
+
+        live_match_id = entity_registry.match_ids[-1]
+        result = tsc_client.update_match_score(
+            match_id=live_match_id,
+            home_score=2,
+            away_score=1,
+            match_status="completed",
+        )
+
+        assert result is not None
+        print(f"Completed league match (ID: {live_match_id}): 2-1")
+
+    def test_03_create_playoff_match(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Create a playoff match (match_type_id=4) between premier and reserve teams."""
+        assert entity_registry.premier_team_id, "Premier team required (run Phase 0)"
+        assert entity_registry.reserve_team_id, "Reserve team required (run Phase 0)"
+
+        result = tsc_client.create_match(
+            home_team_id=entity_registry.premier_team_id,
+            away_team_id=entity_registry.reserve_team_id,
+            game_date="2025-04-01",
+            match_type_id=PLAYOFF_MATCH_TYPE_ID,
+        )
+
+        assert "id" in result
+        # Store playoff match ID for subsequent tests
+        entity_registry.playoff_match_id = result["id"]
+        print(f"Created playoff match (ID: {result['id']})")
+
+    def test_04_set_playoff_match_live(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Set the playoff match to LIVE status."""
+        match_id = entity_registry.playoff_match_id
+        assert match_id, "Playoff match required (run test_03)"
+
+        result = tsc_client.set_match_live(match_id)
+
+        assert result is not None
+        print(f"Set playoff match (ID: {match_id}) to LIVE")
+
+    def test_05_record_playoff_goals(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Live-score the playoff match: record goals for roster players."""
+        match_id = entity_registry.playoff_match_id
+        assert match_id, "Playoff match required"
+        assert len(entity_registry.roster_entries) >= 3, "Roster required (run Phase 2)"
+
+        team_id = entity_registry.premier_team_id
+
+        # Player 1 scores twice
+        player_1 = entity_registry.roster_entries[0]
+        for i in range(2):
+            result = tsc_client.post_goal_with_player(
+                match_id=match_id,
+                team_id=team_id,
+                player_id=player_1["id"],
+                message=f"Playoff goal {i + 1} from #{player_1['jersey_number']}!",
+            )
+            assert result is not None
+
+        # Player 2 scores once
+        player_2 = entity_registry.roster_entries[1]
+        result = tsc_client.post_goal_with_player(
+            match_id=match_id,
+            team_id=team_id,
+            player_id=player_2["id"],
+            message=f"Playoff goal from #{player_2['jersey_number']}!",
+        )
+        assert result is not None
+
+        print(
+            f"Recorded 3 playoff goals: "
+            f"#{player_1['jersey_number']} x2, #{player_2['jersey_number']} x1"
+        )
+
+    def test_06_complete_playoff_match(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Complete the playoff match."""
+        match_id = entity_registry.playoff_match_id
+        assert match_id, "Playoff match required"
+
+        result = tsc_client.update_match_score(
+            match_id=match_id,
+            home_score=3,
+            away_score=0,
+            match_status="completed",
+        )
+
+        assert result is not None
+        print(f"Completed playoff match (ID: {match_id}): 3-0")
+
+    # === Verification: Fan checks the leaderboard ===
+
+    def test_07_login_fan(
+        self,
+        tsc_client: TSCClient,
+        tsc_config: TSCConfig,
+    ):
+        """Login as fan to view leaderboard."""
+        result = tsc_client.login_club_fan()
+
+        assert "access_token" in result or "session" in result
+        print(f"Logged in as club fan: {tsc_config.full_club_fan_username}")
+
+    def test_08_verify_unfiltered_leaderboard_includes_playoff_goals(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Verify the unfiltered leaderboard includes playoff goals."""
+        leaderboard = tsc_client.get_goals_leaderboard(
+            season_id=entity_registry.season_id,
+        )
+
+        assert isinstance(leaderboard, list)
+        assert len(leaderboard) > 0, "Leaderboard should have scorers"
+
+        # Find our playoff scorer (player 1 with 2 goals)
+        player_1_id = entity_registry.roster_entries[0]["id"]
+        scorer = next((p for p in leaderboard if p["player_id"] == player_1_id), None)
+        assert scorer is not None, f"Player {player_1_id} should appear in unfiltered leaderboard"
+        # Player 1 may have goals from Phase 2 (league match) + Phase 5 (playoff)
+        assert scorer["goals"] >= 2, f"Expected at least 2 goals, got {scorer['goals']}"
+
+        print(f"Unfiltered leaderboard: {len(leaderboard)} scorers")
+        for p in leaderboard[:5]:
+            print(f"  #{p.get('jersey_number')} {p.get('first_name')} {p.get('last_name')}: {p['goals']} goals")
+
+    def test_09_verify_playoff_only_leaderboard(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Verify the leaderboard filtered by match_type_id=4 shows only playoff goals."""
+        leaderboard = tsc_client.get_goals_leaderboard(
+            season_id=entity_registry.season_id,
+            match_type_id=PLAYOFF_MATCH_TYPE_ID,
+        )
+
+        assert isinstance(leaderboard, list)
+        assert len(leaderboard) > 0, "Playoff leaderboard should have scorers"
+
+        # Player 1 should have exactly 2 playoff goals
+        player_1_id = entity_registry.roster_entries[0]["id"]
+        scorer_1 = next((p for p in leaderboard if p["player_id"] == player_1_id), None)
+        assert scorer_1 is not None, "Player 1 should appear in playoff leaderboard"
+        assert scorer_1["goals"] == 2, f"Player 1 should have 2 playoff goals, got {scorer_1['goals']}"
+        assert scorer_1["rank"] == 1, f"Player 1 should be ranked #1, got {scorer_1['rank']}"
+
+        # Player 2 should have exactly 1 playoff goal
+        player_2_id = entity_registry.roster_entries[1]["id"]
+        scorer_2 = next((p for p in leaderboard if p["player_id"] == player_2_id), None)
+        assert scorer_2 is not None, "Player 2 should appear in playoff leaderboard"
+        assert scorer_2["goals"] == 1, f"Player 2 should have 1 playoff goal, got {scorer_2['goals']}"
+
+        print(f"Playoff-only leaderboard: {len(leaderboard)} scorers")
+        for p in leaderboard:
+            print(
+                f"  #{p['rank']} #{p.get('jersey_number')} "
+                f"{p.get('first_name')} {p.get('last_name')}: "
+                f"{p['goals']} goals ({p.get('goals_per_game')} per game)"
+            )
+
+    def test_10_verify_league_only_leaderboard_excludes_playoff_goals(
+        self,
+        tsc_client: TSCClient,
+        entity_registry: EntityRegistry,
+    ):
+        """Verify the league-only leaderboard excludes playoff goals."""
+        league_match_type_id = 1
+
+        leaderboard = tsc_client.get_goals_leaderboard(
+            season_id=entity_registry.season_id,
+            match_type_id=league_match_type_id,
+        )
+
+        assert isinstance(leaderboard, list)
+
+        # Player 2 should NOT appear in league leaderboard
+        # (they only scored in the playoff match)
+        player_2_id = entity_registry.roster_entries[1]["id"]
+        scorer_2 = next((p for p in leaderboard if p["player_id"] == player_2_id), None)
+        assert scorer_2 is None, "Player 2 should NOT appear in league-only leaderboard"
+
+        print(f"League-only leaderboard: {len(leaderboard)} scorers (correctly excludes playoff-only scorers)")
+
+    def test_11_verify_phase_complete(
+        self,
+        entity_registry: EntityRegistry,
+    ):
+        """Verify playoff leaderboard journey completed successfully."""
+        assert entity_registry.playoff_match_id is not None, "Playoff match not created"
+
+        print("\n=== Phase 5 Complete ===")
+        print("Playoff goals leaderboard verified:")
+        print(f"  Playoff match ID: {entity_registry.playoff_match_id}")
+        print("  - Unfiltered leaderboard includes playoff + league goals")
+        print("  - match_type_id=4 filter shows only playoff goals")
+        print("  - match_type_id=1 filter excludes playoff goals")

--- a/frontend/src/components/GoalsLeaderboard.vue
+++ b/frontend/src/components/GoalsLeaderboard.vue
@@ -43,6 +43,39 @@
         </div>
       </div>
 
+      <!-- Match Type Filter -->
+      <div data-testid="match-type-filter">
+        <h3 class="text-sm font-medium text-gray-700 mb-3">Match Type</h3>
+        <div class="flex flex-wrap gap-2">
+          <button
+            @click="selectedMatchTypeId = null"
+            :class="[
+              'px-4 py-2 text-sm rounded-md font-medium transition-colors',
+              selectedMatchTypeId === null
+                ? 'bg-purple-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+            ]"
+            data-testid="match-type-all"
+          >
+            All
+          </button>
+          <button
+            v-for="mt in matchTypes"
+            :key="mt.id"
+            @click="selectedMatchTypeId = mt.id"
+            :class="[
+              'px-4 py-2 text-sm rounded-md font-medium transition-colors',
+              selectedMatchTypeId === mt.id
+                ? 'bg-purple-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+            ]"
+            :data-testid="`match-type-${mt.name}`"
+          >
+            {{ mt.name }}
+          </button>
+        </div>
+      </div>
+
       <!-- Season and Division Row -->
       <div
         class="flex flex-col sm:flex-row sm:space-x-6 space-y-4 sm:space-y-0"
@@ -235,10 +268,12 @@ export default {
     const divisions = ref([]);
     const allDivisions = ref([]);
     const seasons = ref([]);
+    const matchTypes = ref([]);
     const selectedAgeGroupId = ref(null);
     const selectedLeagueId = ref(null);
     const selectedDivisionId = ref(null);
     const selectedSeasonId = ref(null);
+    const selectedMatchTypeId = ref(null);
     const error = ref(null);
     const loading = ref(true);
 
@@ -277,6 +312,17 @@ export default {
         }
       } catch (err) {
         console.error('Error fetching leagues:', err);
+      }
+    };
+
+    const fetchMatchTypes = async () => {
+      try {
+        const data = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/match-types`
+        );
+        matchTypes.value = data.sort((a, b) => a.name.localeCompare(b.name));
+      } catch (err) {
+        console.error('Error fetching match types:', err);
       }
     };
 
@@ -357,6 +403,9 @@ export default {
         if (selectedAgeGroupId.value) {
           url += `&age_group_id=${selectedAgeGroupId.value}`;
         }
+        if (selectedMatchTypeId.value) {
+          url += `&match_type_id=${selectedMatchTypeId.value}`;
+        }
 
         console.log('Fetching leaderboard:', url);
         const data = await authStore.apiRequest(url);
@@ -400,6 +449,7 @@ export default {
         selectedAgeGroupId,
         selectedLeagueId,
         selectedDivisionId,
+        selectedMatchTypeId,
       ],
       () => {
         if (selectedSeasonId.value) {
@@ -409,7 +459,12 @@ export default {
     );
 
     onMounted(async () => {
-      await Promise.all([fetchAgeGroups(), fetchLeagues(), fetchSeasons()]);
+      await Promise.all([
+        fetchAgeGroups(),
+        fetchLeagues(),
+        fetchSeasons(),
+        fetchMatchTypes(),
+      ]);
       await fetchDivisions();
       fetchLeaderboardData();
     });
@@ -420,10 +475,12 @@ export default {
       leagues,
       divisions,
       seasons,
+      matchTypes,
       selectedAgeGroupId,
       selectedLeagueId,
       selectedDivisionId,
       selectedSeasonId,
+      selectedMatchTypeId,
       formatSeasonDates,
       formatPlayerName,
       error,


### PR DESCRIPTION
## Summary
- Add `match_type_id` filter to the goals leaderboard API and frontend, enabling playoff-specific goal tracking for Kick Futsal IFA teams
- Backend DAO and `/api/leaderboards/goals` endpoint now accept `match_type_id` param (Python-side filtering due to PostgREST nested join limitation)
- Frontend `GoalsLeaderboard.vue` adds purple Match Type filter buttons (All, Friendly, League, Playoff, Tournament)
- New Phase 5 journey tests: create playoff match, live-score goals, verify leaderboard filters correctly by match type
- Fixed league match left in LIVE status by Phase 2 (now completed at start of Phase 5)

## Test plan
- [x] All 84 TSC journey tests pass (Phases 0-5 + cleanup) in 3.97s
- [x] Ruff linting passes
- [x] Verified leaderboard UI locally with test data
- [ ] Verify playoff filter shows only playoff goals in production after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)