### PR TITLE
feat: Multi-size club logo system

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3699,12 +3699,31 @@ async def upload_club_logo(
         # Get the Supabase client from the DAO
         storage = match_dao.client.storage
 
-        # Upload to club-logos bucket (upsert to overwrite existing)
+        # Upload base image to club-logos bucket (upsert to overwrite existing)
         storage.from_("club-logos").upload(
             file_path, content, file_options={"content-type": file.content_type, "upsert": "true"}
         )
 
-        # Get public URL
+        # Generate and upload size variants (_sm=64px, _md=128px) for PNGs
+        if ext == "png":
+            from io import BytesIO
+
+            from PIL import Image as PILImage
+
+            base_img = PILImage.open(BytesIO(content))
+            for suffix, px in [("_sm", 64), ("_md", 128)]:
+                variant = base_img.resize((px, px), PILImage.LANCZOS)
+                buf = BytesIO()
+                variant.save(buf, "PNG")
+                variant_path = f"{club_id}{suffix}.png"
+                storage.from_("club-logos").upload(
+                    variant_path,
+                    buf.getvalue(),
+                    file_options={"content-type": "image/png", "upsert": "true"},
+                )
+            logger.info(f"Uploaded size variants for club {club_id}")
+
+        # Get public URL (points to base image)
         public_url = storage.from_("club-logos").get_public_url(file_path)
 
         # Update the club with the new logo URL

--- a/backend/manage_clubs.py
+++ b/backend/manage_clubs.py
@@ -277,7 +277,11 @@ def update_club(token: str, club_id: int, club: ClubData) -> bool:
 
 
 def upload_club_logo(token: str, club_id: int, logo_path: Path) -> bool:
-    """Upload a local logo file for a club via the API."""
+    """Upload a local logo file for a club via the API.
+
+    The API endpoint generates _sm (64px) and _md (128px) size variants
+    automatically from the uploaded base image.
+    """
     url = f"{API_URL}/api/clubs/{club_id}/logo"
     headers = {"Authorization": f"Bearer {token}"}
     with open(logo_path, "rb") as f:
@@ -1050,7 +1054,8 @@ def upload_logos(
         console.print("Run prep-logo.py --batch first to prepare logos.")
         raise typer.Exit(code=1)
 
-    ready_files = list(LOGO_READY_DIR.glob("*.png"))
+    # Only process base files, skip _sm/_md size variants
+    ready_files = [f for f in LOGO_READY_DIR.glob("*.png") if not f.stem.endswith(("_sm", "_md"))]
     if not ready_files:
         console.print(f"[yellow]No PNG files found in {LOGO_READY_DIR}[/yellow]")
         return

--- a/docs/features/CLUB_LOGO_SYSTEM.md
+++ b/docs/features/CLUB_LOGO_SYSTEM.md
@@ -14,15 +14,32 @@ The `enrich` command successfully finds club websites, but the logos it captures
 ## Image Standard
 
 - **Format**: PNG with transparent background, square aspect ratio
-- **Source resolution**: 512x512px (or at least 256x256)
-- **One source file per club** — CSS handles all display sizes:
-  - `xs` = 24px (inline in tables/standings)
-  - `sm` = 32px (match cards, profile inline)
-  - `md` = 40px (admin grid, match list cards)
-  - `lg` = 56px (match detail badges)
-  - `xl` = 140px (profile hero sections)
-- **Naming**: `{slug}.png` where slug = lowercase, hyphens for spaces, accents stripped
-  - `inter-miami-cf.png`, `orlando-city-sc.png`, `dc-united.png`, `cf-montreal.png`
+- **Multi-size variants**: 3 files per club for optimal bandwidth
+
+| Tier | Suffix | Pixel size | Used for (CSS sizes) |
+|------|--------|------------|----------------------|
+| sm | `_sm.png` | 64x64 | xs (24px), sm (32px) — retina-ready |
+| md | `_md.png` | 128x128 | md (40px), lg (56px) — retina-ready |
+| base | `.png` | 256x256 | xl (140px) — retina-ready |
+
+- **Frontend auto-selects** the right variant based on the `size` prop, with fallback to base URL on 404
+- **Naming**: `{slug}.png` (base), `{slug}_sm.png`, `{slug}_md.png` where slug = lowercase, hyphens for spaces, accents stripped
+  - `inter-miami-cf.png`, `inter-miami-cf_sm.png`, `inter-miami-cf_md.png`
+
+### Storage Convention
+
+Files in `club-logos` Supabase bucket:
+```
+12.png        ← 256x256 base (logo_url in DB points here)
+12_sm.png     ← 64x64
+12_md.png     ← 128x128
+```
+
+### Bandwidth Impact
+
+Standings table with 20 teams:
+- **Before** (single 512px): 20 x ~130KB = 2.6MB
+- **After** (_sm variants): 20 x ~5KB = 100KB (~96% reduction)
 
 ---
 
@@ -35,7 +52,7 @@ When onboarding new divisions/clubs, follow this repeatable process to add logos
 ```
 club-logos/
   raw/        ← Drop source images here (any format/size), named as {slug}.ext
-  ready/      ← Processed 512x512 PNGs (output of prep-logo.py --batch)
+  ready/      ← Processed PNGs: {slug}.png (256px), {slug}_sm.png (64px), {slug}_md.png (128px)
 ```
 
 ### Step-by-Step
@@ -47,10 +64,10 @@ cd backend && uv run python manage_clubs.py logo-status
 # 2. Drop raw images into staging folder, named by slug from step 1
 cp ~/Downloads/logo.png club-logos/raw/bayside-fc.png
 
-# 3. Batch prep all raw images (bg removal, resize to 512x512)
+# 3. Batch prep all raw images (bg removal, resize + generate 3 size variants)
 cd backend && uv run python ../scripts/prep-logo.py --batch
 
-# 4. Upload all prepared logos to the database
+# 4. Upload all prepared logos to the database (API generates variants server-side)
 cd backend && uv run python manage_clubs.py upload-logos
 ```
 
@@ -59,9 +76,10 @@ cd backend && uv run python manage_clubs.py upload-logos
 | Command | Description |
 |---------|-------------|
 | `manage_clubs.py logo-status` | Show all DB clubs with slug filename and logo status |
-| `prep-logo.py --batch` | Process all `club-logos/raw/*` images to `club-logos/ready/` |
+| `prep-logo.py --batch` | Process all `club-logos/raw/*` → `ready/` (base + _sm + _md) |
+| `prep-logo.py --batch --force` | Regenerate all, even if output is newer than input |
 | `prep-logo.py --batch --no-remove-bg` | Batch prep without background removal |
-| `prep-logo.py input.png --club "Name"` | Process a single file by club name |
+| `prep-logo.py input.png --club "Name"` | Process a single file by club name (3 variants) |
 | `manage_clubs.py upload-logos` | Upload all `club-logos/ready/*.png` to DB |
 | `manage_clubs.py upload-logos --dry-run` | Preview what would be uploaded |
 | `manage_clubs.py upload-logos --overwrite` | Re-upload even if club already has a logo |
@@ -70,10 +88,11 @@ cd backend && uv run python manage_clubs.py upload-logos
 ### Notes
 
 - `logo-status` shows the expected slug filename for every club in the DB
-- `upload-logos` matches files to ALL DB clubs (not just clubs.json)
-- Batch prep skips files where output is already newer than input (re-run safe)
+- `upload-logos` matches base files to ALL DB clubs (skips `_sm`/`_md` variant files)
+- Batch prep skips files where output is already newer than input (use `--force` to override)
 - SVG and other unsupported formats are skipped with a warning
 - The `club-logos` Supabase storage bucket is auto-created on `supabase db reset` via `config.toml`
+- The API upload endpoint auto-generates `_sm` and `_md` variants server-side via Pillow
 
 ---
 
@@ -226,14 +245,13 @@ New method `_download_logo()` that saves the discovered logo image to a local fo
 
 ## Verification Checklist
 
-1. Place a test logo at `club-logos/bayside-fc.png` (512x512 PNG)
-2. Run `manage_clubs.py sync` — verify logo uploads and URL updates in DB
-3. Open MatchesView — verify logos appear next to team names in both desktop/mobile views
-4. Open LeagueTable — verify logos appear in standings rows
-5. Open TeamManagerProfile — verify club logo appears
-6. Open PlayerProfile — verify club logo appears in team line
-7. Run `mls-scraper enrich --input florida-clubs.json --logo-dir ./club-logos/` — verify candidate logos downloaded
-8. Check MatchDetailView still works (regression check)
+1. Run `prep-logo.py --batch --force` — verify 3 files per club in `ready/` (base + _sm + _md)
+2. Run `manage_clubs.py upload-logos --overwrite` — verify upload succeeds
+3. Check Supabase Storage — verify `{id}.png`, `{id}_sm.png`, `{id}_md.png` exist per club
+4. Open LeagueTable — verify Network tab shows `_sm` variant requests (not full-size)
+5. Open MatchDetailView — verify xl logos still use base URL
+6. Block `_sm` URL in DevTools — verify fallback to base URL works
+7. Check MatchesView, profiles — verify logos render at correct sizes
 
 ## Key Files Reference
 

--- a/frontend/src/components/shared/ClubLogo.vue
+++ b/frontend/src/components/shared/ClubLogo.vue
@@ -4,10 +4,10 @@
     :class="containerClass"
     :style="containerStyle"
   >
-    <!-- Logo image -->
+    <!-- Logo image (sized variant with fallback to base) -->
     <img
       v-if="hasLogo"
-      :src="logoUrl"
+      :src="activeSrc"
       :alt="`${name} logo`"
       :class="imgClass"
       @error="onImgError"
@@ -39,8 +39,31 @@ const props = defineProps({
 });
 
 const imgFailed = ref(false);
+const variantFailed = ref(false);
+
+const sizeSuffix = computed(() => {
+  if (['xs', 'sm'].includes(props.size)) return '_sm';
+  if (['md', 'lg'].includes(props.size)) return '_md';
+  return ''; // xl uses base
+});
+
+const sizedLogoUrl = computed(() => {
+  if (!props.logoUrl || !sizeSuffix.value) return props.logoUrl;
+  return props.logoUrl.replace(/\.png$/, `${sizeSuffix.value}.png`);
+});
+
+const activeSrc = computed(() => {
+  if (variantFailed.value || !sizeSuffix.value) return props.logoUrl;
+  return sizedLogoUrl.value;
+});
 
 const onImgError = () => {
+  // If the sized variant failed, fall back to base URL
+  if (!variantFailed.value && sizeSuffix.value) {
+    variantFailed.value = true;
+    return;
+  }
+  // Base URL also failed — no logo available
   imgFailed.value = true;
 };
 

--- a/scripts/prep-logo.py
+++ b/scripts/prep-logo.py
@@ -3,7 +3,10 @@
 Prepare club logo images for upload.
 
 Takes a source image (any format/size), removes the background,
-centers and pads to a square, and outputs a 512x512 transparent PNG.
+centers and pads to a square, and outputs multiple size variants:
+  - {slug}.png      (256x256 base)
+  - {slug}_sm.png   (64x64 for xs/sm display sizes)
+  - {slug}_md.png   (128x128 for md/lg display sizes)
 
 Usage:
     # Single file mode (by club name):
@@ -13,13 +16,13 @@ Usage:
 
     # Batch mode (process all images in club-logos/raw/):
     cd backend && uv run python ../scripts/prep-logo.py --batch
-    cd backend && uv run python ../scripts/prep-logo.py --batch --no-remove-bg
+    cd backend && uv run python ../scripts/prep-logo.py --batch --force
 
 Dependencies (managed via uv in backend/pyproject.toml):
     pillow, rembg
 
-Single-file mode: output to club-logos/ready/{slug}.png (slug from club name).
-Batch mode: globs club-logos/raw/*, outputs to club-logos/ready/{stem}.png.
+Single-file mode: output to club-logos/ready/{slug}.png + _sm/_md variants.
+Batch mode: globs club-logos/raw/*, outputs to club-logos/ready/{stem}.png + variants.
 """
 
 import argparse
@@ -37,6 +40,12 @@ SUPPORTED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff", ".tif
 PROJECT_ROOT = Path(__file__).parent.parent
 RAW_DIR = PROJECT_ROOT / "club-logos" / "raw"
 READY_DIR = PROJECT_ROOT / "club-logos" / "ready"
+
+# Size variants: (suffix, pixel size)
+SIZE_VARIANTS = [
+    ("_sm", 64),
+    ("_md", 128),
+]
 
 
 def remove_background(img: Image.Image) -> Image.Image:
@@ -71,6 +80,17 @@ def center_and_pad(img: Image.Image, target_size: int) -> Image.Image:
     return canvas
 
 
+def generate_variants(base_img: Image.Image, output_path: Path) -> None:
+    """Generate _sm and _md size variants from the base image."""
+    stem = output_path.stem
+    parent = output_path.parent
+    for suffix, px in SIZE_VARIANTS:
+        variant_path = parent / f"{stem}{suffix}.png"
+        variant = base_img.resize((px, px), Image.LANCZOS)
+        variant.save(variant_path, "PNG")
+        print(f"  Variant: {variant_path.name} ({px}x{px})")
+
+
 def process_single(input_path: Path, output_path: Path, size: int, skip_bg_removal: bool) -> bool:
     """Process a single image file. Returns True on success."""
     print(f"Processing: {input_path}")
@@ -88,10 +108,12 @@ def process_single(input_path: Path, output_path: Path, size: int, skip_bg_remov
     output_path.parent.mkdir(parents=True, exist_ok=True)
     img.save(output_path, "PNG")
     print(f"  Saved: {output_path}")
+
+    generate_variants(img, output_path)
     return True
 
 
-def run_batch(size: int, skip_bg_removal: bool) -> None:
+def run_batch(size: int, skip_bg_removal: bool, force: bool = False) -> None:
     """Process all images in club-logos/raw/ and output to club-logos/ready/."""
     if not RAW_DIR.exists():
         print(f"Raw directory not found: {RAW_DIR}")
@@ -120,8 +142,12 @@ def run_batch(size: int, skip_bg_removal: bool) -> None:
         # Output uses the filename stem (without extension) as the slug
         output_path = READY_DIR / f"{raw_path.stem}.png"
 
-        # Skip if output already exists and is newer than input
-        if output_path.exists() and output_path.stat().st_mtime > raw_path.stat().st_mtime:
+        # Skip if output already exists and is newer than input (unless --force)
+        if (
+            not force
+            and output_path.exists()
+            and output_path.stat().st_mtime > raw_path.stat().st_mtime
+        ):
             print(f"Skipping (already up to date): {raw_path.name}")
             stats["skipped_fresh"] += 1
             continue
@@ -149,18 +175,23 @@ def main():
     parser.add_argument("input", type=Path, nargs="?", help="Source image file (single-file mode)")
     parser.add_argument("--club", help="Club name for single-file mode (e.g. 'Inter Miami CF')")
     parser.add_argument("--batch", action="store_true", help="Process all images in club-logos/raw/")
-    parser.add_argument("--size", type=int, default=512, help="Output size in pixels (default: 512)")
+    parser.add_argument("--size", type=int, default=256, help="Output size in pixels (default: 256)")
     parser.add_argument(
         "--no-remove-bg",
         action="store_true",
         help="Skip background removal (use if image already has transparent background)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate even if output is newer than input (batch mode)",
     )
     parser.add_argument("--output-dir", type=Path, default=None, help="Output directory (single-file mode)")
     args = parser.parse_args()
 
     if args.batch:
         # Batch mode: process all files in club-logos/raw/
-        run_batch(args.size, args.no_remove_bg)
+        run_batch(args.size, args.no_remove_bg, args.force)
     elif args.input and args.club:
         # Single-file mode: process one file by club name
         if not args.input.exists():


### PR DESCRIPTION
## Summary
- Generate `_sm` (64px) and `_md` (128px) logo variants alongside the 256px base image
- Frontend `ClubLogo.vue` auto-selects the right variant by size prop, with fallback to base URL on 404
- API upload endpoint generates all 3 variants server-side via Pillow
- Reduces standings table bandwidth ~96% (2.6MB → 100KB for 20 teams)

## Test plan
- [x] All 182 frontend tests pass
- [x] Ruff + ESLint clean
- [x] `prep-logo.py --batch --force` generates 3 files per club (verified: 19 clubs × 3 = 57 variant files)
- [ ] Deploy frontend first — fallback logic means zero visual change before variants are uploaded
- [ ] Re-upload logos to prod: `cd backend && APP_ENV=prod uv run python manage_clubs.py upload-logos --overwrite`
- [ ] Clear Redis cache
- [ ] Verify in browser Network tab that `_sm` variants load for standings table

🤖 Generated with [Claude Code](https://claude.com/claude-code)