### PR TITLE
fix: Prevent browser from caching API responses

### DIFF
--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -624,6 +624,7 @@ export const useAuthStore = () => {
 
     const response = await fetch(endpoint, {
       ...options,
+      cache: 'no-store',
       headers: {
         ...defaultHeaders,
         ...options.headers,
@@ -642,6 +643,7 @@ export const useAuthStore = () => {
           defaultHeaders.Authorization = `Bearer ${retryToken}`;
           const retryResponse = await fetch(endpoint, {
             ...options,
+            cache: 'no-store',
             headers: {
               ...defaultHeaders,
               ...options.headers,


### PR DESCRIPTION
## Summary
- Add `cache: 'no-store'` to both `fetch` calls in `apiCall()` (primary + retry paths)
- Ensures the browser always hits the backend for API requests instead of serving from HTTP cache

## Problem
After editing a match (e.g. changing the date), the match detail view showed stale data. The backend Redis cache was correctly invalidated, but the browser's HTTP cache was serving the old `GET /api/matches/{id}` response.

## Test plan
- [x] ESLint clean
- [x] All 182 frontend tests pass
- [ ] Edit a match date, navigate to detail view, verify new date shows immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)