### PR TITLE
fix: Add missing cert-manager annotation to production ingress

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -709,7 +709,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "helm/missing-table/values-prod.yaml",
-        "hashed_secret": "df4d033b3e7374cd6becfa63f141eb47a0d41713",
+        "hashed_secret": "889510f7de33270e5a7cb99960f20655930d3f6d",
         "is_verified": false,
         "line_number": 10
       }
@@ -795,21 +795,21 @@
         "filename": "supabase-local/config.toml",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 168
       },
       {
         "type": "Secret Keyword",
         "filename": "supabase-local/config.toml",
         "hashed_secret": "30c8249c0f2a25c5eecffceb0428715f274773ec",
         "is_verified": false,
-        "line_number": 255
+        "line_number": 260
       },
       {
         "type": "Secret Keyword",
         "filename": "supabase-local/config.toml",
         "hashed_secret": "d69adab9ea54bd310869061f85347474d740d467",
         "is_verified": false,
-        "line_number": 322
+        "line_number": 327
       }
     ],
     "supabase-local/migrations/.archive/010_invite_system.sql": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-20T00:41:18Z"
+  "generated_at": "2026-03-13T00:56:00Z"
 }

--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -66,6 +66,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts:
     - missingtable.com


### PR DESCRIPTION
## Summary
- Adds `cert-manager.io/cluster-issuer: letsencrypt-prod` annotation to production ingress in `values-prod.yaml`
- This annotation was present in `values.yaml` defaults but was being overridden by the prod values, which only had `force-ssl-redirect`
- Without it, cert-manager doesn't manage/renew the TLS certificate, causing the SSL cert to expire and making missingtable.com unreachable

## Test plan
- [ ] Merge PR and let ArgoCD sync
- [ ] Verify cert-manager picks up the annotation: `kubectl get certificates -n missing-table`
- [ ] Confirm new cert is issued: `kubectl describe certificate -n missing-table`
- [ ] Verify https://missingtable.com loads without certificate errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)