### PR TITLE
feat: Add played tracking, card events, and post-match stats

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -42,6 +42,7 @@ from models import (
     LeagueCreate,
     LeagueUpdate,
     LineupSave,
+    LiveCardEvent,
     LiveMatchClock,
     MatchPatch,
     MatchSubmissionData,
@@ -49,6 +50,7 @@ from models import (
     PlayerCustomization,
     PlayerHistoryCreate,
     PlayerHistoryUpdate,
+    PostMatchCard,
     PostMatchGoal,
     PostMatchSubstitution,
     ProfilePhotoSlot,
@@ -2065,6 +2067,21 @@ async def get_matches(
                 m for m in matches if m.get("home_team_id") in club_team_ids or m.get("away_team_id") in club_team_ids
             ]
 
+        # Enrich matches with card event data
+        match_ids = [m["id"] for m in matches if m.get("id")]
+        if match_ids:
+            card_events = match_event_dao.get_card_events_for_matches(match_ids)
+            for m in matches:
+                cards = card_events.get(m["id"], [])
+                m["red_cards"] = [
+                    {"team_id": c["team_id"], "player_name": c["player_name"]}
+                    for c in cards if c["event_type"] == "red_card"
+                ]
+                m["yellow_cards"] = [
+                    {"team_id": c["team_id"], "player_name": c["player_name"]}
+                    for c in cards if c["event_type"] == "yellow_card"
+                ]
+
         return matches
     except Exception as e:
         logger.error(f"Error retrieving matches: {e!s}", exc_info=True)
@@ -2338,8 +2355,25 @@ async def get_matches_by_team(
     """Get matches for a specific team."""
     try:
         matches = match_dao.get_matches_by_team(team_id, season_id=season_id, age_group_id=age_group_id)
-        # Return empty array if no matches found - this is not an error condition
-        return matches if matches else []
+        if not matches:
+            return []
+
+        # Enrich matches with card event data
+        match_ids = [m["id"] for m in matches if m.get("id")]
+        if match_ids:
+            card_events = match_event_dao.get_card_events_for_matches(match_ids)
+            for m in matches:
+                cards = card_events.get(m["id"], [])
+                m["red_cards"] = [
+                    {"team_id": c["team_id"], "player_name": c["player_name"]}
+                    for c in cards if c["event_type"] == "red_card"
+                ]
+                m["yellow_cards"] = [
+                    {"team_id": c["team_id"], "player_name": c["player_name"]}
+                    for c in cards if c["event_type"] == "yellow_card"
+                ]
+
+        return matches
     except Exception as e:
         logger.error(f"Error retrieving matches for team '{team_id}': {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -2594,6 +2628,89 @@ async def post_goal(
         raise
     except Exception as e:
         logger.error(f"Error posting goal: {e!s}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.post("/api/matches/{match_id}/live/card")
+async def post_live_card(
+    match_id: int,
+    card: LiveCardEvent,
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Record a card event during a live match.
+
+    Creates a card event in the match timeline and updates player_match_stats.
+    The match minute is auto-calculated from the match clock.
+    """
+    try:
+        current_match = match_dao.get_match_by_id(match_id)
+        if not current_match:
+            raise HTTPException(status_code=404, detail="Match not found")
+
+        if not auth_manager.can_edit_match(current_user, current_match["home_team_id"], current_match["away_team_id"]):
+            raise HTTPException(status_code=403, detail="You don't have permission to manage this match")
+
+        if card.team_id not in [current_match["home_team_id"], current_match["away_team_id"]]:
+            raise HTTPException(status_code=400, detail="Team must be one of the match participants")
+
+        # Validate player exists and is on the team
+        player = roster_dao.get_player_by_id(card.player_id)
+        if not player:
+            raise HTTPException(status_code=400, detail="Player not found")
+        if player["team_id"] != card.team_id:
+            raise HTTPException(status_code=400, detail="Player must be on the specified team")
+
+        player_name = player.get("display_name", f"#{player['jersey_number']}")
+        card_label = "RED CARD" if card.card_type == "red_card" else "YELLOW CARD"
+
+        card_message = f"{card_label}: {player_name}"
+        if card.message:
+            card_message += f" ({card.message})"
+
+        # Auto-calculate match minute
+        match_minute, extra_time = calculate_match_minute(current_match)
+
+        user_id = current_user.get("user_id") or current_user.get("id")
+
+        event = match_event_dao.create_event(
+            match_id=match_id,
+            event_type=card.card_type,
+            message=card_message,
+            created_by=user_id,
+            created_by_username=current_user.get("username"),
+            team_id=card.team_id,
+            player_name=player_name,
+            player_id=card.player_id,
+            match_minute=match_minute,
+            extra_time=extra_time,
+        )
+
+        if not event:
+            raise HTTPException(status_code=500, detail="Failed to create card event")
+
+        # Update player card stats
+        stats = player_stats_dao.get_or_create_match_stats(card.player_id, match_id)
+        if stats:
+            card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
+            current_count = stats.get(card_field, 0)
+            player_stats_dao.client.table("player_match_stats").update(
+                {card_field: current_count + 1, "played": True}
+            ).eq("player_id", card.player_id).eq("match_id", match_id).execute()
+
+        logger.info(
+            "live_card_recorded",
+            match_id=match_id,
+            player_id=card.player_id,
+            card_type=card.card_type,
+            minute=match_minute,
+        )
+
+        return event
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error recording live card: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
@@ -3068,6 +3185,141 @@ async def post_match_remove_substitution(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+@app.post("/api/matches/{match_id}/post-match/card")
+async def post_match_add_card(
+    match_id: int,
+    card: PostMatchCard,
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Record a card (yellow or red) for a completed match.
+
+    Creates a card event and updates the player's card count in player_match_stats.
+    """
+    try:
+        current_match = match_dao.get_match_by_id(match_id)
+        if not current_match:
+            raise HTTPException(status_code=404, detail="Match not found")
+
+        validate_post_match_access(current_user, current_match, card.team_id)
+
+        # Validate player exists and is on the team
+        player = roster_dao.get_player_by_id(card.player_id)
+        if not player:
+            raise HTTPException(status_code=400, detail="Player not found")
+        if player["team_id"] != card.team_id:
+            raise HTTPException(status_code=400, detail="Player must be on the specified team")
+
+        player_name = player.get("display_name", f"#{player['jersey_number']}")
+        card_label = "RED CARD" if card.card_type == "red_card" else "YELLOW CARD"
+
+        card_message = f"{card_label}: {player_name}"
+        if card.message:
+            card_message += f" ({card.message})"
+
+        user_id = current_user.get("user_id") or current_user.get("id")
+
+        event = match_event_dao.create_event(
+            match_id=match_id,
+            event_type=card.card_type,
+            message=card_message,
+            created_by=user_id,
+            created_by_username=current_user.get("username"),
+            team_id=card.team_id,
+            player_name=player_name,
+            player_id=card.player_id,
+            match_minute=card.match_minute,
+            extra_time=card.extra_time,
+        )
+
+        if not event:
+            raise HTTPException(status_code=500, detail="Failed to create card event")
+
+        # Update player card stats
+        stats = player_stats_dao.get_or_create_match_stats(card.player_id, match_id)
+        if stats:
+            card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
+            current_count = stats.get(card_field, 0)
+            player_stats_dao.client.table("player_match_stats").update(
+                {card_field: current_count + 1, "played": True}
+            ).eq("player_id", card.player_id).eq("match_id", match_id).execute()
+
+        logger.info(
+            "post_match_card_recorded",
+            match_id=match_id,
+            player_id=card.player_id,
+            card_type=card.card_type,
+            minute=card.match_minute,
+        )
+
+        return event
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error recording post-match card: {e!s}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.delete("/api/matches/{match_id}/post-match/card/{event_id}")
+async def post_match_remove_card(
+    match_id: int,
+    event_id: int,
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Remove a card event from a completed match."""
+    try:
+        current_match = match_dao.get_match_by_id(match_id)
+        if not current_match:
+            raise HTTPException(status_code=404, detail="Match not found")
+
+        event = match_event_dao.get_event_by_id(event_id)
+        if not event:
+            raise HTTPException(status_code=404, detail="Event not found")
+        if event.get("match_id") != match_id:
+            raise HTTPException(status_code=400, detail="Event does not belong to this match")
+        if event.get("event_type") not in ("red_card", "yellow_card"):
+            raise HTTPException(status_code=400, detail="Event is not a card")
+
+        team_id = event.get("team_id")
+        if team_id:
+            validate_post_match_access(current_user, current_match, team_id)
+        else:
+            if not auth_manager.can_edit_match(
+                current_user, current_match["home_team_id"], current_match["away_team_id"]
+            ):
+                raise HTTPException(status_code=403, detail="You don't have permission to manage this match")
+
+        # Decrement player card stats
+        player_id = event.get("player_id")
+        if player_id:
+            stats = player_stats_dao.get_match_stats(player_id, match_id)
+            if stats:
+                card_field = "red_cards" if event["event_type"] == "red_card" else "yellow_cards"
+                new_count = max(0, stats.get(card_field, 0) - 1)
+                player_stats_dao.client.table("player_match_stats").update(
+                    {card_field: new_count}
+                ).eq("player_id", player_id).eq("match_id", match_id).execute()
+
+        user_id = current_user.get("user_id") or current_user.get("id")
+        success = match_event_dao.soft_delete_event(event_id, deleted_by=user_id)
+        if not success:
+            raise HTTPException(status_code=500, detail="Failed to delete card event")
+
+        logger.info(
+            "post_match_card_removed",
+            match_id=match_id,
+            event_id=event_id,
+        )
+
+        return {"detail": "Card removed"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error removing post-match card: {e!s}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 @app.get("/api/matches/{match_id}/post-match/stats/{team_id}")
 async def post_match_get_stats(
     match_id: int,
@@ -3112,7 +3364,10 @@ async def post_match_update_stats(
             {
                 "player_id": entry.player_id,
                 "started": entry.started,
+                "played": entry.played,
                 "minutes_played": entry.minutes_played,
+                "yellow_cards": entry.yellow_cards,
+                "red_cards": entry.red_cards,
             }
             for entry in batch.players
         ]

--- a/backend/dao/match_event_dao.py
+++ b/backend/dao/match_event_dao.py
@@ -351,6 +351,40 @@ class MatchEventDAO(BaseDAO):
             logger.exception("Error getting goal events")
             return []
 
+    def get_card_events_for_matches(self, match_ids: list[int]) -> dict[int, list[dict]]:
+        """Get card events (red/yellow) for multiple matches in one query.
+
+        Args:
+            match_ids: List of match IDs
+
+        Returns:
+            Dict mapping match_id to list of card event dicts
+        """
+        if not match_ids:
+            return {}
+
+        try:
+            response = (
+                self.client.table("match_events")
+                .select("match_id, event_type, team_id, player_name")
+                .in_("match_id", match_ids)
+                .in_("event_type", ["red_card", "yellow_card"])
+                .eq("is_deleted", False)
+                .execute()
+            )
+
+            result: dict[int, list[dict]] = {}
+            for event in response.data or []:
+                mid = event["match_id"]
+                if mid not in result:
+                    result[mid] = []
+                result[mid].append(event)
+            return result
+
+        except Exception:
+            logger.exception("Error fetching card events for matches")
+            return {}
+
     def get_events_count(self, match_id: int) -> int:
         """Get total count of active events for a match.
 

--- a/backend/dao/player_stats_dao.py
+++ b/backend/dao/player_stats_dao.py
@@ -78,6 +78,7 @@ class PlayerStatsDAO(BaseDAO):
                         "player_id": player_id,
                         "match_id": match_id,
                         "started": False,
+                        "played": False,
                         "minutes_played": 0,
                         "goals": 0,
                     }
@@ -123,8 +124,8 @@ class PlayerStatsDAO(BaseDAO):
 
             stats = response.data or []
 
-            # Aggregate
-            games_played = len(stats)
+            # Aggregate - only count games where player actually participated
+            games_played = sum(1 for s in stats if s.get("played") or s.get("started"))
             games_started = sum(1 for s in stats if s.get("started"))
             total_minutes = sum(s.get("minutes_played", 0) for s in stats)
             total_goals = sum(s.get("goals", 0) for s in stats)
@@ -228,6 +229,8 @@ class PlayerStatsDAO(BaseDAO):
                 .select("""
                     player_id,
                     goals,
+                    started,
+                    played,
                     match:matches!inner(
                         id,
                         season_id,
@@ -313,7 +316,8 @@ class PlayerStatsDAO(BaseDAO):
                     }
 
                 player_goals[player_id]["goals"] += goals
-                player_goals[player_id]["games_played"] += 1
+                if stat.get("played") or stat.get("started"):
+                    player_goals[player_id]["games_played"] += 1
 
             # Filter out players with 0 goals and sort
             result = [p for p in player_goals.values() if p["goals"] > 0]
@@ -437,8 +441,11 @@ class PlayerStatsDAO(BaseDAO):
                     "first_name": player.get("first_name"),
                     "last_name": player.get("last_name"),
                     "started": stats.get("started", False),
+                    "played": stats.get("played", False),
                     "minutes_played": stats.get("minutes_played", 0),
                     "goals": stats.get("goals", 0),
+                    "yellow_cards": stats.get("yellow_cards", 0),
+                    "red_cards": stats.get("red_cards", 0),
                 })
 
             return result
@@ -470,10 +477,14 @@ class PlayerStatsDAO(BaseDAO):
                 # Ensure record exists
                 self.get_or_create_match_stats(player_id, match_id)
 
-                # Update started and minutes
+                # Update started, played, minutes, and cards
+                played = entry.get("played", False) or entry["started"]
                 self.client.table("player_match_stats").update({
                     "started": entry["started"],
+                    "played": played,
                     "minutes_played": entry["minutes_played"],
+                    "yellow_cards": entry.get("yellow_cards", 0),
+                    "red_cards": entry.get("red_cards", 0),
                 }).eq("player_id", player_id).eq("match_id", match_id).execute()
 
             logger.info(
@@ -517,7 +528,7 @@ class PlayerStatsDAO(BaseDAO):
 
             response = (
                 self.client.table("player_match_stats")
-                .update({"goals": current_goals + 1})
+                .update({"goals": current_goals + 1, "played": True})
                 .eq("player_id", player_id)
                 .eq("match_id", match_id)
                 .execute()
@@ -598,9 +609,13 @@ class PlayerStatsDAO(BaseDAO):
             # Ensure record exists
             self.get_or_create_match_stats(player_id, match_id)
 
+            update_data = {"started": started}
+            if started:
+                update_data["played"] = True
+
             response = (
                 self.client.table("player_match_stats")
-                .update({"started": started})
+                .update(update_data)
                 .eq("player_id", player_id)
                 .eq("match_id", match_id)
                 .execute()
@@ -675,7 +690,7 @@ class PlayerStatsDAO(BaseDAO):
 
             response = (
                 self.client.table("player_match_stats")
-                .update({"started": started, "minutes_played": minutes})
+                .update({"started": started, "played": True, "minutes_played": minutes})
                 .eq("player_id", player_id)
                 .eq("match_id", match_id)
                 .execute()

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -45,6 +45,7 @@ from .lineup import (
 from .live_match import (
     GoalEvent,
     GoalEventUpdate,
+    LiveCardEvent,
     LiveMatchClock,
     LiveMatchState,
     LiveMatchSummary,
@@ -67,6 +68,7 @@ from .playoffs import (
 from .post_match import (
     BatchPlayerStatsUpdate,
     PlayerStatEntry,
+    PostMatchCard,
     PostMatchGoal,
     PostMatchSubstitution,
 )
@@ -113,6 +115,7 @@ __all__ = [
     "GenerateBracketRequest",
     "GoalEvent",
     "GoalEventUpdate",
+    "LiveCardEvent",
     "JerseyNumberUpdate",
     "League",
     "LeagueCreate",
@@ -133,6 +136,7 @@ __all__ = [
     "PlayerHistoryUpdate",
     "PlayerStatEntry",
     "PlayoffBracketSlot",
+    "PostMatchCard",
     "PostMatchGoal",
     "PostMatchSubstitution",
     "ProfilePhotoSlot",

--- a/backend/models/live_match.py
+++ b/backend/models/live_match.py
@@ -37,6 +37,15 @@ class GoalEvent(BaseModel):
     message: str | None = Field(None, max_length=500, description="Optional description")
 
 
+class LiveCardEvent(BaseModel):
+    """Model for recording a card event during a live match."""
+
+    team_id: int = Field(..., description="ID of the team the player belongs to")
+    player_id: int = Field(..., description="ID of the carded player from roster")
+    card_type: str = Field(..., pattern="^(yellow_card|red_card)$", description="Type of card: yellow_card or red_card")
+    message: str | None = Field(None, max_length=500, description="Optional description (e.g., reason for card)")
+
+
 class MessageEvent(BaseModel):
     """Model for posting a chat message."""
 

--- a/backend/models/post_match.py
+++ b/backend/models/post_match.py
@@ -28,12 +28,26 @@ class PostMatchSubstitution(BaseModel):
     extra_time: int | None = Field(None, ge=1, description="Stoppage time minutes")
 
 
+class PostMatchCard(BaseModel):
+    """Model for recording a post-match card event (yellow or red)."""
+
+    team_id: int = Field(..., description="ID of the team the player belongs to")
+    player_id: int = Field(..., description="ID of the carded player from roster")
+    card_type: str = Field(..., pattern="^(yellow_card|red_card)$", description="Type of card: yellow_card or red_card")
+    match_minute: int = Field(..., ge=1, le=130, description="Minute the card was given")
+    extra_time: int | None = Field(None, ge=1, description="Stoppage time minutes")
+    message: str | None = Field(None, max_length=500, description="Optional description (e.g., reason for card)")
+
+
 class PlayerStatEntry(BaseModel):
     """Model for a single player's match stats update."""
 
     player_id: int = Field(..., description="Player ID from roster")
     started: bool = Field(..., description="Whether the player started the match")
+    played: bool = Field(..., description="Whether the player participated in the match")
     minutes_played: int = Field(..., ge=0, le=130, description="Total minutes played")
+    yellow_cards: int = Field(0, ge=0, le=2, description="Yellow cards received (0-2)")
+    red_cards: int = Field(0, ge=0, le=1, description="Red cards received (0-1)")
 
 
 class BatchPlayerStatsUpdate(BaseModel):

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -194,6 +194,66 @@
               </div>
             </div>
           </div>
+
+          <!-- Cards -->
+          <div
+            v-if="homeCards.length || awayCards.length"
+            class="flex justify-center gap-4 mt-2 pt-2 border-t border-slate-700"
+          >
+            <div class="flex-1 text-right max-w-[140px]">
+              <div
+                v-for="card in homeCards"
+                :key="card.id"
+                class="text-xs text-slate-300 mb-1"
+              >
+                {{ card.player_name }}
+                <svg
+                  width="10"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  class="inline-block align-middle mx-0.5"
+                >
+                  <rect
+                    x="4"
+                    width="16"
+                    height="24"
+                    rx="2"
+                    :fill="
+                      card.event_type === 'red_card' ? '#EA3323' : '#FBBF24'
+                    "
+                  />
+                </svg>
+                {{ formatMinute(card) }}
+              </div>
+            </div>
+            <div class="w-px bg-slate-600 flex-shrink-0"></div>
+            <div class="flex-1 text-left max-w-[140px]">
+              <div
+                v-for="card in awayCards"
+                :key="card.id"
+                class="text-xs text-slate-300 mb-1"
+              >
+                {{ card.player_name }}
+                <svg
+                  width="10"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  class="inline-block align-middle mx-0.5"
+                >
+                  <rect
+                    x="4"
+                    width="16"
+                    height="24"
+                    rx="2"
+                    :fill="
+                      card.event_type === 'red_card' ? '#EA3323' : '#FBBF24'
+                    "
+                  />
+                </svg>
+                {{ formatMinute(card) }}
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Match Details Card -->
@@ -562,6 +622,27 @@ export default {
         .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0));
     });
 
+    // Filter cards by team
+    const homeCards = computed(() => {
+      return events.value
+        .filter(
+          e =>
+            ['red_card', 'yellow_card'].includes(e.event_type) &&
+            e.team_id === match.value?.home_team_id
+        )
+        .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0));
+    });
+
+    const awayCards = computed(() => {
+      return events.value
+        .filter(
+          e =>
+            ['red_card', 'yellow_card'].includes(e.event_type) &&
+            e.team_id === match.value?.away_team_id
+        )
+        .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0));
+    });
+
     // Format minute display (e.g., "22'" or "90+5'")
     const formatMinute = goal => {
       if (!goal.match_minute) return '';
@@ -790,6 +871,8 @@ export default {
       events,
       homeGoals,
       awayGoals,
+      homeCards,
+      awayCards,
       homeTeamColor,
       awayTeamColor,
       leagueName,

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -533,6 +533,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).away.bold }"
                         >{{ getMatchTeams(match).away.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.away_team_id
+                        )"
+                        :key="'away-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).away.icon"
                         :class="getMatchTeams(match).away.iconClass"
@@ -548,6 +568,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).home.bold }"
                         >{{ getMatchTeams(match).home.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.home_team_id
+                        )"
+                        :key="'home-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).home.icon"
                         :class="getMatchTeams(match).home.iconClass"
@@ -679,6 +719,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).away.bold }"
                         >{{ getMatchTeams(match).away.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.away_team_id
+                        )"
+                        :key="'away-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).away.icon"
                         :class="getMatchTeams(match).away.iconClass"
@@ -694,6 +754,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).home.bold }"
                         >{{ getMatchTeams(match).home.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.home_team_id
+                        )"
+                        :key="'home-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).home.icon"
                         :class="getMatchTeams(match).home.iconClass"
@@ -825,6 +905,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).away.bold }"
                         >{{ getMatchTeams(match).away.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.away_team_id
+                        )"
+                        :key="'away-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).away.icon"
                         :class="getMatchTeams(match).away.iconClass"
@@ -840,6 +940,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).home.bold }"
                         >{{ getMatchTeams(match).home.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.home_team_id
+                        )"
+                        :key="'home-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).home.icon"
                         :class="getMatchTeams(match).home.iconClass"
@@ -1145,6 +1265,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).away.bold }"
                         >{{ getMatchTeams(match).away.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.away_team_id
+                        )"
+                        :key="'away-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).away.icon"
                         :class="getMatchTeams(match).away.iconClass"
@@ -1160,6 +1300,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).home.bold }"
                         >{{ getMatchTeams(match).home.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.home_team_id
+                        )"
+                        :key="'home-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).home.icon"
                         :class="getMatchTeams(match).home.iconClass"
@@ -1303,6 +1463,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).away.bold }"
                         >{{ getMatchTeams(match).away.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.away_team_id
+                        )"
+                        :key="'away-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).away.icon"
                         :class="getMatchTeams(match).away.iconClass"
@@ -1318,6 +1498,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).home.bold }"
                         >{{ getMatchTeams(match).home.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.home_team_id
+                        )"
+                        :key="'home-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).home.icon"
                         :class="getMatchTeams(match).home.iconClass"
@@ -1461,6 +1661,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).away.bold }"
                         >{{ getMatchTeams(match).away.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.away_team_id
+                        )"
+                        :key="'away-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).away.icon"
                         :class="getMatchTeams(match).away.iconClass"
@@ -1476,6 +1696,26 @@
                         :class="{ 'font-bold': getMatchTeams(match).home.bold }"
                         >{{ getMatchTeams(match).home.name }}</span
                       >
+                      <svg
+                        v-for="n in getTeamRedCardCount(
+                          match,
+                          match.home_team_id
+                        )"
+                        :key="'home-rc-' + n"
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle"
+                      >
+                        <title>Red card</title>
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          fill="#EA3323"
+                        />
+                      </svg>
                       <span
                         v-if="getMatchTeams(match).home.icon"
                         :class="getMatchTeams(match).home.iconClass"
