### PR TITLE
fix: add imagePullSecrets to celery worker deployment

### DIFF
--- a/helm/missing-table/templates/celery-worker.yaml
+++ b/helm/missing-table/templates/celery-worker.yaml
@@ -26,6 +26,10 @@ spec:
         rollout/commitSha: {{ .Values.commitSha | default "unknown" | quote }}
         rollout/buildId: {{ .Values.buildId | default "unknown" | quote }}
     spec:
+      {{- if .Values.imageCredentials }}
+      imagePullSecrets:
+        - name: {{ include "missing-table.fullname" . }}-ghcr
+      {{- end }}
       containers:
       - name: celery-worker
         image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## Summary
- Celery worker Helm template was missing `imagePullSecrets`, unlike the backend deployment which had it
- Pod was failing with 401 Unauthorized when pulling `ghcr.io/silverbeer/missing-table-backend` anonymously
- Crash loop caused repeated volume attach/detach cycles → Linode email notifications every 10 minutes
- Applied live patch to unblock immediately; this PR makes the fix permanent in the Helm chart

## Test plan
- [x] Live patch confirmed celery worker pod Running immediately after fix
- [ ] Verify no more Linode volume attach emails after merge and deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)