### PR TITLE
Enable Celery worker for match processing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -709,7 +709,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "helm/missing-table/values-prod.yaml",
-        "hashed_secret": "44598139d02109242aacd65bc58bed15e5630f66",
+        "hashed_secret": "df4d033b3e7374cd6becfa63f141eb47a0d41713",
         "is_verified": false,
         "line_number": 10
       }
@@ -721,13 +721,6 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
         "line_number": 73
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "helm/missing-table/values.yaml",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 172
       }
     ],
     "k3s/worker/QUICKSTART.md": [
@@ -838,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-07T22:41:31Z"
+  "generated_at": "2026-02-20T00:41:18Z"
 }

--- a/helm/missing-table/templates/celery-worker.yaml
+++ b/helm/missing-table/templates/celery-worker.yaml
@@ -57,13 +57,13 @@ spec:
               key: supabase-jwt-secret
         # Celery/RabbitMQ configuration
         - name: CELERY_BROKER_URL
-          value: "amqp://{{ .Values.celeryWorker.rabbitmq.username }}:{{ .Values.celeryWorker.rabbitmq.password }}@messaging-rabbitmq.match-scraper.svc.cluster.local:5672//"
+          value: "amqp://{{ .Values.celeryWorker.rabbitmq.username }}:{{ .Values.celeryWorker.rabbitmq.password }}@{{ .Values.celeryWorker.rabbitmq.host }}:{{ .Values.celeryWorker.rabbitmq.port }}//"
         - name: CELERY_RESULT_BACKEND
-          value: "redis://messaging-redis.match-scraper.svc.cluster.local:6379/0"
+          value: {{ .Values.celeryWorker.redis.url | quote }}
         - name: RABBITMQ_URL
-          value: "amqp://{{ .Values.celeryWorker.rabbitmq.username }}:{{ .Values.celeryWorker.rabbitmq.password }}@messaging-rabbitmq.match-scraper.svc.cluster.local:5672//"
+          value: "amqp://{{ .Values.celeryWorker.rabbitmq.username }}:{{ .Values.celeryWorker.rabbitmq.password }}@{{ .Values.celeryWorker.rabbitmq.host }}:{{ .Values.celeryWorker.rabbitmq.port }}//"
         - name: REDIS_URL
-          value: "redis://messaging-redis.match-scraper.svc.cluster.local:6379/0"
+          value: {{ .Values.celeryWorker.redis.url | quote }}
         # Environment configuration
         - name: ENVIRONMENT
           value: {{ .Values.backend.env.environment | quote }}

--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -29,6 +29,20 @@ backend:
 redis:
   enabled: true
 
+# Celery Worker — consumes match data from RabbitMQ (match-scraper namespace)
+celeryWorker:
+  enabled: true
+  replicaCount: 1
+
+  rabbitmq:
+    username: "guest"
+    password: "guest"  #pragma: allowlist secret
+    host: "rabbitmq.match-scraper.svc.cluster.local"
+    port: 5672
+
+  redis:
+    url: "redis://missing-table-redis:6379/0"
+
 frontend:
   replicaCount: 1
 

--- a/helm/missing-table/values.yaml
+++ b/helm/missing-table/values.yaml
@@ -162,16 +162,19 @@ frontend:
     loadBalancerIP: ""  # Let Rancher Desktop assign
 
 # Celery Worker configuration
-# Disabled: Celery workers run on local K3s cluster, not in GKE
+# Enable in values-prod.yaml to run workers in Cloud K8s
 celeryWorker:
   enabled: false
-  replicaCount: 2
+  replicaCount: 1
 
   rabbitmq:
-    username: "admin"
-    password: "admin"
-    host: "messaging-rabbitmq.messaging.svc.cluster.local"
+    username: "guest"
+    password: "guest"  #pragma: allowlist secret
+    host: "rabbitmq.match-scraper.svc.cluster.local"
     port: 5672
+
+  redis:
+    url: "redis://missing-table-redis:6379/0"
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Enables the Celery worker deployment in LKE to consume match data from RabbitMQ
- Fixes celery-worker template to use Helm values for RabbitMQ host and Redis URL instead of hardcoded service names
- Updates default RabbitMQ credentials to match the match-scraper namespace deployment (`guest/guest` at `rabbitmq.match-scraper.svc.cluster.local`)

## Context
The match-scraper-agent publishes scraped matches to a `matches-fanout` exchange in RabbitMQ (match-scraper namespace). Without a Celery worker consuming from the bound `match_processing` queue, messages are dropped and matches never reach the database.

## Test plan
- [ ] ArgoCD syncs the new celery-worker deployment
- [ ] Worker pod starts and connects to RabbitMQ
- [ ] Trigger match-scraper-agent and verify matches appear on missingtable.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)