### PR TITLE
fix: Replace .single() with .limit(1) in get_event_by_id

### DIFF
--- a/backend/dao/match_event_dao.py
+++ b/backend/dao/match_event_dao.py
@@ -141,8 +141,10 @@ class MatchEventDAO(BaseDAO):
             Event record or None if not found
         """
         try:
-            response = self.client.table("match_events").select("*").eq("id", event_id).single().execute()
-            return response.data
+            response = self.client.table("match_events").select("*").eq("id", event_id).limit(1).execute()
+            if response.data:
+                return response.data[0]
+            return None
         except Exception:
             logger.exception("Error getting match event", event_id=event_id)
             return None


### PR DESCRIPTION
## Summary

- Fix goal deletion failing with 404 from the admin Goals panel
- `get_event_by_id()` uses `.single()` which triggers a Supabase SDK Pydantic parsing error, causing the method to return `None` and the delete endpoint to return 404

## Root cause

The `postgrest-py` SDK's `.single()` modifier uses `SingleAPIResponse` Pydantic model internally. This model fails to parse valid responses from the `match_events` table (the row data is fine — visible in the error details — but the SDK's validation rejects it). Since `get_event_by_id` catches all exceptions and returns `None`, the `delete_event` endpoint sees "event not found" → 404.

## Fix

Replace `.single().execute()` with `.limit(1).execute()` and manually extract `response.data[0]`. This uses the standard `APIResponse` parsing path and avoids the SDK issue.

## Test plan

- [ ] Delete a goal from Admin Panel → Goals tab — should succeed and decrement score + player stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)