@@ -2127,6 +2367,11 @@ export default {
           logoUrl: match.home_team_club?.logo_url || '',
         },
       };
+    };
+
+    const getTeamRedCardCount = (match, teamId) => {
+      if (!match.red_cards || !match.red_cards.length) return 0;
+      return match.red_cards.filter(c => c.team_id === teamId).length;
     };
 
     const getSelectedTeamName = () => {
@@ -2909,6 +3154,7 @@ export default {
       seasonStats,
       getTeamDisplay,
       getMatchTeams,
+      getTeamRedCardCount,
       getSelectedTeamName,
       getTeamDisplayName,
       getTeamDisplayWithContext,

--- a/frontend/src/components/PostMatchEditor.vue
+++ b/frontend/src/components/PostMatchEditor.vue
@@ -72,6 +72,8 @@
             @remove-goal="handleRemoveGoal"
             @add-substitution="handleAddSubstitution"
             @remove-substitution="handleRemoveSubstitution"
+            @add-card="handleAddCard"
+            @remove-card="handleRemoveCard"
             @save-stats="handleSaveStats"
           />
         </div>
@@ -91,6 +93,8 @@
             @remove-goal="handleRemoveGoal"
             @add-substitution="handleAddSubstitution"
             @remove-substitution="handleRemoveSubstitution"
+            @add-card="handleAddCard"
+            @remove-card="handleRemoveCard"
             @save-stats="handleSaveStats"
           />
         </div>
@@ -140,6 +144,8 @@ export default {
       removeGoal,
       addSubstitution,
       removeSubstitution,
+      addCard,
+      removeCard,
       savePlayerStats,
     } = usePostMatchStats(
       props.matchId,
@@ -152,7 +158,9 @@ export default {
         e =>
           e.team_id === teamId &&
           !e.is_deleted &&
-          (e.event_type === 'goal' || e.event_type === 'substitution')
+          ['goal', 'substitution', 'red_card', 'yellow_card'].includes(
+            e.event_type
+          )
       );
     }
 
@@ -204,6 +212,22 @@ export default {
       }
     }
 
+    async function handleAddCard(cardData) {
+      const result = await addCard(cardData);
+      if (result.success) {
+        emit('events-changed');
+        await fetchAllStats();
+      }
+    }
+
+    async function handleRemoveCard(eventId) {
+      const result = await removeCard(eventId);
+      if (result.success) {
+        emit('events-changed');
+        await fetchAllStats();
+      }
+    }
+
     async function handleSaveStats(teamId, entries) {
       await savePlayerStats(teamId, entries);
     }
@@ -226,6 +250,8 @@ export default {
       handleRemoveGoal,
       handleAddSubstitution,
       handleRemoveSubstitution,
+      handleAddCard,
+      handleRemoveCard,
       handleSaveStats,
     };
   },

