### PR TITLE
feat: Add position movement and form indicators to league table

### DIFF
--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -16,7 +16,7 @@ from postgrest.exceptions import APIError
 from dao.base_dao import BaseDAO, clear_cache, dao_cache, invalidates_cache
 from dao.exceptions import DuplicateRecordError
 from dao.standings import (
-    calculate_standings,
+    calculate_standings_with_extras,
     filter_by_match_type,
     filter_completed_matches,
     filter_same_division_matches,
@@ -907,8 +907,8 @@ class MatchDAO(BaseDAO):
                 matches = filter_same_division_matches(matches, division_id)
             matches = filter_completed_matches(matches)
 
-            # Calculate standings using pure function
-            return calculate_standings(matches)
+            # Calculate standings using pure function (with form + movement)
+            return calculate_standings_with_extras(matches)
 
         except Exception:
             logger.exception("Error generating league table")

--- a/backend/dao/standings.py
+++ b/backend/dao/standings.py
@@ -10,6 +10,7 @@ unit tested independently.
 
 from collections import defaultdict
 from datetime import date
+from operator import itemgetter
 
 
 def filter_completed_matches(matches: list[dict]) -> list[dict]:
@@ -189,5 +190,131 @@ def calculate_standings(matches: list[dict]) -> list[dict]:
         key=lambda x: (x["points"], x["goal_difference"], x["goals_for"]),
         reverse=True,
     )
+
+    return table
+
+
+def get_team_form(matches: list[dict], last_n: int = 5) -> dict[str, list[str]]:
+    """
+    Calculate recent form (W/D/L) for each team from completed matches.
+
+    Args:
+        matches: List of completed match dicts with scores and match_date
+        last_n: Number of recent results to return (default 5)
+
+    Returns:
+        Dict mapping team name to list of results, most recent last.
+        e.g. {"Northeast IFA": ["W", "L", "D", "W", "W"]}
+    """
+    # Build per-team results ordered by match_date
+    team_results: dict[str, list[tuple[str, str]]] = defaultdict(list)
+
+    for match in matches:
+        home_team = match["home_team"]["name"]
+        away_team = match["away_team"]["name"]
+        home_score = match.get("home_score")
+        away_score = match.get("away_score")
+        match_date = match.get("match_date", "")
+
+        if home_score is None or away_score is None:
+            continue
+
+        if home_score > away_score:
+            team_results[home_team].append((match_date, "W"))
+            team_results[away_team].append((match_date, "L"))
+        elif away_score > home_score:
+            team_results[home_team].append((match_date, "L"))
+            team_results[away_team].append((match_date, "W"))
+        else:
+            team_results[home_team].append((match_date, "D"))
+            team_results[away_team].append((match_date, "D"))
+
+    # Sort by date and take last N
+    form: dict[str, list[str]] = {}
+    for team, results in team_results.items():
+        results.sort(key=itemgetter(0))
+        form[team] = [r for _, r in results[-last_n:]]
+
+    return form
+
+
+def calculate_position_movement(
+    current_matches: list[dict],
+) -> dict[str, int]:
+    """
+    Calculate position change for each team by comparing standings
+    with and without the most recent match day's results.
+
+    Args:
+        current_matches: All completed matches (with scores and match_date)
+
+    Returns:
+        Dict mapping team name to position change (positive = moved up,
+        negative = moved down, 0 = unchanged). Teams with no previous
+        position (first match day) get 0.
+    """
+    # Find distinct match dates
+    match_dates = set()
+    for match in current_matches:
+        md = match.get("match_date")
+        if md and match.get("home_score") is not None:
+            match_dates.add(md)
+
+    if len(match_dates) < 2:
+        # Only one match day — no previous standings to compare
+        return {}
+
+    latest_date = max(match_dates)
+
+    # Previous standings: exclude the latest match day
+    previous_matches = [m for m in current_matches if m.get("match_date") != latest_date]
+    previous_table = calculate_standings(previous_matches)
+
+    # Build position maps (1-indexed)
+    previous_positions = {
+        row["team"]: i + 1 for i, row in enumerate(previous_table)
+    }
+
+    current_table = calculate_standings(current_matches)
+    current_positions = {
+        row["team"]: i + 1 for i, row in enumerate(current_table)
+    }
+
+    # Calculate movement: previous - current (positive = moved up)
+    movement: dict[str, int] = {}
+    for team, current_pos in current_positions.items():
+        previous_pos = previous_positions.get(team)
+        if previous_pos is None:
+            # New team (first match day for them)
+            movement[team] = 0
+        else:
+            movement[team] = previous_pos - current_pos
+
+    return movement
+
+
+def calculate_standings_with_extras(matches: list[dict]) -> list[dict]:
+    """
+    Calculate standings enriched with position movement and recent form.
+
+    Wraps calculate_standings() and adds:
+        - form: list of last 5 results (e.g. ["W", "D", "L", "W", "W"])
+        - position_change: int (positive = moved up, negative = down, 0 = same)
+
+    Args:
+        matches: List of completed match dicts
+
+    Returns:
+        Same as calculate_standings() but each row also has 'form' and
+        'position_change' keys.
+    """
+    table = calculate_standings(matches)
+    form = get_team_form(matches)
+    movement = calculate_position_movement(matches)
+
+    for row in table:
+        team = row["team"]
+        row["form"] = form.get(team, [])
+        row["position_change"] = movement.get(team, 0)
 
     return table

