### PR TITLE
feat: Allow goal and card entry for teams without a roster

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2953,14 +2953,20 @@ async def post_match_add_goal(
 
         validate_post_match_access(current_user, current_match, goal.team_id)
 
-        # Validate player exists and is on the team
-        player = roster_dao.get_player_by_id(goal.player_id)
-        if not player:
-            raise HTTPException(status_code=400, detail="Player not found")
-        if player["team_id"] != goal.team_id:
-            raise HTTPException(status_code=400, detail="Player must be on the specified team")
+        # Resolve player - either from roster or free-text name
+        player_id = goal.player_id
+        player_name = goal.player_name
 
-        player_name = player.get("display_name", f"#{player['jersey_number']}")
+        if player_id:
+            player = roster_dao.get_player_by_id(player_id)
+            if not player:
+                raise HTTPException(status_code=400, detail="Player not found")
+            if player["team_id"] != goal.team_id:
+                raise HTTPException(status_code=400, detail="Player must be on the specified team")
+            player_name = player.get("display_name", f"#{player['jersey_number']}")
+        elif not player_name:
+            raise HTTPException(status_code=400, detail="Either player_id or player_name is required")
+
         team_name = (
             current_match.get("home_team_name")
             if goal.team_id == current_match["home_team_id"]
@@ -2981,7 +2987,7 @@ async def post_match_add_goal(
             created_by_username=current_user.get("username"),
             team_id=goal.team_id,
             player_name=player_name,
-            player_id=goal.player_id,
+            player_id=player_id,
             match_minute=goal.match_minute,
             extra_time=goal.extra_time,
         )
@@ -2989,8 +2995,9 @@ async def post_match_add_goal(
         if not event:
             raise HTTPException(status_code=500, detail="Failed to create goal event")
 
-        # Increment player goal stats
-        player_stats_dao.increment_goals(goal.player_id, match_id)
+        # Increment player goal stats (only if roster player)
+        if player_id:
+            player_stats_dao.increment_goals(player_id, match_id)
 
         logger.info(
             "post_match_goal_recorded",
@@ -3202,14 +3209,20 @@ async def post_match_add_card(
 
         validate_post_match_access(current_user, current_match, card.team_id)
 
-        # Validate player exists and is on the team
-        player = roster_dao.get_player_by_id(card.player_id)
-        if not player:
-            raise HTTPException(status_code=400, detail="Player not found")
-        if player["team_id"] != card.team_id:
-            raise HTTPException(status_code=400, detail="Player must be on the specified team")
+        # Resolve player - either from roster or free-text name
+        player_id = card.player_id
+        player_name = card.player_name
 
-        player_name = player.get("display_name", f"#{player['jersey_number']}")
+        if player_id:
+            player = roster_dao.get_player_by_id(player_id)
+            if not player:
+                raise HTTPException(status_code=400, detail="Player not found")
+            if player["team_id"] != card.team_id:
+                raise HTTPException(status_code=400, detail="Player must be on the specified team")
+            player_name = player.get("display_name", f"#{player['jersey_number']}")
+        elif not player_name:
+            raise HTTPException(status_code=400, detail="Either player_id or player_name is required")
+
         card_label = "RED CARD" if card.card_type == "red_card" else "YELLOW CARD"
 
         card_message = f"{card_label}: {player_name}"
@@ -3226,7 +3239,7 @@ async def post_match_add_card(
             created_by_username=current_user.get("username"),
             team_id=card.team_id,
             player_name=player_name,
-            player_id=card.player_id,
+            player_id=player_id,
             match_minute=card.match_minute,
             extra_time=card.extra_time,
         )
@@ -3234,14 +3247,15 @@ async def post_match_add_card(
         if not event:
             raise HTTPException(status_code=500, detail="Failed to create card event")
 
-        # Update player card stats
-        stats = player_stats_dao.get_or_create_match_stats(card.player_id, match_id)
-        if stats:
-            card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
-            current_count = stats.get(card_field, 0)
-            player_stats_dao.client.table("player_match_stats").update(
+        # Update player card stats (only if roster player)
+        if player_id:
+            stats = player_stats_dao.get_or_create_match_stats(player_id, match_id)
+            if stats:
+                card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
+                current_count = stats.get(card_field, 0)
+                player_stats_dao.client.table("player_match_stats").update(
                 {card_field: current_count + 1, "played": True}
-            ).eq("player_id", card.player_id).eq("match_id", match_id).execute()
+            ).eq("player_id", player_id).eq("match_id", match_id).execute()
 
         logger.info(
             "post_match_card_recorded",

--- a/backend/models/post_match.py
+++ b/backend/models/post_match.py
@@ -12,7 +12,8 @@ class PostMatchGoal(BaseModel):
     """Model for recording a post-match goal event."""
 
     team_id: int = Field(..., description="ID of the team that scored")
-    player_id: int = Field(..., description="ID of the goal scorer from roster")
+    player_id: int | None = Field(None, description="ID of the goal scorer from roster (preferred)")
+    player_name: str | None = Field(None, max_length=200, description="Name of goal scorer (when no roster)")
     match_minute: int = Field(..., ge=1, le=130, description="Minute the goal was scored")
     extra_time: int | None = Field(None, ge=1, description="Stoppage time minutes (e.g., 3 for 45+3)")
     message: str | None = Field(None, max_length=500, description="Optional goal description")
@@ -32,7 +33,8 @@ class PostMatchCard(BaseModel):
     """Model for recording a post-match card event (yellow or red)."""
 
     team_id: int = Field(..., description="ID of the team the player belongs to")
-    player_id: int = Field(..., description="ID of the carded player from roster")
+    player_id: int | None = Field(None, description="ID of the carded player from roster (preferred)")
+    player_name: str | None = Field(None, max_length=200, description="Name of player (when no roster)")
     card_type: str = Field(..., pattern="^(yellow_card|red_card)$", description="Type of card: yellow_card or red_card")
     match_minute: int = Field(..., ge=1, le=130, description="Minute the card was given")
     extra_time: int | None = Field(None, ge=1, description="Stoppage time minutes")

--- a/frontend/src/components/post-match/TeamStatsPanel.vue
+++ b/frontend/src/components/post-match/TeamStatsPanel.vue
@@ -49,6 +49,7 @@
         <div class="flex-1 min-w-[120px]">
           <label class="text-slate-400 text-xs block mb-1">Player</label>
           <select
+            v-if="roster.length > 0"
             v-model="goalForm.player_id"
             class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
           >
@@ -62,6 +63,13 @@
               }}
             </option>
           </select>
+          <input
+            v-else
+            v-model="goalForm.player_name"
+            type="text"
+            placeholder="Enter player name"
+            class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
+          />
         </div>
         <div class="w-20">
           <label class="text-slate-400 text-xs block mb-1">Minute</label>
@@ -86,7 +94,7 @@
         </div>
         <button
           @click="submitGoal"
-          :disabled="!goalForm.player_id || !goalForm.match_minute"
+          :disabled="!canSubmitGoal || !goalForm.match_minute"
           class="px-3 py-1.5 bg-green-600 hover:bg-green-500 disabled:bg-slate-600 disabled:text-slate-400 text-white text-sm rounded font-medium transition-colors"
         >
           Add
@@ -242,6 +250,7 @@
         <div class="flex-1 min-w-[120px]">
           <label class="text-slate-400 text-xs block mb-1">Player</label>
           <select
+            v-if="roster.length > 0"
             v-model="cardForm.player_id"
             class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
           >
@@ -255,6 +264,13 @@
               }}
             </option>
           </select>
+          <input
+            v-else
+            v-model="cardForm.player_name"
+            type="text"
+            placeholder="Enter player name"
+            class="w-full bg-slate-700 text-white text-sm rounded px-2 py-1.5 border border-slate-600"
+          />
         </div>
         <div class="w-24">
           <label class="text-slate-400 text-xs block mb-1">Card</label>
@@ -289,7 +305,7 @@
         </div>
         <button
           @click="submitCard"
-          :disabled="!cardForm.player_id || !cardForm.match_minute"
+          :disabled="!canSubmitCard || !cardForm.match_minute"
           class="px-3 py-1.5 bg-orange-600 hover:bg-orange-500 disabled:bg-slate-600 disabled:text-slate-400 text-white text-sm rounded font-medium transition-colors"
         >
           Add
@@ -440,6 +456,7 @@ export default {
     // Goal form
     const goalForm = ref({
       player_id: '',
+      player_name: '',
       match_minute: null,
       extra_time: null,
     });
@@ -447,6 +464,7 @@ export default {
     // Card form
     const cardForm = ref({
       player_id: '',
+      player_name: '',
       card_type: 'yellow_card',
       match_minute: null,
       extra_time: null,
@@ -509,17 +527,36 @@ export default {
       return name || `#${player.jersey_number}`;
     }
 
+    const canSubmitGoal = computed(() => {
+      if (props.roster.length > 0) return !!goalForm.value.player_id;
+      return !!goalForm.value.player_name.trim();
+    });
+
+    const canSubmitCard = computed(() => {
+      if (props.roster.length > 0) return !!cardForm.value.player_id;
+      return !!cardForm.value.player_name.trim();
+    });
+
     function submitGoal() {
       const data = {
         team_id: props.teamId,
-        player_id: goalForm.value.player_id,
         match_minute: goalForm.value.match_minute,
       };
+      if (goalForm.value.player_id) {
+        data.player_id = goalForm.value.player_id;
+      } else {
+        data.player_name = goalForm.value.player_name.trim();
+      }
       if (goalForm.value.extra_time) {
         data.extra_time = goalForm.value.extra_time;
       }
       emit('add-goal', data);
-      goalForm.value = { player_id: '', match_minute: null, extra_time: null };
+      goalForm.value = {
+        player_id: '',
+        player_name: '',
+        match_minute: null,
+        extra_time: null,
+      };
     }
 
     function submitSubstitution() {
@@ -544,16 +581,21 @@ export default {
     function submitCard() {
       const data = {
         team_id: props.teamId,
-        player_id: cardForm.value.player_id,
         card_type: cardForm.value.card_type,
         match_minute: cardForm.value.match_minute,
       };
+      if (cardForm.value.player_id) {
+        data.player_id = cardForm.value.player_id;
+      } else {
+        data.player_name = cardForm.value.player_name.trim();
+      }
       if (cardForm.value.extra_time) {
         data.extra_time = cardForm.value.extra_time;
       }
       emit('add-card', data);
       cardForm.value = {
         player_id: '',
+        player_name: '',
         card_type: 'yellow_card',
         match_minute: null,
         extra_time: null,
@@ -586,6 +628,8 @@ export default {
       goalEvents,
       subEvents,
       cardEvents,
+      canSubmitGoal,
+      canSubmitCard,
       formatMinute,
       playerDisplayName,
       onStartedChanged,


### PR DESCRIPTION
## Summary

- When a team has no roster, the player dropdown is replaced with a text input for goals and cards
- Backend `PostMatchGoal` and `PostMatchCard` models now accept `player_name` as a fallback when `player_id` is not provided
- Player stats tracking is skipped for non-roster players (no `player_match_stats` row to update)
- Fixes a bug in the live card endpoint where `player_id` variable was undefined

## Test plan

- [ ] Open a completed match where the opponent has no roster
- [ ] Verify Goals section shows a text input instead of dropdown
- [ ] Enter a player name (e.g., "X") and a minute, click Add — goal should appear in events
- [ ] Verify Cards section also shows text input for no-roster teams
- [ ] Enter a card with a player name — card should appear with the name displayed
- [ ] Verify teams WITH a roster still show the dropdown as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)