--- a/frontend/src/components/live/ActivityStream.vue
+++ b/frontend/src/components/live/ActivityStream.vue
@@ -45,6 +45,51 @@
           </button>
         </template>
 
+        <!-- Card Event -->
+        <template
+          v-else-if="
+            event.event_type === 'red_card' ||
+            event.event_type === 'yellow_card'
+          "
+        >
+          <div
+            :class="[
+              'event-icon card-icon',
+              event.event_type === 'red_card' ? 'red-card' : 'yellow-card',
+            ]"
+          >
+            <span class="card-rect"></span>
+          </div>
+          <div class="event-content">
+            <div class="event-header">
+              <span v-if="event.match_minute" class="match-minute card-minute">
+                {{ formatMatchMinute(event) }}
+              </span>
+              <span class="event-time">{{ formatTime(event.created_at) }}</span>
+              <span
+                :class="[
+                  'team-badge',
+                  event.team_id === homeTeamId ? 'home' : 'away',
+                ]"
+              >
+                {{ event.team_id === homeTeamId ? 'HOME' : 'AWAY' }}
+              </span>
+            </div>
+            <div class="card-player">{{ event.player_name }}</div>
+            <div v-if="event.message" class="event-message">
+              {{ event.message }}
+            </div>
+          </div>
+          <button
+            v-if="canDelete"
+            @click="$emit('delete-event', event.id)"
+            class="delete-button"
+            title="Delete card"
+          >
+            &#10005;
+          </button>
+        </template>
+
         <!-- Status Change Event -->
         <template v-else-if="event.event_type === 'status_change'">
           <div class="event-icon status-icon">
