### PR TITLE
feat: Add needs_kickoff to match-summary API

### DIFF
--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -461,9 +461,10 @@ class MatchDAO(BaseDAO):
         and make smart decisions about what to scrape.
         """
         from collections import defaultdict
-        from datetime import date
+        from datetime import date, timedelta
 
         today = date.today().isoformat()
+        kickoff_horizon = (date.today() + timedelta(days=14)).isoformat()
 
         # Look up season by name
         season_resp = self.client.table("seasons").select("id").eq("name", season_name).limit(1).execute()
@@ -475,7 +476,7 @@ class MatchDAO(BaseDAO):
         response = (
             self.client.table("matches")
             .select("""
-                match_date, match_status, home_score, away_score,
+                match_date, match_status, home_score, away_score, scheduled_kickoff,
                 age_group:age_groups(name),
                 division:divisions(name, league_id, leagues:leagues!divisions_league_id_fkey(name))
             """)
@@ -498,6 +499,7 @@ class MatchDAO(BaseDAO):
         for (ag, league, div), matches in sorted(groups.items()):
             by_status = defaultdict(int)
             needs_score = 0
+            needs_kickoff = 0
             dates = []
             last_played = None
 
@@ -510,6 +512,13 @@ class MatchDAO(BaseDAO):
                 if md < today and status in ("scheduled", "tbd") and m.get("home_score") is None:
                     needs_score += 1
 
+                if (
+                    status in ("scheduled", "tbd")
+                    and today <= md <= kickoff_horizon
+                    and not m.get("scheduled_kickoff")
+                ):
+                    needs_kickoff += 1
+
                 if status == "played" and (last_played is None or md > last_played):
                     last_played = md
 
@@ -521,6 +530,7 @@ class MatchDAO(BaseDAO):
                     "total": len(matches),
                     "by_status": dict(by_status),
                     "needs_score": needs_score,
+                    "needs_kickoff": needs_kickoff,
                     "date_range": {
                         "earliest": min(dates) if dates else None,
                         "latest": max(dates) if dates else None,


### PR DESCRIPTION
## Summary
- Adds `needs_kickoff` field to `/api/agent/match-summary` response — counts matches in the next 14 days with status `scheduled`/`tbd` that have no `scheduled_kickoff` set
- Fetches `scheduled_kickoff` in the aggregation query to support the count
- Celery worker already handles kick-off upserts correctly (no changes needed)

## Context
Part of the Kick-off Time Awareness feature. MLS Next often publishes kick-off times close to match day. This field lets the match-scraper-agent (MSA) decide when to run `KICKOFF_SYNC` to re-check for newly published times. MSA changes are in a separate PR.

## Backward Compatibility
MSA uses `.get("needs_kickoff", 0)`, so it works with or without this change deployed.

## Test plan
- [ ] Verify `needs_kickoff` appears in `/api/agent/match-summary` response
- [ ] Confirm count is correct for matches within 14-day window missing kick-off times
- [ ] Existing backend tests pass (`uv run pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)