### PR TITLE
fix: Allow club managers to edit matches for their club's teams

### DIFF
--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -2234,6 +2234,19 @@ export default {
         return true;
       }
 
+      // Club managers can edit matches involving any team in their club
+      if (authStore.isClubManager.value && authStore.userClubId.value) {
+        const clubId = authStore.userClubId.value;
+        const homeTeam = teams.value.find(t => t.id === match.home_team_id);
+        const awayTeam = teams.value.find(t => t.id === match.away_team_id);
+        if (
+          (homeTeam && homeTeam.club_id === clubId) ||
+          (awayTeam && awayTeam.club_id === clubId)
+        ) {
+          return true;
+        }
+      }
+
       // Team managers can only edit matches involving their team
       // IMPORTANT: userTeamId is a computed property, so we need .value
       if (authStore.isTeamManager.value && authStore.userTeamId.value) {


### PR DESCRIPTION
## Summary
- Fix `canEditGame()` in `MatchesView.vue` to include `isClubManager` role check
- Club managers can now see the Edit button on matches involving any team in their club
- Aligns frontend with backend `can_edit_match()` which already permits club managers

## Context
`tom_club` (CLUB MANAGER) could not see the Edit button on IFA playoff matches despite the backend allowing it. The `canEditGame()` function only checked `isAdmin` and `isTeamManager`, missing `isClubManager`.

## Test plan
- [ ] Login as `tom_club` on prod and verify Edit button appears on IFA club matches
- [ ] Verify admins still see Edit on all matches
- [ ] Verify team managers still see Edit only on their team's matches
- [ ] Verify fans/players do not see Edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)