### PR TITLE
feat: Achieve 100% API coverage with cache and playoff endpoints

### DIFF
--- a/backend/api_client/client.py
+++ b/backend/api_client/client.py
@@ -28,6 +28,7 @@ from .exceptions import (
 from .models import (
     AdminPlayerTeamAssignment,
     AdminPlayerUpdate,
+    AdvanceWinnerRequest,
     AgeGroupCreate,
     AgeGroupUpdate,
     BulkRenumberRequest,
@@ -36,6 +37,7 @@ from .models import (
     DivisionUpdate,
     EnhancedGame,
     GamePatch,
+    GenerateBracketRequest,
     GoalEvent,
     InviteRequestCreate,
     InviteRequestStatusUpdate,
@@ -1160,6 +1162,56 @@ class MissingTableClient:
     def delete_invite_request(self, request_id: str) -> dict[str, Any]:
         """Delete an invite request (admin only)."""
         response = self._request("DELETE", f"/api/invite-requests/{request_id}")
+        return response.json()
+
+    # Playoffs
+
+    def get_playoff_bracket(
+        self, league_id: int, season_id: int, age_group_id: int
+    ) -> dict[str, Any]:
+        """Get playoff bracket for a league/season/age group."""
+        params = {"league_id": league_id, "season_id": season_id, "age_group_id": age_group_id}
+        response = self._request("GET", "/api/playoffs/bracket", params=params)
+        return response.json()
+
+    def advance_playoff_winner(self, request: AdvanceWinnerRequest) -> dict[str, Any]:
+        """Advance the winner of a completed bracket slot (team manager or admin)."""
+        response = self._request("POST", "/api/playoffs/advance", json_data=request.model_dump())
+        return response.json()
+
+    def generate_playoff_bracket(self, request: GenerateBracketRequest) -> dict[str, Any]:
+        """Generate playoff brackets from current standings (admin only)."""
+        response = self._request("POST", "/api/admin/playoffs/generate", json_data=request.model_dump())
+        return response.json()
+
+    def advance_playoff_winner_admin(self, request: AdvanceWinnerRequest) -> dict[str, Any]:
+        """Advance the winner of a completed bracket slot (admin only)."""
+        response = self._request("POST", "/api/admin/playoffs/advance", json_data=request.model_dump())
+        return response.json()
+
+    def delete_playoff_bracket(
+        self, league_id: int, season_id: int, age_group_id: int
+    ) -> dict[str, Any]:
+        """Delete an entire playoff bracket and its matches (admin only)."""
+        params = {"league_id": league_id, "season_id": season_id, "age_group_id": age_group_id}
+        response = self._request("DELETE", "/api/admin/playoffs/bracket", params=params)
+        return response.json()
+
+    # Cache management
+
+    def get_cache_stats(self) -> dict[str, Any]:
+        """Get cache statistics and keys grouped by type (admin only)."""
+        response = self._request("GET", "/api/admin/cache")
+        return response.json()
+
+    def clear_all_cache(self) -> dict[str, Any]:
+        """Clear all DAO cache entries (admin only)."""
+        response = self._request("DELETE", "/api/admin/cache")
+        return response.json()
+
+    def clear_cache_by_type(self, cache_type: str) -> dict[str, Any]:
+        """Clear cache entries for a specific type (admin only)."""
+        response = self._request("DELETE", f"/api/admin/cache/{cache_type}")
         return response.json()
 
     # Version

--- a/backend/api_client/models.py
+++ b/backend/api_client/models.py
@@ -166,6 +166,7 @@ from models.auth import (  # noqa: F401
 from models.lineup import LineupSave  # noqa: F401
 from models.live_match import GoalEvent, LiveMatchClock, MessageEvent  # noqa: F401
 from models.matches import MatchSubmissionData  # noqa: F401
+from models.playoffs import AdvanceWinnerRequest, GenerateBracketRequest  # noqa: F401
 from models.roster import (  # noqa: F401
     BulkRenumberRequest,
     BulkRosterCreate,

--- a/backend/api_inventory.json
+++ b/backend/api_inventory.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-27T21:03:53.765549+00:00",
+  "generated_at": "2026-02-06T19:07:31.201036+00:00",
   "excluded_endpoints": [
     {
       "method": "POST",
@@ -69,6 +69,88 @@
           "file": "tests/integration/api/test_endpoints.py",
           "test_name": "test_get_active_seasons",
           "type": "integration"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/admin/cache",
+      "client_method": "clear_all_cache",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_get_cache_stats_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_clear_all_cache_requires_auth",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "GET",
+      "path": "/api/admin/cache",
+      "client_method": "get_cache_stats",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_get_cache_stats_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_clear_all_cache_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_clear_cache_by_type_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_get_cache_stats_admin",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/admin/cache/{cache_type}",
+      "client_method": "clear_cache_by_type",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_get_cache_stats_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_clear_all_cache_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_clear_cache_by_type_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_get_cache_stats_admin",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_cache_contract.py",
+          "test_name": "test_clear_cache_by_type_invalid",
+          "type": "contract"
         }
       ],
       "coverage_status": "fully_covered"
@@ -174,6 +256,93 @@
         {
           "file": "tests/contract/test_admin_contract.py",
           "test_name": "test_add_admin_player_team_requires_auth",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "POST",
+      "path": "/api/admin/playoffs/advance",
+      "client_method": "advance_playoff_winner_admin",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_get_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_generate_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_admin_requires_auth",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/admin/playoffs/bracket",
+      "client_method": "delete_playoff_bracket",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_get_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_generate_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_admin_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_delete_playoff_bracket_requires_auth",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "POST",
+      "path": "/api/admin/playoffs/generate",
+      "client_method": "generate_playoff_bracket",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_get_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_generate_playoff_bracket_requires_auth",
           "type": "contract"
         }
       ],
@@ -784,6 +953,41 @@
         {
           "file": "tests/tsc/test_01_club_manager.py",
           "test_name": "test_03_login_club_manager",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_01_login_admin",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_02_complete_live_league_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_03_create_playoff_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_04_set_playoff_match_live",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_05_record_playoff_goals",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_06_complete_playoff_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_07_login_fan",
           "type": "journey"
         },
         {
@@ -6737,6 +6941,56 @@
           "file": "tests/contract/test_standings_contract.py",
           "test_name": "test_get_goals_leaderboard",
           "type": "contract"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_01_login_admin",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_02_complete_live_league_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_03_create_playoff_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_04_set_playoff_match_live",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_05_record_playoff_goals",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_06_complete_playoff_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_07_login_fan",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_08_verify_unfiltered_leaderboard_includes_playoff_goals",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_09_verify_playoff_only_leaderboard",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_10_verify_league_only_leaderboard_excludes_playoff_goals",
+          "type": "journey"
         }
       ],
       "coverage_status": "fully_covered"
@@ -8264,6 +8518,31 @@
           "file": "tests/tsc/test_02_team_manager.py",
           "test_name": "test_11c_record_goal_with_roster_player",
           "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_01_login_admin",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_02_complete_live_league_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_03_create_playoff_match",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_04_set_playoff_match_live",
+          "type": "journey"
+        },
+        {
+          "file": "tests/tsc/test_05_playoff_leaderboard.py",
+          "test_name": "test_05_record_playoff_goals",
+          "type": "journey"
         }
       ],
       "coverage_status": "fully_covered"
@@ -8345,6 +8624,49 @@
         {
           "file": "tests/contract/test_player_stats_contract.py",
           "test_name": "test_get_player_profile",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "POST",
+      "path": "/api/playoffs/advance",
+      "client_method": "advance_playoff_winner",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_get_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_generate_playoff_bracket_requires_auth",
+          "type": "contract"
+        },
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_advance_playoff_winner_admin_requires_auth",
+          "type": "contract"
+        }
+      ],
+      "coverage_status": "fully_covered"
+    },
+    {
+      "method": "GET",
+      "path": "/api/playoffs/bracket",
+      "client_method": "get_playoff_bracket",
+      "client_file": "api_client/client.py",
+      "tests": [
+        {
+          "file": "tests/contract/test_playoffs_contract.py",
+          "test_name": "test_get_playoff_bracket_requires_auth",
           "type": "contract"
         }
       ],
@@ -11302,13 +11624,13 @@
     }
   ],
   "summary": {
-    "total_endpoints": 117,
+    "total_endpoints": 125,
     "excluded": 3,
-    "with_client_method": 114,
-    "with_tests": 114,
+    "with_client_method": 122,
+    "with_tests": 122,
     "without_tests": 0,
     "coverage_status": {
-      "fully_covered": 114
+      "fully_covered": 122
     }
   }
 }