--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -146,6 +146,12 @@
               #
             </th>
             <th
+              class="px-1 sm:px-2 md:px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              title="Position movement"
+            >
+              +/-
+            </th>
+            <th
               class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider max-w-[100px] sm:max-w-[140px] md:max-w-none"
             >
               Team
@@ -190,6 +196,11 @@
             >
               Pts
             </th>
+            <th
+              class="hidden sm:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              Form
+            </th>
           </tr>
         </thead>
         <tbody
@@ -205,6 +216,25 @@
               class="px-1 sm:px-2 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-gray-500"
             >
               {{ index + 1 }}
+            </td>
+            <td
+              class="px-1 sm:px-2 md:px-3 py-3 md:py-4 whitespace-nowrap text-xs text-center"
+            >
+              <span
+                v-if="team.position_change > 0"
+                class="text-green-600 font-medium"
+                :title="`Up ${team.position_change}`"
+              >
+                ▲ {{ team.position_change }}
+              </span>
+              <span
+                v-else-if="team.position_change < 0"
+                class="text-red-600 font-medium"
+                :title="`Down ${Math.abs(team.position_change)}`"
+              >
+                ▼ {{ Math.abs(team.position_change) }}
+              </span>
+              <span v-else class="text-gray-400">—</span>
             </td>
             <td
               class="px-2 sm:px-4 md:px-6 py-3 md:py-4 text-xs sm:text-sm font-medium text-gray-900 max-w-[100px] sm:max-w-[140px] md:max-w-none md:whitespace-nowrap"
@@ -257,6 +287,27 @@
               class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center font-medium text-gray-900"
             >
               {{ team.points }}
+            </td>
+            <td
+              class="hidden sm:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-center"
+            >
+              <div class="flex items-center justify-center gap-1">
+                <span
+                  v-for="(result, rIdx) in team.form || []"
+                  :key="rIdx"
+                  class="inline-block w-5 h-5 rounded-full text-[10px] font-bold leading-5 text-white text-center"
+                  :class="{
+                    'bg-green-500': result === 'W',
+                    'bg-red-500': result === 'L',
+                    'bg-gray-400': result === 'D',
+                  }"
+                  :title="
+                    result === 'W' ? 'Win' : result === 'L' ? 'Loss' : 'Draw'
+                  "
+                >
+                  {{ result }}
+                </span>
+              </div>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Summary
- **Position movement column (+/-)**: Shows how many positions each team moved since the last match day (e.g., ▲ 2 in green, ▼ 1 in red, — for unchanged)
- **Last 5 form column**: Displays recent results as colored circles (green W, red L, gray D)
- Both features are computed from existing match data — no schema changes, no new endpoints, no extra DB queries

## Implementation
- `standings.py`: Added `get_team_form()`, `calculate_position_movement()`, and `calculate_standings_with_extras()` pure functions
- `match_dao.py`: Switched to `calculate_standings_with_extras()` 
- `LeagueTable.vue`: Added movement column (always visible) and form column (hidden on mobile)

## Test plan
- [x] Backend linter passes (`ruff check`)
- [x] Frontend linter passes (`npm run lint`)
- [x] Existing unit/contract tests pass
- [x] Verified locally — table displays movement arrows and form circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)