### PR TITLE
fix: correct RabbitMQ credentials for celery worker

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": "/Users/silverbeer/gitrepos/missing-table/.secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -705,15 +705,6 @@
         "line_number": 40
       }
     ],
-    "helm/missing-table/values-prod.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "helm/missing-table/values-prod.yaml",
-        "hashed_secret": "889510f7de33270e5a7cb99960f20655930d3f6d",
-        "is_verified": false,
-        "line_number": 10
-      }
-    ],
     "helm/missing-table/values.yaml": [
       {
         "type": "Basic Auth Credentials",
@@ -831,5 +822,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-13T00:56:00Z"
+  "generated_at": "2026-03-22T13:29:14Z"
 }

--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -7,7 +7,7 @@ namespace: missing-table
 # Version information - updated by CI workflow
 version: "1.2.2" # version-tag
 buildId: "479" # build-id
-commitSha: "fd2172ea6a51e42bdcdbd237c880e3fc59e476dc" # commit-sha
+commitSha: "fd2172ea6a51e42bdcdbd237c880e3fc59e476dc" # commit-sha  #pragma: allowlist secret
 buildDate: "2026-03-21T21:33:25Z" # build-date
 
 backend:
@@ -35,8 +35,8 @@ celeryWorker:
   replicaCount: 1
 
   rabbitmq:
-    username: "guest"
-    password: "guest"  #pragma: allowlist secret
+    username: "admin"
+    password: "admin123"  #pragma: allowlist secret
     host: "rabbitmq.match-scraper.svc.cluster.local"
     port: 5672
 


### PR DESCRIPTION
## Summary

- Celery workers have been in `CrashLoopBackOff` for 15+ hours with `ACCESS_REFUSED (403)` from RabbitMQ
- Root cause: `values-prod.yaml` had `guest/guest` credentials, but RabbitMQ's `guest` account only allows `localhost` connections — cross-pod connections are always refused
- RabbitMQ in the `match-scraper` namespace has a single `admin` user (confirmed via `rabbitmqctl list_users`)
- Updated credentials to `admin/admin123` to match the actual RabbitMQ deployment

## Test plan

- [ ] ArgoCD syncs after merge
- [ ] `kubectl get pods -n missing-table` shows celery worker `Running` (not `CrashLoopBackOff`)
- [ ] No more `ACCESS_REFUSED` errors in celery worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)