### PR TITLE
fix: Consume matches.prod queue so MSA submissions are processed

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -70,6 +70,10 @@ app.conf.update(
         Queue("match_processing", Exchange("match_processing"), routing_key="match.*"),
         Queue("validation", Exchange("validation"), routing_key="validation.*"),
         Queue("celery", Exchange("celery"), routing_key="celery"),  # Default queue
+        # Legacy direct queue: MSA pods configured with AGENT_QUEUE_NAME=matches.prod
+        # bypass the fanout exchange and publish here. Worker must consume both until
+        # all pods are switched back to using the matches-fanout exchange.
+        Queue("matches.prod"),
     ),
     # Monitoring
     task_send_sent_event=True,  # Enable task-sent events


### PR DESCRIPTION
## Summary

- MSA K3s configmap has `AGENT_QUEUE_NAME=matches.prod`, publishing Celery tasks directly to that queue instead of via the `matches-fanout` exchange that routes to `match_processing`
- The Celery worker only listened on `match_processing` — result: **1899 messages backlogged with 0 consumers**
- Add `matches.prod` to `task_queues` so the worker drains the backlog on restart

## Root cause

`_queue_client_kwargs()` uses `queue_name` when set, bypassing the exchange. The configmap `AGENT_QUEUE_NAME=matches.prod` was set at some point and never removed.

## What's in the backlog

Valid Celery `process_match_data` tasks accumulated from all MSA runs since the misconfiguration. Includes the NYCFC/Oakwood `home_away_mismatch` resubmission and today's match submissions.

## Follow-up (separate kubectl patch — no code change needed)

Remove `AGENT_QUEUE_NAME` from the MSA configmap so future submissions use `matches-fanout` → `match_processing` exclusively.

## Test plan

- [ ] Merge and watch CI build + deploy
- [ ] Confirm worker pod restarts and starts consuming `matches.prod`
- [ ] `kubectl exec rabbitmq -- rabbitmqctl list_queues` → `matches.prod` count drops to 0
- [ ] Re-run `audit --dry-run` for NYCFC U14 → 0 `home_away_mismatch` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)