### PR TITLE
feat: Add score date window to match-summary API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5521,15 +5521,20 @@ async def full_health_check():
 @app.get("/api/agent/match-summary")
 async def get_agent_match_summary(
     season: str = Query(..., description="Season name, e.g. '2025-26'"),
+    score_from: str | None = Query(None, description="needs_score window start (YYYY-MM-DD)"),
+    score_to: str | None = Query(None, description="needs_score window end (YYYY-MM-DD)"),
     current_user: dict[str, Any] = Depends(require_match_management_permission),
 ):
     """Get match summary for agent decision-making.
 
     Returns match counts grouped by age group, league, and division
     with status breakdowns to help the agent decide what to scrape.
+
+    Optional score_from/score_to params narrow the needs_score calculation
+    to a specific date window (e.g. last weekend only).
     """
     try:
-        targets = match_dao.get_match_summary(season)
+        targets = match_dao.get_match_summary(season, score_from=score_from, score_to=score_to)
         return {
             "season": season,
             "generated_at": datetime.now(UTC).isoformat(),

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -454,11 +454,21 @@ class MatchDAO(BaseDAO):
             logger.exception("Error querying matches")
             return []
 
-    def get_match_summary(self, season_name: str) -> list[dict]:
+    def get_match_summary(
+        self,
+        season_name: str,
+        score_from: str | None = None,
+        score_to: str | None = None,
+    ) -> list[dict]:
         """Get match summary statistics grouped by age group, league, and division.
 
         Used by the match-scraper-agent to understand what MT already has
         and make smart decisions about what to scrape.
+
+        Args:
+            season_name: Season name, e.g. '2025-2026'.
+            score_from: If set, only count needs_score for matches >= this date.
+            score_to: If set, only count needs_score for matches <= this date.
         """
         from collections import defaultdict
         from datetime import date, timedelta
@@ -510,7 +520,9 @@ class MatchDAO(BaseDAO):
                 dates.append(md)
 
                 if md < today and status in ("scheduled", "tbd") and m.get("home_score") is None:
-                    needs_score += 1
+                    in_window = (not score_from or md >= score_from) and (not score_to or md <= score_to)
+                    if in_window:
+                        needs_score += 1
 
                 if status in ("scheduled", "tbd") and today <= md <= kickoff_horizon and not m.get("scheduled_kickoff"):
                     needs_kickoff += 1


### PR DESCRIPTION
## Summary
- Adds optional `score_from`/`score_to` query params to `/api/agent/match-summary`
- When provided, `needs_score` only counts matches within that date window
- Backward compatible — omitting params gives the existing full-season behavior

## Why
The scraper agent needs to know if there are missing scores from **last weekend specifically**, not the entire season. Old `tbd` matches from weeks ago should be handled by the weekly audit, not trigger unnecessary score-sync scrapes.

## Test plan
- [ ] Verify `/api/agent/match-summary?season=2025-2026` returns same results as before (no params)
- [ ] Verify `/api/agent/match-summary?season=2025-2026&score_from=2026-03-14&score_to=2026-03-15` returns `needs_score=0` for targets with no tbd matches last weekend
- [ ] Verify a target with a known tbd match in the window returns `needs_score > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)