@@ -167,6 +212,17 @@ function formatMatchMinute(event) {
   border-left: 3px solid #ffc107;
 }
 
+/* Card events */
+.event-red_card {
+  background: linear-gradient(135deg, #4a1a1a 0%, #16213e 100%);
+  border-left: 3px solid #d32f2f;
+}
+
+.event-yellow_card {
+  background: linear-gradient(135deg, #4a3a0a 0%, #16213e 100%);
+  border-left: 3px solid #f9a825;
+}
+
 /* Message events */
 .event-message {
   background: #1a1a2e;
@@ -195,6 +251,37 @@ function formatMatchMinute(event) {
 
 .message-icon {
   background: #444;
+}
+
+.card-icon {
+  border-radius: 50%;
+}
+
+.card-icon.red-card {
+  background: #d32f2f;
+}
+
+.card-icon.yellow-card {
+  background: #f9a825;
+}
+
+.card-rect {
+  display: inline-block;
+  width: 12px;
+  height: 16px;
+  border-radius: 2px;
+  background: white;
+}
+
+.card-minute {
+  color: #ff9800;
+}
+
+.card-player {
+  font-size: 16px;
+  font-weight: bold;
+  color: white;
+  margin-bottom: 4px;
 }
 
 /* Event content */

--- a/frontend/src/components/live/LiveAdminControls.vue
+++ b/frontend/src/components/live/LiveAdminControls.vue
@@ -90,13 +90,16 @@
       </button>
     </div>
 
-    <!-- Goal Button - only when clock is running (1st or 2nd half) -->
+    <!-- Goal & Card Buttons - only when clock is running (1st or 2nd half) -->
     <div
       v-if="matchPeriod === '1st Half' || matchPeriod === '2nd Half'"
       class="goal-controls"
     >
       <button @click="showGoalModal = true" class="control-button goal">
         + Goal
+      </button>
+      <button @click="showCardModal = true" class="control-button card">
+        + Card
       </button>
     </div>
 
@@ -250,6 +253,112 @@
         </div>
       </div>
     </div>
+    <!-- Card Modal -->
+    <div
+      v-if="showCardModal"
+      class="modal-overlay"
+      @click.self="closeCardModal"
+    >
+      <div class="modal-content">
+        <h3 class="modal-title">Record Card</h3>
+
+        <div class="form-group">
+          <label>Team</label>
+          <div class="team-selector">
+            <button
+              @click="selectCardTeam(matchState.home_team_id)"
+              :class="[
+                'team-button',
+                { selected: cardTeamId === matchState.home_team_id },
+              ]"
+            >
+              {{ matchState.home_team_name }}
+            </button>
+            <button
+              @click="selectCardTeam(matchState.away_team_id)"
+              :class="[
+                'team-button',
+                { selected: cardTeamId === matchState.away_team_id },
+              ]"
+            >
+              {{ matchState.away_team_name }}
+            </button>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Card Type</label>
+          <div class="team-selector">
+            <button
+              @click="selectedCardType = 'yellow_card'"
+              :class="[
+                'team-button card-yellow',
+                { selected: selectedCardType === 'yellow_card' },
+              ]"
+            >
+              Yellow
+            </button>
+            <button
+              @click="selectedCardType = 'red_card'"
+              :class="[
+                'team-button card-red',
+                { selected: selectedCardType === 'red_card' },
+              ]"
+            >
+              Red
+            </button>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="card-player-select">Player</label>
+          <div v-if="rostersLoading" class="roster-loading">
+            Loading roster...
+          </div>
+          <select
+            v-else-if="cardTeamRoster.length > 0"
+            id="card-player-select"
+            v-model="cardPlayerId"
+            class="player-select"
+          >
+            <option :value="null">Select player...</option>
+            <option
+              v-for="player in cardTeamRoster"
+              :key="player.id"
+              :value="player.id"
+            >
+              {{ formatPlayerOption(player) }}
+            </option>
+          </select>
+          <div v-else class="no-roster-message">No roster available</div>
+        </div>
+
+        <div class="form-group">
+          <label for="card-message">Reason (optional)</label>
+          <input
+            id="card-message"
+            v-model="cardMessage"
+            type="text"
+            placeholder="e.g., Dangerous tackle"
+            class="text-input"
+          />
+        </div>
+
+        <div class="modal-actions">
+          <button @click="closeCardModal" class="cancel-button">Cancel</button>
+          <button
+            @click="submitCard"
+            :disabled="!canSubmitCard"
+            class="submit-button"
+            :class="
+              selectedCardType === 'red_card' ? 'submit-red' : 'submit-yellow'
+            "
+          >
+            Record Card
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -292,7 +401,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['update-clock', 'post-goal']);
+const emit = defineEmits(['update-clock', 'post-goal', 'post-card']);
 
 // Goal modal state
 const showGoalModal = ref(false);
