### PR TITLE
fix: Use correct nullsfirst kwarg in AuditDAO

### DIFF
--- a/backend/dao/audit_dao.py
+++ b/backend/dao/audit_dao.py
@@ -45,7 +45,7 @@ class AuditDAO(BaseDAO):
                 .eq("season", season)
                 .eq("division", division)
                 .eq("league", league)
-                .order("last_audited_at", desc=False, nulls_first=True)
+                .order("last_audited_at", desc=False, nullsfirst=True)
                 .limit(1)
                 .execute()
             )


### PR DESCRIPTION
## Summary
- Fixes `nulls_first` → `nullsfirst` in `AuditDAO.get_next_team()` — the Supabase Python client uses `nullsfirst` (no underscore)
- This was causing a 500 error on `/api/agent/audit/next-team`, which the MSA audit job reported as a 403 (before auth was verified)

## Test plan
- [ ] CI passes
- [ ] After deploy, verify `curl -H "Authorization: Bearer $TOKEN" "https://api.missingtable.com/api/agent/audit/next-team?season=2025-2026&division=Northeast&league=Homegrown"` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)