--- a/backend/tests/contract/test_cache_contract.py
+++ b/backend/tests/contract/test_cache_contract.py
@@ -1,0 +1,38 @@
+"""Contract tests for admin cache management endpoints."""
+
+import pytest
+
+from api_client import AuthenticationError, AuthorizationError, MissingTableClient
+
+
+@pytest.mark.contract
+class TestCacheContract:
+    """Test admin cache management endpoint contracts."""
+
+    def test_get_cache_stats_requires_auth(self, api_client: MissingTableClient):
+        """Test getting cache stats requires authentication."""
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.get_cache_stats()
+
+    def test_clear_all_cache_requires_auth(self, api_client: MissingTableClient):
+        """Test clearing all cache requires authentication."""
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.clear_all_cache()
+
+    def test_clear_cache_by_type_requires_auth(self, api_client: MissingTableClient):
+        """Test clearing cache by type requires authentication."""
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.clear_cache_by_type("standings")
+
+    def test_get_cache_stats_admin(self, admin_client: MissingTableClient):
+        """Test getting cache stats as admin."""
+        stats = admin_client.get_cache_stats()
+        assert isinstance(stats, dict)
+        assert "enabled" in stats
+
+    def test_clear_cache_by_type_invalid(self, admin_client: MissingTableClient):
+        """Test clearing cache with invalid type returns error."""
+        from api_client import APIError
+
+        with pytest.raises(APIError):
+            admin_client.clear_cache_by_type("invalid_type")