@@ -306,6 +415,13 @@ const homeRoster = ref([]);
 const awayRoster = ref([]);
 const rostersLoading = ref(false);
 const rostersLoaded = ref(false);
+
+// Card modal state
+const showCardModal = ref(false);
+const cardTeamId = ref(null);
+const cardPlayerId = ref(null);
+const selectedCardType = ref('yellow_card');
+const cardMessage = ref('');
 
 // Start match modal state
 const showStartModal = ref(false);
@@ -412,6 +528,23 @@ watch(showStartModal, newVal => {
   }
 });
 
+// Load rosters when card modal opens
+watch(showCardModal, async newVal => {
+  if (newVal && props.fetchRosters && !rostersLoaded.value) {
+    rostersLoading.value = true;
+    try {
+      const rosters = await props.fetchRosters();
+      homeRoster.value = rosters.home || [];
+      awayRoster.value = rosters.away || [];
+      rostersLoaded.value = true;
+    } catch (err) {
+      console.error('Failed to load rosters:', err);
+    } finally {
+      rostersLoading.value = false;
+    }
+  }
+});
+
 // Load rosters when goal modal opens
 watch(showGoalModal, async newVal => {
   if (newVal && props.fetchRosters && !rostersLoaded.value) {
@@ -469,6 +602,45 @@ function formatPlayerOption(player) {
   }
 
   return `#${jerseyNum} ${displayName}`;
+}
+
+// Card modal computed and functions
+const cardTeamRoster = computed(() => {
+  if (!cardTeamId.value) return [];
+  if (cardTeamId.value === props.matchState.home_team_id) {
+    return homeRoster.value;
+  }
+  return awayRoster.value;
+});
+
+const canSubmitCard = computed(() => {
+  return cardTeamId.value && cardPlayerId.value && selectedCardType.value;
+});
+
+function selectCardTeam(teamId) {
+  cardTeamId.value = teamId;
+  cardPlayerId.value = null;
+}
+
+function closeCardModal() {
+  showCardModal.value = false;
+  cardTeamId.value = null;
+  cardPlayerId.value = null;
+  selectedCardType.value = 'yellow_card';
+  cardMessage.value = '';
+}
+
+function submitCard() {
+  if (!canSubmitCard.value) return;
+
+  emit('post-card', {
+    teamId: cardTeamId.value,
+    playerId: cardPlayerId.value,
+    cardType: selectedCardType.value,
+    message: cardMessage.value.trim() || null,
+  });
+
+  closeCardModal();
 }
 
 function submitGoal() {
@@ -565,6 +737,15 @@ function submitGoal() {
 
 .control-button.goal:hover {
   background: #1e88e5;
+}
+
+.control-button.card {
+  background: #ff9800;
+  color: white;
+}
+
+.control-button.card:hover {
+  background: #f57c00;
 }
 
 /* Modal */
@@ -741,6 +922,25 @@ function submitGoal() {
 .submit-button:disabled {
   background: #666;
   cursor: not-allowed;
+}
+
+.submit-button.submit-yellow {
+  background: #f9a825;
+  color: black;
+}
+
+.submit-button.submit-red {
+  background: #d32f2f;
+}
+
+.team-button.card-yellow.selected {
+  border-color: #f9a825;
+  background: rgba(249, 168, 37, 0.2);
+}
+
+.team-button.card-red.selected {
+  border-color: #d32f2f;
+  background: rgba(211, 47, 47, 0.2);
 }
 
 /* Player selection styles */

--- a/frontend/src/components/live/LiveMatchView.vue
+++ b/frontend/src/components/live/LiveMatchView.vue
@@ -49,6 +49,7 @@
         :sport-type="sportType"
         @update-clock="handleUpdateClock"
         @post-goal="handlePostGoal"
+        @post-card="handlePostCard"
       />
 
       <!-- Activity Stream -->
@@ -94,6 +95,7 @@ const {
   canManage,
   updateClock,
   postGoal,
+  postCard,
   postMessage,
   deleteEvent,
   loadMoreEvents,
@@ -121,6 +123,13 @@ async function handlePostGoal({ teamId, playerName, message, playerId }) {
   const result = await postGoal(teamId, playerName, message, playerId);
   if (!result.success) {
     alert(result.error || 'Failed to post goal');
+  }
+}
+
+async function handlePostCard({ teamId, playerId, cardType, message }) {
+  const result = await postCard(teamId, playerId, cardType, message);
+  if (!result.success) {
+    alert(result.error || 'Failed to record card');
   }
 }
 

--- a/frontend/src/components/live/LiveScoreboard.vue
+++ b/frontend/src/components/live/LiveScoreboard.vue
@@ -45,6 +45,51 @@
       </div>
     </div>
 
+    <!-- Cards -->
+    <div v-if="homeCards.length || awayCards.length" class="scorers-container">
+      <div class="scorers home-scorers">
+        <div v-for="card in homeCards" :key="card.id" class="scorer">
+          {{ card.player_name }}
+          <svg
+            width="10"
+            height="14"
+            viewBox="0 0 24 24"
+            class="inline-block align-middle mx-0.5"
+          >
+            <rect
+              x="4"
+              width="16"
+              height="24"
+              rx="2"
+              :fill="card.event_type === 'red_card' ? '#EA3323' : '#FBBF24'"
+            />
+          </svg>
+          {{ formatMinute(card) }}
+        </div>
+      </div>
+      <div class="scorers-divider"></div>
+      <div class="scorers away-scorers">
+        <div v-for="card in awayCards" :key="card.id" class="scorer">
+          {{ card.player_name }}
+          <svg
+            width="10"
+            height="14"
+            viewBox="0 0 24 24"
+            class="inline-block align-middle mx-0.5"
+          >
+            <rect
+              x="4"
+              width="16"
+              height="24"
+              rx="2"
+              :fill="card.event_type === 'red_card' ? '#EA3323' : '#FBBF24'"
+            />
+          </svg>
+          {{ formatMinute(card) }}
+        </div>
+      </div>
+    </div>
+
     <!-- Clock -->
     <div class="clock-container">
       <div class="clock">{{ elapsedTime }}</div>
@@ -115,6 +160,27 @@ const awayGoals = computed(() => {
     .filter(
       e =>
         e.event_type === 'goal' && e.team_id === props.matchState.away_team_id
+    )
+    .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0));
+});
+
+// Filter cards by team
+const homeCards = computed(() => {
+  return props.events
+    .filter(
+      e =>
+        ['red_card', 'yellow_card'].includes(e.event_type) &&
+        e.team_id === props.matchState.home_team_id
+    )
+    .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0));
+});
+
+const awayCards = computed(() => {
+  return props.events
+    .filter(
+      e =>
+        ['red_card', 'yellow_card'].includes(e.event_type) &&
+        e.team_id === props.matchState.away_team_id
     )
     .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0));
 });

