### PR TITLE
fix: Correct date-only timezone bug showing wrong day

### DIFF
--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -598,7 +598,7 @@ export default {
     // Format date for display
     const formatDate = dateString => {
       if (!dateString) return '';
-      const date = new Date(dateString);
+      const date = new Date(dateString + 'T00:00:00');
       return date.toLocaleDateString('en-US', {
         weekday: 'short',
         month: 'short',

--- a/frontend/src/components/admin/AdminGoals.vue
+++ b/frontend/src/components/admin/AdminGoals.vue
@@ -323,7 +323,7 @@ export default {
 
     const formatDate = dateString => {
       if (!dateString) return '-';
-      return new Date(dateString).toLocaleDateString();
+      return new Date(dateString + 'T00:00:00').toLocaleDateString();
     };
 
     const formatMinute = (minute, extraTime) => {

--- a/frontend/src/components/admin/AdminMatches.vue
+++ b/frontend/src/components/admin/AdminMatches.vue
@@ -554,7 +554,7 @@ export default {
     };
 
     const formatDate = dateString => {
-      return new Date(dateString).toLocaleDateString();
+      return new Date(dateString + 'T00:00:00').toLocaleDateString();
     };
 
     // Format UTC datetime to local time display

--- a/frontend/src/components/admin/AdminSeasons.vue
+++ b/frontend/src/components/admin/AdminSeasons.vue
@@ -260,7 +260,7 @@ export default {
     };
 
     const formatDate = dateString => {
-      return new Date(dateString).toLocaleDateString();
+      return new Date(dateString + 'T00:00:00').toLocaleDateString();
     };
 
     const createSeason = async () => {

--- a/frontend/src/components/profiles/PlayerDetailView.vue
+++ b/frontend/src/components/profiles/PlayerDetailView.vue
@@ -271,7 +271,7 @@ export default {
     // Format date for display
     const formatDate = dateString => {
       if (!dateString) return '';
-      const date = new Date(dateString);
+      const date = new Date(dateString + 'T00:00:00');
       return date.toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',


### PR DESCRIPTION
## Summary
- Date-only strings (e.g., `2026-03-14`) parsed by `new Date()` are treated as UTC midnight, which rolls back to the previous day in US timezones (e.g., shows "Fri, Mar 13" instead of "Sat, Mar 14")
- Fixed by appending `T00:00:00` to force local time parsing, matching the fix already in `PlayoffBracket.vue`
- Applied across 5 components: MatchDetailView, PlayerDetailView, AdminGoals, AdminMatches, AdminSeasons

## Test plan
- [ ] Open a match detail view — verify the date matches the actual match date
- [ ] Check AdminMatches list — dates should be correct
- [ ] Check AdminSeasons — start/end dates should be correct
- [ ] Check PlayerDetailView match history — dates should be correct
- [ ] Check AdminGoals — match dates should be correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)