### PR TITLE
feat: Add audit tables and agent audit API endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -74,6 +74,7 @@ from services import InviteService
 # Legacy flag kept for backwards compatibility so existing envs keep working.
 DISABLE_SECURITY = os.getenv("DISABLE_SECURITY", "false").lower() == "true"
 
+from dao.audit_dao import AuditDAO
 from dao.club_dao import ClubDAO
 from dao.exceptions import DuplicateRecordError
 from dao.league_dao import LeagueDAO
@@ -209,6 +210,7 @@ season_dao = SeasonDAO(db_conn_holder_obj)
 league_dao = LeagueDAO(db_conn_holder_obj)
 match_type_dao = MatchTypeDAO(db_conn_holder_obj)
 playoff_dao = PlayoffDAO(db_conn_holder_obj)
+audit_dao = AuditDAO(db_conn_holder_obj)
 
 
 # === Simple Redis Caching ===
@@ -1589,8 +1591,7 @@ async def get_current_user_info(current_user: dict = Depends(get_current_user_re
         if role == "team-player":
             teams_data = player_dao.get_all_current_player_teams(current_user["user_id"])
             current_teams = [
-                {"team_id": t.get("team_id"), "team": t.get("team"), "season": t.get("season")}
-                for t in teams_data
+                {"team_id": t.get("team_id"), "team": t.get("team"), "season": t.get("season")} for t in teams_data
             ]
 
         return {
@@ -2075,11 +2076,13 @@ async def get_matches(
                 cards = card_events.get(m["id"], [])
                 m["red_cards"] = [
                     {"team_id": c["team_id"], "player_name": c["player_name"]}
-                    for c in cards if c["event_type"] == "red_card"
+                    for c in cards
+                    if c["event_type"] == "red_card"
                 ]
                 m["yellow_cards"] = [
                     {"team_id": c["team_id"], "player_name": c["player_name"]}
-                    for c in cards if c["event_type"] == "yellow_card"
+                    for c in cards
+                    if c["event_type"] == "yellow_card"
                 ]
 
         return matches
@@ -2366,11 +2369,13 @@ async def get_matches_by_team(
                 cards = card_events.get(m["id"], [])
                 m["red_cards"] = [
                     {"team_id": c["team_id"], "player_name": c["player_name"]}
-                    for c in cards if c["event_type"] == "red_card"
+                    for c in cards
+                    if c["event_type"] == "red_card"
                 ]
                 m["yellow_cards"] = [
                     {"team_id": c["team_id"], "player_name": c["player_name"]}
-                    for c in cards if c["event_type"] == "yellow_card"
+                    for c in cards
+                    if c["event_type"] == "yellow_card"
                 ]
 
         return matches
@@ -2906,9 +2911,7 @@ async def save_lineup(
 # === Post-Match Stats Endpoints ===
 
 
-def validate_post_match_access(
-    user: dict[str, Any], match: dict, team_id: int
-) -> None:
+def validate_post_match_access(user: dict[str, Any], match: dict, team_id: int) -> None:
     """Validate user has access to edit post-match stats for a team.
 
     Checks:
@@ -3254,8 +3257,8 @@ async def post_match_add_card(
                 card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
                 current_count = stats.get(card_field, 0)
                 player_stats_dao.client.table("player_match_stats").update(
-                {card_field: current_count + 1, "played": True}
-            ).eq("player_id", player_id).eq("match_id", match_id).execute()
+                    {card_field: current_count + 1, "played": True}
+                ).eq("player_id", player_id).eq("match_id", match_id).execute()
 
         logger.info(
             "post_match_card_recorded",
@@ -3310,9 +3313,9 @@ async def post_match_remove_card(
             if stats:
                 card_field = "red_cards" if event["event_type"] == "red_card" else "yellow_cards"
                 new_count = max(0, stats.get(card_field, 0) - 1)
-                player_stats_dao.client.table("player_match_stats").update(
-                    {card_field: new_count}
-                ).eq("player_id", player_id).eq("match_id", match_id).execute()
+                player_stats_dao.client.table("player_match_stats").update({card_field: new_count}).eq(
+                    "player_id", player_id
+                ).eq("match_id", match_id).execute()
 
         user_id = current_user.get("user_id") or current_user.get("id")
         success = match_event_dao.soft_delete_event(event_id, deleted_by=user_id)
@@ -5026,9 +5029,7 @@ async def advance_playoff_winner_by_manager(
                 raise HTTPException(status_code=400, detail="Match is tied - admin must resolve")
 
             # Determine the winner
-            winner_team_id = (
-                home_team_id if match["home_score"] > match["away_score"] else away_team_id
-            )
+            winner_team_id = home_team_id if match["home_score"] > match["away_score"] else away_team_id
 
             # Check if user's team is the winner
             user_team_id = current_user.get("team_id")
@@ -5045,10 +5046,7 @@ async def advance_playoff_winner_by_manager(
                     user_is_winner = True
 
             if not user_is_winner:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only the winning team's manager can advance the winner"
-                )
+                raise HTTPException(status_code=403, detail="Only the winning team's manager can advance the winner")
 
         # All checks passed, advance the winner
         result = playoff_dao.advance_winner(request.slot_id)
@@ -5111,10 +5109,7 @@ async def forfeit_playoff_match_by_manager(
                     can_forfeit = True
 
             if not can_forfeit:
-                raise HTTPException(
-                    status_code=403,
-                    detail="You can only forfeit your own team"
-                )
+                raise HTTPException(status_code=403, detail="You can only forfeit your own team")
 
         result = playoff_dao.forfeit_match(request.slot_id, request.forfeit_team_id)
         return result or {"message": "Forfeit recorded (final match)"}
@@ -5542,6 +5537,160 @@ async def get_agent_match_summary(
         }
     except Exception as e:
         logger.error("agent_match_summary_failed", error=str(e), season=season)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.get("/api/agent/matches")
+async def get_agent_matches(
+    team: str = Query(..., description="MT canonical team name, e.g. 'IFA'"),
+    age_group: str = Query(..., description="e.g. 'U14'"),
+    league: str = Query(..., description="e.g. 'Homegrown'"),
+    division: str = Query(..., description="e.g. 'Northeast'"),
+    season: str = Query(..., description="e.g. '2025-2026'"),
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Get individual match records for a team — used by the audit agent for comparison.
+
+    Returns matches involving the specified team (home or away) in the given
+    age-group/league/division/season. Returns 200 with empty list if no matches.
+    """
+    try:
+        matches = match_dao.get_agent_matches(
+            team=team,
+            age_group=age_group,
+            league=league,
+            division=division,
+            season=season,
+        )
+        return {"matches": matches}
+    except Exception as e:
+        logger.error("agent_matches_failed", error=str(e), team=team, season=season)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.get("/api/agent/audit/next-team")
+async def get_audit_next_team(
+    season: str = Query(..., description="e.g. '2025-2026'"),
+    division: str = Query(..., description="e.g. 'Northeast'"),
+    league: str = Query(..., description="e.g. 'Homegrown'"),
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Return the next team to audit (least recently audited).
+
+    Returns HTTP 204 when all teams were audited within the last 7 days.
+    """
+    try:
+        team = audit_dao.get_next_team(season=season, division=division, league=league)
+    except Exception as e:
+        logger.error("audit_next_team_failed", error=str(e), season=season)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    if team is None:
+        return Response(status_code=204)
+    return team
+
+
+@app.get("/api/agent/audit/teams")
+async def get_audit_teams(
+    season: str = Query(..., description="e.g. '2025-2026'"),
+    division: str = Query(..., description="e.g. 'Northeast'"),
+    league: str = Query(..., description="e.g. 'Homegrown'"),
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Return full team list with audit scheduling state. Used for metrics/reporting."""
+    try:
+        teams = audit_dao.get_audit_teams(season=season, division=division, league=league)
+        return {"teams": teams}
+    except Exception as e:
+        logger.error("audit_teams_failed", error=str(e), season=season)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.post("/api/agent/audit/events")
+async def post_audit_events(
+    payload: dict[str, Any],
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Submit audit findings for a completed team audit.
+
+    Updates audit_teams.last_audited_at. Stores an audit_events row only when
+    findings is non-empty. Returns 200 with empty findings if audit was clean.
+    """
+    required = ("event_id", "team", "age_group", "league", "division", "season")
+    missing = [f for f in required if not payload.get(f)]
+    if missing:
+        raise HTTPException(status_code=422, detail=f"Missing required fields: {missing}")
+
+    try:
+        audit_dao.submit_audit_event(payload)
+    except Exception as e:
+        logger.error("audit_post_events_failed", error=str(e), event_id=payload.get("event_id"))
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    findings = payload.get("findings", [])
+    return {
+        "event_id": payload["event_id"],
+        "team": payload["team"],
+        "age_group": payload["age_group"],
+        "findings_stored": len(findings),
+        "status": "findings" if findings else "clean",
+    }
+
+
+@app.get("/api/agent/audit/events")
+async def get_audit_events(
+    season: str = Query(..., description="e.g. '2025-2026'"),
+    status: str = Query("pending", description="pending | processed | ignored"),
+    team: str | None = Query(None),
+    age_group: str | None = Query(None),
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """List audit events. Defaults to pending events for the processor to consume."""
+    try:
+        events = audit_dao.get_events(season=season, status=status, team=team, age_group=age_group)
+        return {"events": events}
+    except Exception as e:
+        logger.error("audit_get_events_failed", error=str(e), season=season)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.patch("/api/agent/audit/events/{event_id}")
+async def patch_audit_event(
+    event_id: str,
+    payload: dict[str, Any],
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Update the status of an audit event after the processor has handled it."""
+    new_status = payload.get("status")
+    if not new_status:
+        raise HTTPException(status_code=422, detail="'status' field required")
+
+    try:
+        audit_dao.update_event_status(
+            event_id=event_id,
+            status=new_status,
+            processed_at=payload.get("processed_at"),
+        )
+    except Exception as e:
+        logger.error("audit_patch_event_failed", error=str(e), event_id=event_id)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    return {"event_id": event_id, "status": new_status}
+
+
+@app.get("/api/agent/audit/summary")
+async def get_audit_summary(
+    season: str = Query(..., description="e.g. '2025-2026'"),
+    division: str = Query(..., description="e.g. 'Northeast'"),
+    league: str = Query(..., description="e.g. 'Homegrown'"),
+    current_user: dict[str, Any] = Depends(require_match_management_permission),
+):
+    """Audit coverage metrics: teams audited this week, findings breakdown, overdue teams."""
+    try:
+        summary = audit_dao.get_audit_summary(season=season, division=division, league=league)
+        return summary
+    except Exception as e:
+        logger.error("audit_summary_failed", error=str(e), season=season)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 

--- a/backend/dao/audit_dao.py
+++ b/backend/dao/audit_dao.py
@@ -1,0 +1,298 @@
+"""
+Audit data access object for match data-integrity auditing.
+
+Provides operations for the audit_teams scheduling table and audit_events
+findings table. Used exclusively by the match-scraper-agent (service key).
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import structlog
+
+from dao.base_dao import BaseDAO
+
+logger = structlog.get_logger()
+
+# Teams audited within this window are considered "up-to-date"
+_AUDIT_WINDOW_DAYS = 7
+
+
+class AuditDAO(BaseDAO):
+    """Data Access Object for audit scheduling and findings."""
+
+    # ── Scheduling ────────────────────────────────────────────────────────────
+
+    def get_next_team(self, season: str, division: str, league: str) -> dict | None:
+        """Return the next team to audit, or None if all teams are current.
+
+        Selects the row with the oldest last_audited_at (NULL first = highest
+        priority). Returns None when the oldest audit is still within the
+        7-day window — meaning every team has been seen this week.
+
+        Args:
+            season:   Season name, e.g. "2025-2026".
+            division: Division name, e.g. "Northeast".
+            league:   League name, e.g. "Homegrown".
+
+        Returns:
+            Dict with team/age_group/league/division/season/last_audited_at,
+            or None if all teams are up-to-date.
+        """
+        try:
+            response = (
+                self.client.table("audit_teams")
+                .select("team, age_group, league, division, season, last_audited_at")
+                .eq("season", season)
+                .eq("division", division)
+                .eq("league", league)
+                .order("last_audited_at", desc=False, nulls_first=True)
+                .limit(1)
+                .execute()
+            )
+        except Exception:
+            logger.exception("audit_dao.get_next_team.error")
+            raise
+
+        if not response.data:
+            logger.info("audit_dao.get_next_team.no_teams", season=season)
+            return None
+
+        row = response.data[0]
+        last_audited = row.get("last_audited_at")
+
+        if last_audited is not None:
+            # Parse timestamp and check if still within the audit window
+            try:
+                audited_dt = datetime.fromisoformat(last_audited.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                audited_dt = None
+
+            if audited_dt is not None:
+                cutoff = datetime.now(tz=UTC) - timedelta(days=_AUDIT_WINDOW_DAYS)
+                if audited_dt >= cutoff:
+                    logger.info(
+                        "audit_dao.get_next_team.all_current",
+                        season=season,
+                        oldest_audit=last_audited,
+                    )
+                    return None
+
+        logger.info(
+            "audit_dao.get_next_team.selected",
+            team=row["team"],
+            age_group=row["age_group"],
+            last_audited_at=last_audited,
+        )
+        return row
+
+    def get_audit_teams(self, season: str, division: str, league: str) -> list[dict]:
+        """Return all teams registered for auditing in a season/division/league."""
+        try:
+            response = (
+                self.client.table("audit_teams")
+                .select("*")
+                .eq("season", season)
+                .eq("division", division)
+                .eq("league", league)
+                .order("age_group")
+                .order("team")
+                .execute()
+            )
+            return response.data or []
+        except Exception:
+            logger.exception("audit_dao.get_audit_teams.error")
+            raise
+
+    # ── Event submission ──────────────────────────────────────────────────────
+
+    def submit_audit_event(self, event_data: dict) -> None:
+        """Record a completed audit run and update the team's scheduling state.
+
+        Always upserts audit_teams.last_audited_at (records that an audit ran).
+        Only inserts an audit_events row when findings exist.
+
+        Args:
+            event_data: Dict matching the POST /api/agent/audit/events body:
+                event_id, audit_run_id, team, age_group, league,
+                division, season, findings (list of dicts).
+        """
+        event_id = event_data["event_id"]
+        team = event_data["team"]
+        age_group = event_data["age_group"]
+        league = event_data["league"]
+        division = event_data["division"]
+        season = event_data["season"]
+        findings = event_data.get("findings", [])
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        audit_status = "findings" if findings else "clean"
+
+        # 1. Upsert audit_teams scheduling state
+        try:
+            self.client.table("audit_teams").upsert(
+                {
+                    "team": team,
+                    "age_group": age_group,
+                    "league": league,
+                    "division": division,
+                    "season": season,
+                    "last_audited_at": now_iso,
+                    "last_audit_status": audit_status,
+                    "findings_count": len(findings),
+                },
+                on_conflict="team,age_group,league,division,season",
+            ).execute()
+        except Exception:
+            logger.exception(
+                "audit_dao.submit_event.upsert_team_error",
+                team=team,
+                age_group=age_group,
+            )
+            raise
+
+        # 2. Insert audit_events row only when there are findings
+        if not findings:
+            logger.info(
+                "audit_dao.submit_event.clean",
+                team=team,
+                age_group=age_group,
+                event_id=event_id,
+            )
+            return
+
+        try:
+            self.client.table("audit_events").insert(
+                {
+                    "event_id": event_id,
+                    "audit_run_id": event_data.get("audit_run_id", event_id),
+                    "team": team,
+                    "age_group": age_group,
+                    "league": league,
+                    "division": division,
+                    "season": season,
+                    "findings": findings,
+                    "status": "pending",
+                }
+            ).execute()
+        except Exception:
+            logger.exception(
+                "audit_dao.submit_event.insert_error",
+                event_id=event_id,
+                team=team,
+            )
+            raise
+
+        logger.info(
+            "audit_dao.submit_event.done",
+            event_id=event_id,
+            team=team,
+            age_group=age_group,
+            findings=len(findings),
+        )
+
+    # ── Event processing ──────────────────────────────────────────────────────
+
+    def get_events(
+        self,
+        season: str,
+        status: str = "pending",
+        team: str | None = None,
+        age_group: str | None = None,
+    ) -> list[dict]:
+        """Return audit events filtered by status (and optionally team/age_group)."""
+        try:
+            query = (
+                self.client.table("audit_events")
+                .select("*")
+                .eq("season", season)
+                .eq("status", status)
+                .order("created_at", desc=False)
+            )
+            if team:
+                query = query.eq("team", team)
+            if age_group:
+                query = query.eq("age_group", age_group)
+
+            response = query.execute()
+            return response.data or []
+        except Exception:
+            logger.exception("audit_dao.get_events.error", season=season, status=status)
+            raise
+
+    def update_event_status(
+        self,
+        event_id: str,
+        status: str,
+        processed_at: str | None = None,
+    ) -> None:
+        """Update the processing status of an audit event."""
+        payload: dict = {"status": status}
+        if processed_at:
+            payload["processed_at"] = processed_at
+
+        try:
+            self.client.table("audit_events").update(payload).eq("event_id", event_id).execute()
+        except Exception:
+            logger.exception(
+                "audit_dao.update_event_status.error",
+                event_id=event_id,
+                status=status,
+            )
+            raise
+
+        logger.info("audit_dao.update_event_status", event_id=event_id, status=status)
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+
+    def get_audit_summary(self, season: str, division: str, league: str) -> dict:
+        """Return audit coverage metrics for a season/division/league."""
+        from datetime import date
+
+        cutoff = (date.today() - timedelta(days=_AUDIT_WINDOW_DAYS)).isoformat()
+
+        try:
+            teams_resp = (
+                self.client.table("audit_teams")
+                .select("team, age_group, last_audited_at, last_audit_status, findings_count")
+                .eq("season", season)
+                .eq("division", division)
+                .eq("league", league)
+                .execute()
+            )
+        except Exception:
+            logger.exception("audit_dao.get_audit_summary.error")
+            raise
+
+        teams = teams_resp.data or []
+        total = len(teams)
+        audited_this_week = sum(1 for t in teams if t.get("last_audited_at") and t["last_audited_at"][:10] >= cutoff)
+        overdue = total - audited_this_week
+        clean = sum(1 for t in teams if t.get("last_audit_status") == "clean")
+        with_findings = sum(1 for t in teams if t.get("last_audit_status") == "findings")
+
+        # Findings breakdown from pending events
+        findings_by_type: dict[str, int] = {}
+        try:
+            events_resp = (
+                self.client.table("audit_events")
+                .select("findings")
+                .eq("season", season)
+                .eq("status", "pending")
+                .execute()
+            )
+            for ev in events_resp.data or []:
+                for f in ev.get("findings", []):
+                    ft = f.get("finding_type", "unknown")
+                    findings_by_type[ft] = findings_by_type.get(ft, 0) + 1
+        except Exception:
+            logger.warning("audit_dao.get_audit_summary.findings_error")
+
+        return {
+            "season": season,
+            "total_teams": total,
+            "audited_this_week": audited_this_week,
+            "overdue_teams": overdue,
+            "findings_by_type": findings_by_type,
+            "teams_with_findings": with_findings,
+            "clean_teams": clean,
+        }

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -512,11 +512,7 @@ class MatchDAO(BaseDAO):
                 if md < today and status in ("scheduled", "tbd") and m.get("home_score") is None:
                     needs_score += 1
 
-                if (
-                    status in ("scheduled", "tbd")
-                    and today <= md <= kickoff_horizon
-                    and not m.get("scheduled_kickoff")
-                ):
+                if status in ("scheduled", "tbd") and today <= md <= kickoff_horizon and not m.get("scheduled_kickoff"):
                     needs_kickoff += 1
 
                 if status == "played" and (last_played is None or md > last_played):
@@ -1199,6 +1195,128 @@ class MatchDAO(BaseDAO):
         except Exception:
             logger.exception("Error updating match score", match_id=match_id)
             return None
+
+    def get_agent_matches(
+        self,
+        team: str,
+        age_group: str,
+        league: str,
+        division: str,
+        season: str,
+    ) -> list[dict]:
+        """Get individual match records for the audit agent's comparison step.
+
+        Returns matches involving the specified team (home or away) in the
+        given age-group/league/division/season. Used by GET /api/agent/matches.
+
+        Args:
+            team:      MT canonical team name, e.g. "IFA".
+            age_group: e.g. "U14".
+            league:    e.g. "Homegrown".
+            division:  e.g. "Northeast".
+            season:    e.g. "2025-2026".
+
+        Returns:
+            List of match dicts with fields the audit comparator expects.
+        """
+        # Resolve IDs for the reference dimensions
+        season_resp = self.client.table("seasons").select("id").eq("name", season).limit(1).execute()
+        if not season_resp.data:
+            logger.warning("get_agent_matches.season_not_found", season=season)
+            return []
+        season_id = season_resp.data[0]["id"]
+
+        ag_resp = self.client.table("age_groups").select("id").eq("name", age_group).limit(1).execute()
+        if not ag_resp.data:
+            logger.warning("get_agent_matches.age_group_not_found", age_group=age_group)
+            return []
+        age_group_id = ag_resp.data[0]["id"]
+
+        # Resolve division_id via league join
+        div_resp = (
+            self.client.table("divisions")
+            .select("id, leagues!divisions_league_id_fkey(name)")
+            .eq("name", division)
+            .execute()
+        )
+        division_id = None
+        for row in div_resp.data or []:
+            if row.get("leagues") and row["leagues"].get("name") == league:
+                division_id = row["id"]
+                break
+        if division_id is None:
+            logger.warning("get_agent_matches.division_not_found", division=division, league=league)
+            return []
+
+        # Resolve team IDs matching the given name
+        team_resp = self.client.table("teams").select("id").eq("name", team).execute()
+        team_ids = [r["id"] for r in (team_resp.data or [])]
+        if not team_ids:
+            logger.warning("get_agent_matches.team_not_found", team=team)
+            return []
+
+        # Build OR filter for home/away team membership
+        or_filter = ",".join(
+            [f"home_team_id.eq.{tid}" for tid in team_ids] + [f"away_team_id.eq.{tid}" for tid in team_ids]
+        )
+
+        try:
+            response = (
+                self.client.table("matches")
+                .select(
+                    "match_id, match_date, scheduled_kickoff, home_score, away_score, match_status, "
+                    "home_team:teams!matches_home_team_id_fkey(name), "
+                    "away_team:teams!matches_away_team_id_fkey(name)"
+                )
+                .eq("season_id", season_id)
+                .eq("age_group_id", age_group_id)
+                .eq("division_id", division_id)
+                .or_(or_filter)
+                .order("match_date", desc=False)
+                .execute()
+            )
+        except Exception:
+            logger.exception("get_agent_matches.query_error", team=team)
+            return []
+
+        results = []
+        for m in response.data or []:
+            # Format match_time as "HH:MM" from scheduled_kickoff (UTC)
+            match_time = None
+            if m.get("scheduled_kickoff"):
+                try:
+                    from datetime import datetime
+
+                    kt = datetime.fromisoformat(m["scheduled_kickoff"].replace("Z", "+00:00"))
+                    if kt.hour or kt.minute:
+                        match_time = kt.strftime("%H:%M")
+                except (ValueError, AttributeError):
+                    pass
+
+            results.append(
+                {
+                    "external_match_id": m.get("match_id"),
+                    "home_team": m["home_team"]["name"] if m.get("home_team") else None,
+                    "away_team": m["away_team"]["name"] if m.get("away_team") else None,
+                    "match_date": m["match_date"],
+                    "match_time": match_time,
+                    "home_score": m.get("home_score"),
+                    "away_score": m.get("away_score"),
+                    "match_status": m.get("match_status"),
+                    "age_group": age_group,
+                    "league": league,
+                    "division": division,
+                    "season": season,
+                }
+            )
+
+        logger.info(
+            "get_agent_matches.done",
+            team=team,
+            age_group=age_group,
+            count=len(results),
+        )
+        return results
 
     # Admin CRUD methods for reference data have been moved to:
     # - SeasonDAO (seasons, age_groups)

--- a/supabase-local/migrations/20260319000000_add_audit_tables.sql
+++ b/supabase-local/migrations/20260319000000_add_audit_tables.sql
@@ -1,0 +1,113 @@
+-- Add audit tables for Northeast HG division data-integrity auditing.
+-- Two tables:
+--   audit_teams  — team registry and audit scheduling state (one row per team × age-group)
+--   audit_events — one row per audit run that found discrepancies
+
+-- ─── audit_teams ────────────────────────────────────────────────────────────
+
+CREATE TABLE public.audit_teams (
+    id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    team             text        NOT NULL,
+    age_group        text        NOT NULL,
+    league           text        NOT NULL,
+    division         text        NOT NULL,
+    season           text        NOT NULL,
+    last_audited_at  timestamptz,                  -- null = never audited (highest priority)
+    last_audit_status text        CHECK (last_audit_status IN ('clean', 'findings', 'error')),
+    findings_count   int         NOT NULL DEFAULT 0,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (team, age_group, league, division, season)
+);
+
+COMMENT ON TABLE public.audit_teams IS
+    'One row per team × age-group scheduled for weekly data-integrity auditing.';
+
+COMMENT ON COLUMN public.audit_teams.last_audited_at IS
+    'UTC timestamp of the most recent completed audit for this row. NULL = never audited.';
+
+-- ─── audit_events ────────────────────────────────────────────────────────────
+
+CREATE TABLE public.audit_events (
+    id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id      text        UNIQUE NOT NULL,      -- MSA-generated hex ID per audit run
+    audit_run_id  text        NOT NULL,             -- same as event_id (kept for future correlation)
+    team          text        NOT NULL,
+    age_group     text        NOT NULL,
+    league        text        NOT NULL,
+    division      text        NOT NULL,
+    season        text        NOT NULL,
+    findings      jsonb       NOT NULL DEFAULT '[]', -- list of AuditFinding dicts
+    status        text        NOT NULL DEFAULT 'pending'
+                              CHECK (status IN ('pending', 'processed', 'ignored')),
+    processed_at  timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.audit_events IS
+    'One row per audit run that produced findings. Clean runs (0 findings) are not stored here.';
+
+COMMENT ON COLUMN public.audit_events.findings IS
+    'JSON array of AuditFinding objects — each describes a single discrepancy found.';
+
+-- ─── RLS — service key bypasses; no user-facing access needed ────────────────
+
+ALTER TABLE public.audit_teams  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_events ENABLE ROW LEVEL SECURITY;
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+
+-- Scheduling query: find least-recently-audited team in a season/division/league
+CREATE INDEX idx_audit_teams_schedule
+    ON public.audit_teams (season, division, league, last_audited_at NULLS FIRST);
+
+-- Processor query: pending events by season
+CREATE INDEX idx_audit_events_pending
+    ON public.audit_events (status, season)
+    WHERE status = 'pending';
+
+-- Fast event lookup for PATCH
+CREATE INDEX idx_audit_events_event_id
+    ON public.audit_events (event_id);
+
+-- ─── Seed audit_teams from existing Northeast HG match data ──────────────────
+-- Derives the team list automatically from matches already in the DB.
+-- Covers both home and away teams for U13/U14/U15/U16, Homegrown, Northeast.
+
+INSERT INTO public.audit_teams (team, age_group, league, division, season)
+SELECT DISTINCT
+    ht.name     AS team,
+    ag.name     AS age_group,
+    l.name      AS league,
+    d.name      AS division,
+    s.name      AS season
+FROM public.matches  m
+JOIN public.teams      ht ON ht.id = m.home_team_id
+JOIN public.age_groups ag ON ag.id = m.age_group_id
+JOIN public.divisions   d ON  d.id = m.division_id
+JOIN public.leagues     l ON  l.id = d.league_id
+JOIN public.seasons     s ON  s.id = m.season_id
+WHERE s.name    = '2025-2026'
+  AND d.name    = 'Northeast'
+  AND l.name    = 'Homegrown'
+  AND ag.name  IN ('U13', 'U14', 'U15', 'U16')
+
+UNION
+
+SELECT DISTINCT
+    at_.name    AS team,
+    ag.name     AS age_group,
+    l.name      AS league,
+    d.name      AS division,
+    s.name      AS season
+FROM public.matches  m
+JOIN public.teams      at_ ON at_.id = m.away_team_id
+JOIN public.age_groups  ag ON  ag.id = m.age_group_id
+JOIN public.divisions    d ON   d.id = m.division_id
+JOIN public.leagues      l ON   l.id = d.league_id
+JOIN public.seasons      s ON   s.id = m.season_id
+WHERE s.name    = '2025-2026'
+  AND d.name    = 'Northeast'
+  AND l.name    = 'Homegrown'
+  AND ag.name  IN ('U13', 'U14', 'U15', 'U16')
+
+ON CONFLICT (team, age_group, league, division, season) DO NOTHING;


### PR DESCRIPTION
## Summary

Implements the MT side of the Northeast HG division data-integrity audit system.

- **Migration** `20260319000000`: Creates `audit_teams` (scheduling state) and `audit_events` (findings store) tables, auto-seeded from existing Northeast HG match data
- **`AuditDAO`**: Scheduling logic (`get_next_team` with 7-day window), event submission, processor support, summary metrics
- **`MatchDAO.get_agent_matches`**: New method returning flat match dicts by team name for audit comparison
- **7 new API endpoints** under `/api/agent/audit/` + `/api/agent/matches`

## New endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/agent/matches` | Per-team match records for audit comparator |
| `GET` | `/api/agent/audit/next-team` | Next team to audit (204 = all current) |
| `GET` | `/api/agent/audit/teams` | Full team list with audit state |
| `POST` | `/api/agent/audit/events` | Submit audit findings + update last_audited_at |
| `GET` | `/api/agent/audit/events` | List events by status (default: pending) |
| `PATCH` | `/api/agent/audit/events/{event_id}` | Mark event processed |
| `GET` | `/api/agent/audit/summary` | Coverage metrics |

## Test plan

- [ ] Apply migration to local Supabase: `supabase db push` or `supabase migration up`
- [ ] Verify `audit_teams` seeded: `SELECT count(*) FROM audit_teams;` (expect ~40 rows)
- [ ] `GET /api/agent/audit/next-team?season=2025-2026&division=Northeast&league=Homegrown` → returns team
- [ ] `POST /api/agent/audit/events` with empty findings → 200, audit_teams.last_audited_at updated
- [ ] `POST /api/agent/audit/events` with findings → audit_events row created
- [ ] `GET /api/agent/audit/events?season=2025-2026&status=pending` → returns events
- [ ] `PATCH /api/agent/audit/events/{event_id}` → status updated
- [ ] MSA dry-run: `uv run match-scraper-agent audit --env local --dry-run`
- [ ] 210 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)