--- a/frontend/src/components/post-match/TeamStatsPanel.vue
+++ b/frontend/src/components/post-match/TeamStatsPanel.vue
@@ -195,6 +195,108 @@
       </div>
     </div>
 
+    <!-- Cards Section -->
+    <div>
+      <h4 class="text-slate-300 text-sm font-semibold mb-2">Cards</h4>
+
+      <!-- Existing cards -->
+      <div v-if="cardEvents.length" class="space-y-1 mb-2">
+        <div
+          v-for="event in cardEvents"
+          :key="event.id"
+          class="flex items-center justify-between bg-slate-700/50 px-3 py-1.5 rounded text-sm"
+        >
+          <span class="text-white">
+            <span class="text-yellow-400 font-medium">{{
+              formatMinute(event)
+            }}</span>
+            <svg
+              width="12"
+              height="16"
+              viewBox="0 0 24 24"
+              class="inline-block align-middle mx-1"
+            >
+              <rect
+                x="4"
+                width="16"
+                height="24"
+                rx="2"
+                :fill="event.event_type === 'red_card' ? '#EA3323' : '#FBBF24'"
+              />
+            </svg>
+            {{ event.player_name || 'Unknown' }}
+          </span>
+          <button
+            v-if="canEdit"
+            @click="$emit('remove-card', event.id)"
+            class="text-red-400 hover:text-red-300 text-xs px-1.5 py-0.5 rounded hover:bg-red-900/30"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      <div v-else class="text-slate-500 text-xs mb-2">No cards recorded.</div>
+
+      <!-- Add card form -->
+      <div v-if="canEdit" class="flex flex-wrap gap-2 items-end">
+        <div class="flex-1 min-w-[120px]">
+          <label class="text-slate-400 text-xs block mb-1">Player</label>
+          <select
+            v-model="cardForm.player_id"
+            class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
+          >
+            <option value="">Select player</option>
+            <option v-for="p in roster" :key="p.id" :value="p.id">
+              #{{ p.jersey_number }}
+              {{
+                p.display_name ||
+                `${p.first_name || ''} ${p.last_name || ''}`.trim() ||
+                `#${p.jersey_number}`
+              }}
+            </option>
+          </select>
+        </div>
+        <div class="w-24">
+          <label class="text-slate-400 text-xs block mb-1">Card</label>
+          <select
+            v-model="cardForm.card_type"
+            class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
+          >
+            <option value="yellow_card">Yellow</option>
+            <option value="red_card">Red</option>
+          </select>
+        </div>
+        <div class="w-20">
+          <label class="text-slate-400 text-xs block mb-1">Minute</label>
+          <input
+            v-model.number="cardForm.match_minute"
+            type="number"
+            min="1"
+            max="130"
+            placeholder="Min"
+            class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
+          />
+        </div>
+        <div class="w-16">
+          <label class="text-slate-400 text-xs block mb-1">+ET</label>
+          <input
+            v-model.number="cardForm.extra_time"
+            type="number"
+            min="1"
+            placeholder=""
+            class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
+          />
+        </div>
+        <button
+          @click="submitCard"
+          :disabled="!cardForm.player_id || !cardForm.match_minute"
+          class="px-3 py-1.5 bg-orange-600 hover:bg-orange-500 disabled:bg-slate-600 disabled:text-slate-400 text-white text-sm rounded font-medium transition-colors"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+
     <!-- Player Stats Section -->
     <div>
       <h4 class="text-slate-300 text-sm font-semibold mb-2">Player Stats</h4>
