### PR TITLE
fix: Add cert-manager annotation and update club data

### DIFF
--- a/clubs.json
+++ b/clubs.json
@@ -239,7 +239,7 @@
     {
         "club_name": "Rochester NY FC",
         "location": "Rochester, NY",
-        "website": "https://www.rochesternyfc.com",
+        "website": "https://www.rnyfc-youth.com",
         "teams": [
             {
                 "team_name": "Rochester NY FC",
@@ -264,6 +264,9 @@
                 ]
             }
         ],
+        "logo_url": "https://images.mlssoccer.com/image/upload/t_q-best/v1645628273/assets/mnp/logos/clubs/rnyfc-color.png",
+        "primary_color": "#3DDB85",
+        "secondary_color": "#1A1A2E",
         "is_pro_academy": false
     },
     {


### PR DESCRIPTION
## Summary
- Add missing `cert-manager.io/cluster-issuer` annotation to production ingress for TLS cert renewal
- Update Rochester NY FC: correct website URL (rnyfc-youth.com), add logo and brand colors
- FC Westchester and Seacoast United logos updated directly in prod database/storage

## Test plan
- [ ] Verify TLS cert renewal works with the new annotation
- [ ] Confirm Rochester NY FC logo displays correctly on missingtable.com
- [ ] Confirm FC Westchester and Seacoast United logos display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)