### PR TITLE
feat: Add Florida division to setup and seed data

### DIFF
--- a/backend/scripts/setup/setup_leagues_divisions.py
+++ b/backend/scripts/setup/setup_leagues_divisions.py
@@ -39,6 +39,11 @@ divisions_to_create = [
         "description": "Northeast Division (Homegrown)",
     },
     {
+        "name": "Florida",
+        "league_id": homegrown_league_id,
+        "description": "Florida Division (Homegrown)",
+    },
+    {
         "name": "New England",
         "league_id": academy_league_id,
         "description": "New England Conference (Academy)",

--- a/supabase-local/seed.sql
+++ b/supabase-local/seed.sql
@@ -47,6 +47,7 @@ SELECT setval('public.leagues_id_seq', (SELECT COALESCE(MAX(id), 0) FROM public.
 -- Divisions (depend on leagues)
 INSERT INTO public.divisions (id, name, description, league_id) VALUES
   (1, 'Northeast', 'Northeast Division', 1),
+  (2, 'Florida', 'Florida Division', 1),
   (7, 'New England', 'New England Division', 2)
 ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
## Summary

- Add Florida division (Homegrown league) to `setup_leagues_divisions.py` so it gets created when the script runs
- Add Florida division (id=2, league_id=1) to `seed.sql` so it exists on fresh DB resets
- Prepares the database for Florida club/team imports via `manage_clubs.py sync`

## Test plan

- [ ] Run `npx supabase db reset` locally — verify Florida division appears
- [ ] Run `setup_leagues_divisions.py` — verify idempotent (skips if exists)
- [ ] Verify existing Northeast and New England divisions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)