@@ -206,8 +308,11 @@
               <th class="text-left py-1.5 px-2">#</th>
               <th class="text-left py-1.5 px-2">Name</th>
               <th class="text-center py-1.5 px-2">Started</th>
+              <th class="text-center py-1.5 px-2">Played</th>
               <th class="text-center py-1.5 px-2">Min</th>
               <th class="text-center py-1.5 px-2">Goals</th>
+              <th class="text-center py-1.5 px-2">YC</th>
+              <th class="text-center py-1.5 px-2">RC</th>
             </tr>
           </thead>
           <tbody>
@@ -227,10 +332,23 @@
                   v-if="canEdit"
                   type="checkbox"
                   v-model="player.started"
+                  @change="onStartedChanged(player)"
                   class="rounded bg-slate-700 border-slate-600 text-blue-500"
                 />
                 <span v-else class="text-slate-300">{{
                   player.started ? 'Y' : '-'
+                }}</span>
+              </td>
+              <td class="text-center py-1.5 px-2">
+                <input
+                  v-if="canEdit"
+                  type="checkbox"
+                  v-model="player.played"
+                  :disabled="player.started"
+                  class="rounded bg-slate-700 border-slate-600 text-green-500 disabled:opacity-50"
+                />
+                <span v-else class="text-slate-300">{{
+                  player.played ? 'Y' : '-'
                 }}</span>
               </td>
               <td class="text-center py-1.5 px-2">
@@ -248,6 +366,30 @@
               </td>
               <td class="text-center py-1.5 px-2 text-slate-300">
                 {{ player.goals }}
+              </td>
+              <td class="text-center py-1.5 px-2">
+                <input
+                  v-if="canEdit"
+                  type="number"
+                  v-model.number="player.yellow_cards"
+                  min="0"
+                  max="2"
+                  class="w-10 bg-slate-700 text-yellow-400 text-sm text-center rounded px-1 py-0.5 border border-slate-600"
+                />
+                <span v-else class="text-slate-300">{{
+                  player.yellow_cards || 0
+                }}</span>
+              </td>
+              <td class="text-center py-1.5 px-2">
+                <input
+                  v-if="canEdit"
+                  type="checkbox"
+                  v-model="player.red_card"
+                  class="rounded bg-slate-700 border-slate-600 text-red-500"
+                />
+                <span v-else class="text-slate-300">{{
+                  player.red_card ? 'Y' : '-'
+                }}</span>
               </td>
             </tr>
           </tbody>
@@ -290,12 +432,22 @@ export default {
     'remove-goal',
     'add-substitution',
     'remove-substitution',
+    'add-card',
+    'remove-card',
     'save-stats',
   ],
   setup(props, { emit }) {
     // Goal form
     const goalForm = ref({
       player_id: '',
+      match_minute: null,
+      extra_time: null,
+    });
+
+    // Card form
+    const cardForm = ref({
+      player_id: '',
+      card_type: 'yellow_card',
       match_minute: null,
       extra_time: null,
     });
@@ -315,7 +467,11 @@ export default {
     watch(
       () => props.playerStats,
       newStats => {
-        editableStats.value = newStats.map(s => ({ ...s }));
+        editableStats.value = newStats.map(s => ({
+          ...s,
+          yellow_cards: s.yellow_cards || 0,
+          red_card: (s.red_cards || 0) > 0,
+        }));
       },
       { immediate: true, deep: true }
     );
@@ -330,6 +486,12 @@ export default {
     const subEvents = computed(() =>
       props.events
         .filter(e => e.event_type === 'substitution')
+        .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0))
+    );
+
+    const cardEvents = computed(() =>
+      props.events
+        .filter(e => ['red_card', 'yellow_card'].includes(e.event_type))
         .sort((a, b) => (a.match_minute || 0) - (b.match_minute || 0))
     );
 
@@ -379,11 +541,39 @@ export default {
       };
     }
 
