### PR TITLE
feat: Add agent match-summary endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5251,6 +5251,31 @@ async def full_health_check():
         raise HTTPException(status_code=503, detail=health_status)
 
 
+# === Agent Endpoints ===
+
+
+@app.get("/api/agent/match-summary")
+async def get_agent_match_summary(
+    season: str = Query(..., description="Season name, e.g. '2025-26'"),
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Get match summary for agent decision-making.
+
+    Returns match counts grouped by age group, league, and division
+    with status breakdowns to help the agent decide what to scrape.
+    """
+    try:
+        targets = match_dao.get_match_summary(season)
+        return {
+            "season": season,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "targets": targets,
+        }
+    except Exception as e:
+        logger.error("agent_match_summary_failed", error=str(e), season=season)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 if __name__ == "__main__":
     import uvicorn
 

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -454,6 +454,83 @@ class MatchDAO(BaseDAO):
             logger.exception("Error querying matches")
             return []
 
+    def get_match_summary(self, season_name: str) -> list[dict]:
+        """Get match summary statistics grouped by age group, league, and division.
+
+        Used by the match-scraper-agent to understand what MT already has
+        and make smart decisions about what to scrape.
+        """
+        from collections import defaultdict
+        from datetime import date
+
+        today = date.today().isoformat()
+
+        # Look up season by name
+        season_resp = self.client.table("seasons").select("id").eq("name", season_name).limit(1).execute()
+        if not season_resp.data:
+            return []
+        season_id = season_resp.data[0]["id"]
+
+        # Fetch all matches for this season with joins
+        response = (
+            self.client.table("matches")
+            .select("""
+                match_date, match_status, home_score, away_score,
+                age_group:age_groups(name),
+                division:divisions(name, league_id, leagues:leagues!divisions_league_id_fkey(name))
+            """)
+            .eq("season_id", season_id)
+            .execute()
+        )
+
+        # Group by (age_group, league, division)
+        groups = defaultdict(list)
+        for m in response.data:
+            ag = m["age_group"]["name"] if m.get("age_group") else "Unknown"
+            div_name = m["division"]["name"] if m.get("division") else "Unknown"
+            league_name = (
+                m["division"]["leagues"]["name"] if m.get("division") and m["division"].get("leagues") else "Unknown"
+            )
+            groups[(ag, league_name, div_name)].append(m)
+
+        # Compute summary per group
+        summaries = []
+        for (ag, league, div), matches in sorted(groups.items()):
+            by_status = defaultdict(int)
+            needs_score = 0
+            dates = []
+            last_played = None
+
+            for m in matches:
+                status = m.get("match_status", "scheduled")
+                by_status[status] += 1
+                md = m["match_date"]
+                dates.append(md)
+
+                if md < today and status in ("scheduled", "tbd") and m.get("home_score") is None:
+                    needs_score += 1
+
+                if status == "played" and (last_played is None or md > last_played):
+                    last_played = md
+
+            summaries.append(
+                {
+                    "age_group": ag,
+                    "league": league,
+                    "division": div,
+                    "total": len(matches),
+                    "by_status": dict(by_status),
+                    "needs_score": needs_score,
+                    "date_range": {
+                        "earliest": min(dates) if dates else None,
+                        "latest": max(dates) if dates else None,
+                    },
+                    "last_played_date": last_played,
+                }
+            )
+
+        return summaries
+
     def get_matches_by_team(
         self, team_id: int, season_id: int | None = None, age_group_id: int | None = None
     ) -> list[dict]:

--- a/backend/tests/unit/test_match_summary.py
+++ b/backend/tests/unit/test_match_summary.py
@@ -1,0 +1,201 @@
+"""Unit tests for the agent match-summary endpoint."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestGetMatchSummary:
+    """Tests for MatchDAO.get_match_summary()."""
+
+    def _make_dao(self):
+        from unittest.mock import patch
+
+        from dao.match_dao import MatchDAO
+
+        mock_client = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.get_client.return_value = mock_client
+
+        with patch.object(MatchDAO, "__init__", lambda self, conn: None):
+            dao = MatchDAO(mock_conn)
+            dao.connection_holder = mock_conn
+            dao.client = mock_client
+
+        return dao
+
+    def test_returns_empty_for_unknown_season(self):
+        dao = self._make_dao()
+        # Mock season lookup returning no results
+        mock_table = MagicMock()
+        dao.client.table.return_value = mock_table
+        mock_table.select.return_value = mock_table
+        mock_table.eq.return_value = mock_table
+        mock_table.limit.return_value = mock_table
+        mock_table.execute.return_value = MagicMock(data=[])
+
+        result = dao.get_match_summary("9999-00")
+        assert result == []
+
+    def test_groups_matches_correctly(self):
+        dao = self._make_dao()
+
+        matches_data = [
+            {
+                "match_date": "2026-03-01",
+                "match_status": "played",
+                "home_score": 2,
+                "away_score": 1,
+                "age_group": {"name": "U14"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+            {
+                "match_date": "2026-03-15",
+                "match_status": "scheduled",
+                "home_score": None,
+                "away_score": None,
+                "age_group": {"name": "U14"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+        ]
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "seasons":
+                mock.select.return_value = mock
+                mock.eq.return_value = mock
+                mock.limit.return_value = mock
+                mock.execute.return_value = MagicMock(data=[{"id": 1}])
+            elif name == "matches":
+                mock.select.return_value = mock
+                mock.eq.return_value = mock
+                mock.execute.return_value = MagicMock(data=matches_data)
+            return mock
+
+        dao.client.table = table_side_effect
+
+        result = dao.get_match_summary("2025-26")
+        assert len(result) == 1
+        group = result[0]
+        assert group["age_group"] == "U14"
+        assert group["league"] == "Homegrown"
+        assert group["division"] == "Northeast"
+        assert group["total"] == 2
+        assert group["by_status"]["played"] == 1
+        assert group["by_status"]["scheduled"] == 1
+        assert group["last_played_date"] == "2026-03-01"
+
+    def test_needs_score_counts_past_unscored(self):
+        dao = self._make_dao()
+
+        matches_data = [
+            {
+                "match_date": "2026-03-01",
+                "match_status": "scheduled",
+                "home_score": None,
+                "away_score": None,
+                "age_group": {"name": "U14"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+            {
+                "match_date": "2026-03-01",
+                "match_status": "tbd",
+                "home_score": None,
+                "away_score": None,
+                "age_group": {"name": "U14"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+            {
+                "match_date": "2099-12-31",
+                "match_status": "scheduled",
+                "home_score": None,
+                "away_score": None,
+                "age_group": {"name": "U14"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+        ]
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "seasons":
+                mock.select.return_value = mock
+                mock.eq.return_value = mock
+                mock.limit.return_value = mock
+                mock.execute.return_value = MagicMock(data=[{"id": 1}])
+            elif name == "matches":
+                mock.select.return_value = mock
+                mock.eq.return_value = mock
+                mock.execute.return_value = MagicMock(data=matches_data)
+            return mock
+
+        dao.client.table = table_side_effect
+
+        result = dao.get_match_summary("2025-26")
+        assert result[0]["needs_score"] == 2  # Only past matches count
+
+
+@pytest.mark.unit
+class TestMatchSummaryEndpoint:
+    """Tests for GET /api/agent/match-summary endpoint."""
+
+    def test_returns_summary(self):
+        from unittest.mock import patch as mock_patch
+
+        with (
+            mock_patch("app.match_dao") as mock_dao,
+            mock_patch("app.require_match_management_permission", return_value=lambda: {"role": "service_account"}),
+        ):
+            mock_dao.get_match_summary.return_value = [
+                {
+                    "age_group": "U14",
+                    "league": "Homegrown",
+                    "division": "Northeast",
+                    "total": 92,
+                    "by_status": {"played": 45, "scheduled": 40},
+                    "needs_score": 5,
+                    "date_range": {"earliest": "2026-03-01", "latest": "2026-06-28"},
+                    "last_played_date": "2026-03-07",
+                }
+            ]
+
+            from fastapi.testclient import TestClient
+
+            from app import app
+
+            # Override the auth dependency
+            from auth import require_match_management_permission
+
+            app.dependency_overrides[require_match_management_permission] = lambda: {
+                "role": "service_account",
+                "service_name": "test",
+                "permissions": ["manage_matches"],
+            }
+
+            try:
+                client = TestClient(app)
+                response = client.get("/api/agent/match-summary?season=2025-26")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["season"] == "2025-26"
+                assert len(data["targets"]) == 1
+                assert data["targets"][0]["total"] == 92
+            finally:
+                app.dependency_overrides.clear()
+
+    def test_missing_season_param(self):
+        from fastapi.testclient import TestClient
+
+        from app import app
+        from auth import require_match_management_permission
+
+        app.dependency_overrides[require_match_management_permission] = lambda: {
+            "role": "service_account",
+        }
+
+        try:
+            client = TestClient(app)
+            response = client.get("/api/agent/match-summary")
+            assert response.status_code == 422  # Missing required query param
+        finally:
+            app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- New `GET /api/agent/match-summary?season=2025-26` endpoint for the match-scraper-agent
- New `MatchDAO.get_match_summary()` method that queries all season matches, groups by (age_group, league, division), and computes per-group stats: total count, status breakdown, needs_score count, date range, last_played_date
- Auth: uses existing `require_match_management_permission` (supports service accounts with `manage_matches` permission)
- Unit tests for both DAO and endpoint

## Context
The agent currently scrapes 454 matches (full season) and resubmits everything every 6 hours with zero awareness of what MT already has. This endpoint gives the agent memory — it can check what exists and make targeted scraping decisions.

## Test plan
- [x] Unit tests pass: `uv run pytest tests/unit/test_match_summary.py -v` (5/5)
- [x] Ruff lint clean
- [ ] Deploy to prod, verify with: `curl -H "Authorization: Bearer $TOKEN" https://api.missingtable.com/api/agent/match-summary?season=2025-26`

🤖 Generated with [Claude Code](https://claude.com/claude-code)