--- a/backend/tests/contract/test_playoffs_contract.py
+++ b/backend/tests/contract/test_playoffs_contract.py
@@ -1,0 +1,54 @@
+"""Contract tests for playoff bracket endpoints."""
+
+import pytest
+
+from api_client import AuthenticationError, AuthorizationError, MissingTableClient
+from api_client.models import AdvanceWinnerRequest
+
+
+@pytest.mark.contract
+class TestPlayoffBracketContract:
+    """Test playoff bracket endpoint contracts."""
+
+    def test_get_playoff_bracket_requires_auth(self, api_client: MissingTableClient):
+        """Test getting playoff bracket requires authentication."""
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.get_playoff_bracket(league_id=1, season_id=1, age_group_id=1)
+
+    def test_advance_playoff_winner_requires_auth(self, api_client: MissingTableClient):
+        """Test advancing playoff winner requires authentication."""
+        request = AdvanceWinnerRequest(slot_id=999)
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.advance_playoff_winner(request)
+
+
+@pytest.mark.contract
+class TestAdminPlayoffContract:
+    """Test admin playoff bracket endpoint contracts."""
+
+    def test_generate_playoff_bracket_requires_auth(self, api_client: MissingTableClient):
+        """Test generating playoff bracket requires authentication."""
+        from api_client.models import GenerateBracketRequest
+
+        request = GenerateBracketRequest(
+            league_id=1,
+            season_id=1,
+            age_group_id=1,
+            division_a_id=1,
+            division_b_id=2,
+            start_date="2026-03-01",
+            tiers=[],
+        )
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.generate_playoff_bracket(request)
+
+    def test_advance_playoff_winner_admin_requires_auth(self, api_client: MissingTableClient):
+        """Test admin advancing playoff winner requires authentication."""
+        request = AdvanceWinnerRequest(slot_id=999)
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.advance_playoff_winner_admin(request)
+
+    def test_delete_playoff_bracket_requires_auth(self, api_client: MissingTableClient):
+        """Test deleting playoff bracket requires authentication."""
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.delete_playoff_bracket(league_id=1, season_id=1, age_group_id=1)

