### PR TITLE
fix: Update home_team_id/away_team_id on upsert when teams are swapped

### DIFF
--- a/backend/celery_tasks/match_tasks.py
+++ b/backend/celery_tasks/match_tasks.py
@@ -95,11 +95,18 @@ class DatabaseTask(Task):
             return utc_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
         return None
 
-    def _check_needs_update(self, existing_match: dict[str, Any], new_data: dict[str, Any]) -> bool:
+    def _check_needs_update(
+        self,
+        existing_match: dict[str, Any],
+        new_data: dict[str, Any],
+        home_team_id: int,
+        away_team_id: int,
+    ) -> bool:
         """
         Check if the existing match needs to be updated based on new data.
 
         Returns True if any of these conditions are met:
+        - Home/away teams swapped (home_team_id or away_team_id differ)
         - Status changed (scheduled → tbd, tbd → completed, etc.)
         - Scores changed (were null, now have values)
         - Scores were updated (different values)
@@ -110,6 +117,14 @@ class DatabaseTask(Task):
         - tbd → completed: Score posted (update with scores)
         - scheduled → completed: Direct completion (skip tbd)
         """
+        # Check home/away team swap
+        if existing_match.get("home_team_id") != home_team_id or existing_match.get("away_team_id") != away_team_id:
+            logger.debug(
+                f"Team assignment changed: home {existing_match.get('home_team_id')} → {home_team_id}, "
+                f"away {existing_match.get('away_team_id')} → {away_team_id}"
+            )
+            return True
+
         # Check status change
         existing_status = existing_match.get("match_status", "scheduled")
         new_status = new_data.get("match_status", "scheduled")
@@ -147,18 +162,36 @@ class DatabaseTask(Task):
 
         return False
 
-    def _update_match_scores(self, existing_match: dict[str, Any], new_data: dict[str, Any]) -> bool:
+    def _update_match_scores(
+        self,
+        existing_match: dict[str, Any],
+        new_data: dict[str, Any],
+        home_team_id: int | None = None,
+        away_team_id: int | None = None,
+    ) -> bool:
         """
-        Update an existing match's scores and status.
+        Update an existing match's scores, status, and team assignments.
 
-        This is a simplified update that only changes scores and status,
-        preserving all other match data.
+        Updates scores, status, match_date, scheduled_kickoff, and
+        home_team_id/away_team_id when a home/away swap is detected.
         """
         try:
             match_id = existing_match["id"]
 
             # Prepare update data
             update_data = {}
+
+            # Correct home/away team swap if team IDs differ
+            if home_team_id is not None and home_team_id != existing_match.get("home_team_id"):
+                update_data["home_team_id"] = home_team_id
+                logger.info(
+                    f"Match {match_id} home_team_id corrected: {existing_match.get('home_team_id')} → {home_team_id}"
+                )
+            if away_team_id is not None and away_team_id != existing_match.get("away_team_id"):
+                update_data["away_team_id"] = away_team_id
+                logger.info(
+                    f"Match {match_id} away_team_id corrected: {existing_match.get('away_team_id')} → {away_team_id}"
+                )
 
             # Update scores if provided
             if new_data.get("home_score") is not None:
