### PR TITLE
fix: Remove empty spacer in ClubLogo for no-logo teams

### DIFF
--- a/frontend/src/components/shared/ClubLogo.vue
+++ b/frontend/src/components/shared/ClubLogo.vue
@@ -1,18 +1,21 @@
 <template>
-  <div :class="containerClass" :style="containerStyle">
+  <div
+    v-if="hasLogo || showInitials"
+    :class="containerClass"
+    :style="containerStyle"
+  >
     <!-- Logo image -->
     <img
-      v-if="logoUrl"
+      v-if="hasLogo"
       :src="logoUrl"
       :alt="`${name} logo`"
       :class="imgClass"
       @error="onImgError"
     />
-    <!-- Initials fallback for lg/xl when no logo -->
+    <!-- Initials fallback for md/lg/xl when no logo -->
     <span v-else-if="showInitials" :class="initialsClass">
       {{ initial }}
     </span>
-    <!-- xs/sm: empty spacer when no logo (no visual, just width reservation) -->
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- ClubLogo component was rendering a fixed-size empty container (24px at xs, 32px at sm) even when no logo existed, causing visible gaps in match lists and standings tables
- Now renders nothing when there's no logo at xs/sm sizes — clean layout whether teams have logos or not
- Also fixes image error handling: broken images now properly fall back to initials display instead of showing a broken img tag

## Test plan
- [ ] Verify Matches tab has no extra spacing gaps for teams without logos
- [ ] Verify Table tab shows logos for teams that have them (e.g. NEFC, NY Red Bulls)
- [ ] Verify Table tab has no spacing gaps for teams without logos
- [ ] Verify MatchDetailView still renders logos at lg size
- [ ] Verify profile pages still show initials fallback at xl size when no logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)