+    function submitCard() {
+      const data = {
+        team_id: props.teamId,
+        player_id: cardForm.value.player_id,
+        card_type: cardForm.value.card_type,
+        match_minute: cardForm.value.match_minute,
+      };
+      if (cardForm.value.extra_time) {
+        data.extra_time = cardForm.value.extra_time;
+      }
+      emit('add-card', data);
+      cardForm.value = {
+        player_id: '',
+        card_type: 'yellow_card',
+        match_minute: null,
+        extra_time: null,
+      };
+    }
+
+    function onStartedChanged(player) {
+      if (player.started) {
+        player.played = true;
+      }
+    }
+
     function submitStats() {
       const entries = editableStats.value.map(s => ({
         player_id: s.player_id,
         started: s.started,
+        played: s.played || s.started,
         minutes_played: s.minutes_played,
+        yellow_cards: s.yellow_cards || 0,
+        red_cards: s.red_card ? 1 : 0,
       }));
       emit('save-stats', props.teamId, entries);
     }
@@ -391,13 +581,17 @@ export default {
     return {
       goalForm,
       subForm,
+      cardForm,
       editableStats,
       goalEvents,
       subEvents,
+      cardEvents,
       formatMinute,
       playerDisplayName,
+      onStartedChanged,
       submitGoal,
       submitSubstitution,
+      submitCard,
       submitStats,
     };
   },

--- a/frontend/src/composables/useLiveMatch.js
+++ b/frontend/src/composables/useLiveMatch.js
@@ -314,6 +314,35 @@ export function useLiveMatch(matchId) {
     }
   }
 
+  async function postCard(teamId, playerId, cardType, message = null) {
+    try {
+      const cardData = {
+        team_id: teamId,
+        player_id: playerId,
+        card_type: cardType,
+      };
+      if (message) {
+        cardData.message = message;
+      }
+
+      const response = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/matches/${matchId}/live/card`,
+        {
+          method: 'POST',
+          body: JSON.stringify(cardData),
+        }
+      );
+      // Refetch events to get the new card event
+      if (response) {
+        await fetchMatchState();
+      }
+      return { success: true };
+    } catch (err) {
+      console.error('Error posting card:', err);
+      return { success: false, error: err.message };
+    }
+  }
+
   async function postMessage(message) {
     try {
       const response = await authStore.apiRequest(
@@ -425,6 +454,7 @@ export function useLiveMatch(matchId) {
     // Methods
     updateClock,
     postGoal,
+    postCard,
     postMessage,
     deleteEvent,
     loadMoreEvents,

--- a/frontend/src/composables/usePostMatchStats.js
+++ b/frontend/src/composables/usePostMatchStats.js
@@ -152,6 +152,45 @@ export function usePostMatchStats(matchId, matchData) {
   }
 
   /**
+   * Record a card (yellow or red) for a completed match.
+   */
+  async function addCard(cardData) {
+    error.value = null;
+    try {
+      const response = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/matches/${matchId}/post-match/card`,
+        {
+          method: 'POST',
+          body: JSON.stringify(cardData),
+        }
+      );
+      return { success: true, event: response };
+    } catch (err) {
+      console.error('Error adding card:', err);
+      error.value = err.message || 'Failed to add card';
+      return { success: false, error: err.message };
+    }
+  }
+
+  /**
+   * Remove a card event.
+   */
+  async function removeCard(eventId) {
+    error.value = null;
+    try {
+      await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/matches/${matchId}/post-match/card/${eventId}`,
+        { method: 'DELETE' }
+      );
+      return { success: true };
+    } catch (err) {
+      console.error('Error removing card:', err);
+      error.value = err.message || 'Failed to remove card';
+      return { success: false, error: err.message };
+    }
+  }
+
+  /**
    * Batch save player stats (started, minutes_played) for a team.
    */
   async function savePlayerStats(teamId, entries) {
@@ -199,6 +238,8 @@ export function usePostMatchStats(matchId, matchData) {
     removeGoal,
     addSubstitution,
     removeSubstitution,
+    addCard,
+    removeCard,
     savePlayerStats,
   };
 }

--- a/supabase-local/migrations/20260315000000_add_played_to_player_match_stats.sql
+++ b/supabase-local/migrations/20260315000000_add_played_to_player_match_stats.sql
@@ -1,0 +1,14 @@
+-- Add 'played' boolean to player_match_stats
+-- Tracks whether a player participated in a match (started or came off bench).
+-- Players who started obviously played, but this allows recording participation
+-- for matches where a full starting lineup wasn't set.
+
+ALTER TABLE public.player_match_stats
+    ADD COLUMN played boolean DEFAULT false NOT NULL;
+
+COMMENT ON COLUMN public.player_match_stats.played IS 'Whether player participated in the match (started or came off bench)';
+
+-- Backfill: any existing row with started=true or goals>0 or minutes_played>0 should be marked as played
+UPDATE public.player_match_stats
+SET played = true
+WHERE started = true OR goals > 0 OR minutes_played > 0;

--- a/supabase-local/migrations/20260315000001_add_card_event_types.sql
+++ b/supabase-local/migrations/20260315000001_add_card_event_types.sql
@@ -1,0 +1,9 @@
+-- Add 'red_card' and 'yellow_card' event types to match_events
+-- so cards appear in the match timeline alongside goals and substitutions.
+
+ALTER TABLE public.match_events
+  DROP CONSTRAINT IF EXISTS match_events_event_type_check;
+
+ALTER TABLE public.match_events
+  ADD CONSTRAINT match_events_event_type_check
+  CHECK (event_type::text = ANY (ARRAY['goal', 'message', 'status_change', 'substitution', 'red_card', 'yellow_card']::text[]));


### PR DESCRIPTION
## Summary

- **Played tracking**: New `played` boolean on `player_match_stats` so Games column accurately reflects participation without requiring a full starting lineup. Checking "Started" auto-checks "Played"; scoring a goal also marks the player as played.
- **Card events**: Full yellow/red card support as match events with CRUD for both live scoring (auto-calculated minute) and post-match editing flows.
- **Card display**: Cards visible across all views — Matches list (Premier League-style SVG card icon next to team name), Match Detail, Live Scoreboard, Activity Stream, and Post-Match Editor.
- **Post-match stats**: Added YC/RC columns to the player stats table, plus a dedicated Cards section for adding/removing card events.

## Test plan

- [ ] Apply migrations: `cd supabase-local && npx supabase migration up`
- [ ] Verify post-match stats panel shows Started, Played, Min, Goals, YC, RC columns
- [ ] Check "Started" → auto-checks "Played" and disables it
- [ ] Record a red card via post-match editor → verify it appears in match detail and matches list
- [ ] Record a card during live scoring → verify auto-calculated minute and display in scoreboard/activity stream
- [ ] Check leaderboard Games column only counts matches where played=true or started=true
- [ ] Verify red card SVG icon appears next to team name in Matches tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)