@@ -335,14 +368,14 @@ def process_match_data(self: DatabaseTask, match_data: dict[str, Any]) -> dict[s
         # Step 4: Insert or update match
         if existing_match:
             # Check if this is a score update
-            needs_update = self._check_needs_update(existing_match, match_data)
+            needs_update = self._check_needs_update(existing_match, match_data, home_team["id"], away_team["id"])
 
             if needs_update:
                 logger.info(
                     f"Updating existing match DB ID {existing_match['id']} (MLS ID: {external_match_id}): "
                     f"{home_team_name} vs {away_team_name}"
                 )
-                success = self._update_match_scores(existing_match, match_data)
+                success = self._update_match_scores(existing_match, match_data, home_team["id"], away_team["id"])
 
                 if success:
                     result = {

--- a/backend/tests/unit/test_match_tasks.py
+++ b/backend/tests/unit/test_match_tasks.py
@@ -53,91 +53,115 @@ class TestBuildScheduledKickoff:
 
 
 class TestCheckNeedsUpdate:
+    # Helpers: existing match with matching team IDs (no swap)
+    HOME_ID = 10
+    AWAY_ID = 20
+
+    def _existing(self, **kwargs):
+        base = {
+            "match_status": "scheduled",
+            "home_score": None,
+            "away_score": None,
+            "scheduled_kickoff": None,
+            "home_team_id": self.HOME_ID,
+            "away_team_id": self.AWAY_ID,
+        }
+        base.update(kwargs)
+        return base
+
     def test_no_changes_returns_false(self, task):
-        existing = {"match_status": "scheduled", "home_score": None, "away_score": None, "scheduled_kickoff": None}
+        existing = self._existing()
         new_data = {"match_status": "scheduled", "home_score": None, "away_score": None}
-        assert task._check_needs_update(existing, new_data) is False
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is False
+
+    def test_home_away_swap_returns_true(self, task):
+        """Scraped data has home/away reversed → needs update."""
+        existing = self._existing()
+        new_data = {"match_status": "completed", "home_score": 7, "away_score": 0}
+        # Teams are swapped: scraper says AWAY_ID is home, HOME_ID is away
+        assert task._check_needs_update(existing, new_data, self.AWAY_ID, self.HOME_ID) is True
+
+    def test_home_team_id_unchanged_returns_false(self, task):
+        """Same team IDs, no other changes → no update needed."""
+        existing = self._existing(match_status="completed", home_score=7, away_score=0)
+        new_data = {"match_status": "completed", "home_score": 7, "away_score": 0}
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is False
 
     def test_status_change_returns_true(self, task):
-        existing = {"match_status": "scheduled", "home_score": None, "away_score": None, "scheduled_kickoff": None}
+        existing = self._existing()
         new_data = {"match_status": "completed", "home_score": 2, "away_score": 1}
-        assert task._check_needs_update(existing, new_data) is True
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is True
 
     def test_score_change_returns_true(self, task):
-        existing = {"match_status": "completed", "home_score": 1, "away_score": 0, "scheduled_kickoff": None}
+        existing = self._existing(match_status="completed", home_score=1, away_score=0)
         new_data = {"match_status": "completed", "home_score": 2, "away_score": 0}
-        assert task._check_needs_update(existing, new_data) is True
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is True
 
     def test_kickoff_backfill_returns_true(self, task):
         """New data has match_time, existing has no scheduled_kickoff → needs update."""
-        existing = {"match_status": "scheduled", "home_score": None, "away_score": None, "scheduled_kickoff": None}
+        existing = self._existing()
         new_data = {"match_status": "scheduled", "match_date": "2026-03-01", "match_time": "14:00"}
-        assert task._check_needs_update(existing, new_data) is True
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is True
 
     def test_kickoff_changed_returns_true(self, task):
         """Kickoff time changed (rescheduled) → needs update."""
-        existing = {
-            "match_status": "scheduled",
-            "home_score": None,
-            "away_score": None,
-            "scheduled_kickoff": "2026-03-01T19:00:00+00:00",
-        }
+        existing = self._existing(scheduled_kickoff="2026-03-01T19:00:00+00:00")
         new_data = {"match_status": "scheduled", "match_date": "2026-03-01", "match_time": "16:00"}
         # 16:00 EST = 21:00 UTC ≠ 19:00 UTC → True
-        assert task._check_needs_update(existing, new_data) is True
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is True
 
     def test_kickoff_unchanged_returns_false(self, task):
         """Same kickoff time, same everything → no update needed."""
-        existing = {
-            "match_status": "scheduled",
-            "home_score": None,
-            "away_score": None,
-            "scheduled_kickoff": "2026-03-01T19:00:00+00:00",
-        }
+        existing = self._existing(scheduled_kickoff="2026-03-01T19:00:00+00:00")
         new_data = {"match_status": "scheduled", "match_date": "2026-03-01", "match_time": "14:00"}
         # 14:00 EST = 19:00 UTC == 19:00 UTC → False
-        assert task._check_needs_update(existing, new_data) is False
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is False
 
     def test_no_match_time_in_new_data_returns_false(self, task):
         """New data has no match_time → don't clear existing kickoff."""
-        existing = {
-            "match_status": "scheduled",
-            "home_score": None,
-            "away_score": None,
-            "scheduled_kickoff": "2026-03-01T19:00:00+00:00",
-        }
+        existing = self._existing(scheduled_kickoff="2026-03-01T19:00:00+00:00")
         new_data = {"match_status": "scheduled", "match_date": "2026-03-01", "match_time": None}
-        assert task._check_needs_update(existing, new_data) is False
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is False
 
     def test_rescheduled_match_date_returns_true(self, task):
         """Match rescheduled to a different date → needs update."""
-        existing = {
-            "match_status": "scheduled",
-            "home_score": None,
-            "away_score": None,
-            "match_date": "2026-03-01",
-            "scheduled_kickoff": None,
-        }
+        existing = self._existing(match_date="2026-03-01")
         new_data = {"match_status": "scheduled", "match_date": "2026-06-08"}
-        assert task._check_needs_update(existing, new_data) is True
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is True
 
     def test_same_match_date_returns_false(self, task):
         """Same date, same everything → no update needed."""
-        existing = {
-            "match_status": "scheduled",
-            "home_score": None,
-            "away_score": None,
-            "match_date": "2026-03-01",
-            "scheduled_kickoff": None,
-        }
+        existing = self._existing(match_date="2026-03-01")
         new_data = {"match_status": "scheduled", "match_date": "2026-03-01"}
-        assert task._check_needs_update(existing, new_data) is False
+        assert task._check_needs_update(existing, new_data, self.HOME_ID, self.AWAY_ID) is False
 
 
 # ── _update_match_scores ─────────────────────────────────────────────
 
 
 class TestUpdateMatchScores:
+    def test_corrects_home_away_swap(self, task):
+        """Home/away team IDs swapped → both corrected in update payload."""
+        existing = {"id": 42, "home_team_id": 10, "away_team_id": 20, "scheduled_kickoff": None}
+        new_data = {"home_score": 7, "away_score": 0, "match_status": "completed"}
+
+        task._update_match_scores(existing, new_data, home_team_id=20, away_team_id=10)
+
+        update_payload = task._dao.client.table("matches").update.call_args[0][0]
+        assert update_payload["home_team_id"] == 20
+        assert update_payload["away_team_id"] == 10
+
+    def test_no_team_change_skips_team_fields(self, task):
+        """Same team IDs → home_team_id/away_team_id not in update payload."""
+        existing = {"id": 42, "home_team_id": 10, "away_team_id": 20, "scheduled_kickoff": None}
+        new_data = {"home_score": 2, "away_score": 1, "match_status": "completed"}
+
+        task._update_match_scores(existing, new_data, home_team_id=10, away_team_id=20)
+
+        update_payload = task._dao.client.table("matches").update.call_args[0][0]
+        assert "home_team_id" not in update_payload
+        assert "away_team_id" not in update_payload
+
     def test_updates_scheduled_kickoff(self, task):
         """scheduled_kickoff should be in the update payload when match_time provided."""
         existing = {"id": 42, "scheduled_kickoff": None}


### PR DESCRIPTION
## Summary

- The Celery upsert worker treated `home_team_id`/`away_team_id` as immutable after initial insert, so home/away swaps detected by the audit system never took effect in MT
- `_check_needs_update` now detects team ID mismatches and returns `True`
- `_update_match_scores` now includes corrected team IDs in the `UPDATE` payload
- Resolves Match 1112 (NYCFC U14 HG Northeast, 2026-02-28): Oakwood was incorrectly stored as home; resubmission will now correct it

## Test plan

- [ ] All 23 unit tests pass (`pytest tests/unit/test_match_tasks.py`)
- [ ] Deploy to prod Celery worker
- [ ] Re-run audit to verify fix: `uv run match-scraper-agent audit --env prod --team "New York City FC" --age-group U14 --dry-run` → expect 0 `home_away_mismatch` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)