### PR TITLE
Regenerate API inventory at runtime in quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -119,6 +119,11 @@ jobs:
           npm run test:coverage
         continue-on-error: true
 
+      - name: Regenerate API inventory from source
+        run: |
+          cd backend
+          uv run python scripts/generate_api_inventory.py
+
       - name: Generate API coverage page
         run: |
           cd backend


### PR DESCRIPTION
## Summary
- Add a "Regenerate API inventory from source" step to `quality.yml` that runs `generate_api_inventory.py` before building the coverage page
- This ensures the quality dashboard always reflects the actual FastAPI routes, not a stale committed file

## Problem
`api_inventory.json` is a committed file that must be manually regenerated. When new endpoints are added (live scoring, playoffs, leaderboards, etc.) without regenerating, the API Contract Coverage page shows stale data. The playoff endpoints are a current example — they exist in `app.py` but aren't in the inventory.

## Test plan
- [ ] Push triggers quality.yml → verify API coverage page shows all current endpoints including playoffs
- [ ] Compare endpoint count before/after to confirm new endpoints are picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)