### PR TITLE
fix: Re-raise HTTPException in update_profile to surface correct errors

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -981,6 +981,10 @@ async def update_profile(profile_data: UserProfile, current_user: dict[str, Any]
                     profile_data.email, exclude_user_id=current_user["user_id"]
                 )
                 if existing:
+                    logger.warning(
+                        f"Email conflict: {profile_data.email!r} already on profile {existing.get('id')} "
+                        f"(requesting user: {current_user['user_id']})"
+                    )
                     raise HTTPException(status_code=409, detail="Email already in use")
 
             update_data["email"] = profile_data.email if profile_data.email.strip() else None
@@ -1018,6 +1022,8 @@ async def update_profile(profile_data: UserProfile, current_user: dict[str, Any]
 
         return {"message": "Profile updated successfully"}
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Update profile error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update profile") from e


### PR DESCRIPTION
## Summary
- `except Exception` in `update_profile` was swallowing `HTTPException` (409, 400, 403) and replacing it with a generic 500 "Failed to update profile"
- Added `except HTTPException: raise` so specific errors surface correctly to the frontend (e.g. "Email already in use", "Invalid email format", "Only admins can change roles")
- Added a warning log when an email conflict is detected to make future debugging easier

## Test plan
- [ ] Try saving a profile with an email already used by another account → should show "Email already in use" (not "Failed to update profile")
- [ ] Try saving with an invalid email format → should show "Invalid email format"
- [ ] Happy path: valid profile update succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)