### PR TITLE
docs: Make infra docs provider-agnostic, fix stale dev refs

### DIFF
--- a/docs/05-deployment/gke-deployment.md
+++ b/docs/05-deployment/gke-deployment.md
@@ -1,6 +1,14 @@
-# GKE Deployment Guide
+# DEPRECATED — Historical Reference
 
-This guide covers deploying the Missing Table application to Google Kubernetes Engine (GKE) Autopilot.
+> **GKE was shut down on 2025-12-07.** Missing Table production moved to DOKS (Dec 2025) and then LKE (Feb 2026). See [Production Environment](../07-operations/CLOUD_K8S_PRODUCTION.md) for current deployment docs.
+>
+> This document is preserved for historical reference only. Do not follow these instructions.
+
+---
+
+# GKE Deployment Guide (Historical)
+
+This guide covered deploying the Missing Table application to Google Kubernetes Engine (GKE) Autopilot.
 
 ## Architecture
 

--- a/docs/05-deployment/https-setup.md
+++ b/docs/05-deployment/https-setup.md
@@ -1,7 +1,15 @@
-# GKE HTTPS & Custom Domain Setup Guide
+# DEPRECATED — Historical Reference
+
+> **GKE was shut down on 2025-12-07.** HTTPS/TLS is now managed by cert-manager + Let's Encrypt in the current cloud K8s cluster. See [Production Environment](../07-operations/CLOUD_K8S_PRODUCTION.md) for current setup.
+>
+> This document is preserved for historical reference only.
+
+---
+
+# GKE HTTPS & Custom Domain Setup Guide (Historical)
 
 **Project:** Missing Table
-**Environment:** Development (dev.missingtable.com)
+**Environment:** Development (dev.missingtable.com — no longer exists)
 **Date Completed:** October 3, 2025
 **Time to Complete:** ~90 minutes
 

--- a/docs/07-operations/CLOUD_K8S_PRODUCTION.md
+++ b/docs/07-operations/CLOUD_K8S_PRODUCTION.md
@@ -1,10 +1,13 @@
-# Production Environment
+# Production Environment — Cloud K8s
 
 ## Overview
 
-Missing Table production runs on **Linode Kubernetes Engine (LKE)**, managed via GitOps with ArgoCD.
+Missing Table production (API + frontend) runs on **cloud K8s**, managed via GitOps with ArgoCD. The cloud provider has changed over time and may change again — this doc is intentionally provider-agnostic.
 
+**Current provider**: LKE (as of February 2026)
 **Migration history**: GKE (shutdown 2025-12-07) → DOKS (December 2025) → LKE (February 2026)
+
+> **Note**: The match-scraper pipeline runs separately on an M4 Mac in rancher-desktop K3s. See the [match-scraper-agent](https://github.com/silverbeer/match-scraper-agent) repo for those docs.
 
 ---
 
@@ -20,7 +23,7 @@ CI Workflow (.github/workflows/ci.yml)
 ArgoCD (watches values-prod.yaml)
     ↓ syncs to cluster
     ↓
-LKE Cluster
+Cloud K8s Cluster
     ├── missing-table namespace
     │   ├── backend (FastAPI)
     │   ├── frontend (Vue/Nginx)
@@ -37,7 +40,7 @@ LKE Cluster
 | Repository | Purpose |
 |------------|---------|
 | **missing-table** (this repo) | Application code, Helm charts, CI/CD |
-| **[missingtable-platform-bootstrap](https://github.com/silverbeer/missingtable-platform-bootstrap)** | Terraform IaC, ArgoCD config, LKE provisioning |
+| **[missingtable-platform-bootstrap](https://github.com/silverbeer/missingtable-platform-bootstrap)** | Terraform IaC, ArgoCD config, cluster provisioning |
 
 ---
 
@@ -83,7 +86,7 @@ Secrets include:
 1. Merge PR to `main`
 2. CI builds images, pushes to GHCR
 3. CI updates `values-prod.yaml` with new image tags
-4. ArgoCD detects changes and syncs to LKE
+4. ArgoCD detects changes and syncs to cluster
 
 ### Manual (Emergency only)
 


### PR DESCRIPTION
## Summary
- Renamed `DOKS_PRODUCTION.md` → `CLOUD_K8S_PRODUCTION.md` and made content provider-agnostic (says "cloud K8s" not LKE/DOKS)
- Marked `gke-deployment.md` and `https-setup.md` as DEPRECATED — Historical Reference
- Fixed `match-scraper.md`: scraper runs on M4 Mac K3s (not GKE), replaced `dev.missingtable.com` URLs with `missingtable.com`, fixed namespace references
- Clarified there is no dev Supabase — only prod and local

Part of a cross-repo documentation cleanup. Related PRs:
- silverbeer/match-scraper-agent — `docs/environment-cleanup`
- silverbeer/match-scraper — `docs/environment-cleanup`

## Test plan
- [ ] Review updated docs match actual infrastructure
- [ ] Verify no broken internal doc cross-references from the rename
- [ ] No functional code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)