--- a/scripts/generate-api-coverage.py
+++ b/scripts/generate-api-coverage.py
@@ -129,7 +129,7 @@ def generate_html(inventory: dict, commit_sha: str, run_id: str) -> str:
       background-color: #f3f4f6;
       min-height: 100vh;
     }}
-    .container {{ max-width: 1100px; margin: 0 auto; padding: 2rem 1rem; }}
+    .container {{ max-width: 1280px; margin: 0 auto; padding: 2rem 1rem; }}
     .header {{ text-align: center; margin-bottom: 2rem; }}
     .header h1 {{ font-size: 2rem; font-weight: 700; color: #2563eb; margin-bottom: 0.5rem; }}
     .header p {{ font-size: 1rem; color: #4b5563; }}
@@ -209,7 +209,9 @@ def generate_html(inventory: dict, commit_sha: str, run_id: str) -> str:
       padding: 0.5rem 0.75rem;
       text-align: left;
       border-bottom: 1px solid #e5e7eb;
+      white-space: nowrap;
     }}
+    .endpoints-table td:nth-child(3) {{ white-space: normal; }}
     .endpoints-table th {{
       background: #f9fafb;
       font-weight: 600;


### PR DESCRIPTION
## Summary
- **UX fix (API Coverage page)**: Fixed STATUS column truncation by widening the container (1100px → 1280px) and adding `white-space: nowrap` to table cells
- **UX fix (Quality Dashboard)**: Widened dashboard container (1024px → 1280px) so the Quality History table no longer requires horizontal scrolling
- **Contract test display fix**: Changed test counts from `passed/total` to `passed/executed` (excluding skipped). Contract tests showing "0/145" now correctly show "-" since all 145 tests are skipped, not failed
- **Coverage**: Added 8 missing client methods (cache management + playoff bracket) and 10 contract tests, bringing API coverage from 91.2% to 100% (122/122 endpoints fully covered)
- **Regenerated** `api_inventory.json` to reflect the new coverage

## Changes
| File | Change |
|------|--------|
| `scripts/generate-api-coverage.py` | Widen container, add nowrap to prevent column truncation |
| `scripts/generate-quality-dashboard.py` | Widen container, use executed (not total) test counts everywhere |
| `backend/api_client/client.py` | Add 8 client methods: cache stats/clear, playoff bracket CRUD |
| `backend/api_client/models.py` | Re-export `AdvanceWinnerRequest`, `GenerateBracketRequest` |
| `backend/tests/contract/test_cache_contract.py` | 5 contract tests for cache endpoints |
| `backend/tests/contract/test_playoffs_contract.py` | 5 contract tests for playoff endpoints |
| `backend/api_inventory.json` | Regenerated: 122/122 fully covered |

## Test plan
- [ ] Verify `uv run ruff check` passes on changed files
- [ ] Verify `uv run python scripts/generate_api_inventory.py` produces 122/122 fully covered
- [ ] Verify API Coverage page renders STATUS column without truncation
- [ ] Verify Quality Dashboard history table fits without horizontal scroll
- [ ] Verify contract suite card shows "-" instead of "0/145" when all tests are skipped
- [ ] Run contract tests against local server: `uv run pytest tests/contract/ -m contract -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)