### PR TITLE
feat: admin user login activity view

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -522,6 +522,18 @@ async def login(request: Request, user_data: UserLogin):
 
             auth_logger.info("auth_login_success", user_id=response.user.id)
 
+            # Record login event
+            try:
+                auth_service_client.table("login_events").insert({
+                    "user_id": str(response.user.id),
+                    "username": user_data.username,
+                    "client_ip": client_ip,
+                    "success": True,
+                    "role": profile.get("role"),
+                }).execute()
+            except Exception as log_err:
+                logger.warning(f"Failed to record login event: {log_err}")
+
             return {
                 "access_token": response.session.access_token,
                 "refresh_token": response.session.refresh_token,
@@ -541,6 +553,16 @@ async def login(request: Request, user_data: UserLogin):
             }
         else:
             auth_logger.warning("auth_login_failed", reason="invalid_credentials")
+            # Record failed login event
+            try:
+                auth_service_client.table("login_events").insert({
+                    "username": user_data.username,
+                    "client_ip": client_ip,
+                    "success": False,
+                    "failure_reason": "invalid_credentials",
+                }).execute()
+            except Exception as log_err:
+                logger.warning(f"Failed to record login event: {log_err}")
             raise HTTPException(status_code=401, detail="Invalid username or password")
 
     except HTTPException:
@@ -548,6 +570,16 @@ async def login(request: Request, user_data: UserLogin):
     except Exception as e:
         auth_logger.error("auth_login_error", error=str(e))
         logger.error(f"Login error: {e}", exc_info=True)
+        # Record failed login event
+        try:
+            auth_service_client.table("login_events").insert({
+                "username": user_data.username,
+                "client_ip": client_ip,
+                "success": False,
+                "failure_reason": "account_error",
+            }).execute()
+        except Exception as log_err:
+            logger.warning(f"Failed to record login event: {log_err}")
         raise HTTPException(status_code=401, detail="Invalid credentials") from e
 
 
@@ -5490,6 +5522,82 @@ async def clear_cache_by_type(
         return {"message": f"{cache_type} cache cleared", "deleted": deleted}
     except Exception as e:
         logger.error(f"Error clearing {cache_type} cache: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+# =============================================================================
+# User Login Activity Endpoints (Admin Only)
+# =============================================================================
+
+
+@app.get("/api/admin/users")
+async def get_all_users(current_user: dict[str, Any] = Depends(require_admin)):
+    """Get all users with their last login time (admin only)."""
+    try:
+        profiles_resp = auth_service_client.table("user_profiles").select(
+            "id, username, display_name, role, email, team_id, club_id, created_at"
+        ).order("username").execute()
+        profiles = profiles_resp.data or []
+
+        # Get last login time for each user
+        if profiles:
+            user_ids = [p["id"] for p in profiles]
+            # Fetch most recent login event per user_id
+            events_resp = auth_service_client.table("login_events").select(
+                "user_id, success, created_at"
+            ).in_("user_id", user_ids).order("created_at", desc=True).execute()
+            events = events_resp.data or []
+
+            # Build a map of user_id -> last login info
+            last_login_map: dict[str, dict] = {}
+            for ev in events:
+                uid = ev["user_id"]
+                if uid not in last_login_map:
+                    last_login_map[uid] = {
+                        "last_login_at": ev["created_at"],
+                        "last_login_success": ev["success"],
+                    }
+
+            for profile in profiles:
+                info = last_login_map.get(profile["id"], {})
+                profile["last_login_at"] = info.get("last_login_at")
+                profile["last_login_success"] = info.get("last_login_success")
+
+        return {"users": profiles, "total": len(profiles)}
+    except Exception as e:
+        logger.error(f"Error fetching users: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.get("/api/admin/users/login-events")
+async def get_login_events(
+    limit: int = 100,
+    offset: int = 0,
+    username: str | None = None,
+    success: bool | None = None,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    """Get login events with optional filters (admin only)."""
+    try:
+        query = auth_service_client.table("login_events").select(
+            "id, user_id, username, client_ip, success, failure_reason, role, created_at",
+            count="exact",
+        ).order("created_at", desc=True).range(offset, offset + limit - 1)
+
+        if username:
+            query = query.ilike("username", f"%{username}%")
+        if success is not None:
+            query = query.eq("success", success)
+
+        resp = query.execute()
+        return {
+            "events": resp.data or [],
+            "total": resp.count or 0,
+            "limit": limit,
+            "offset": offset,
+        }
+    except Exception as e:
+        logger.error(f"Error fetching login events: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 

--- a/frontend/src/components/AdminPanel.vue
+++ b/frontend/src/components/AdminPanel.vue
@@ -166,6 +166,15 @@
         >
           <AdminCache />
         </div>
+
+        <!-- Users / Login Activity -->
+        <div
+          v-if="currentSection === 'users'"
+          class="p-6"
+          data-testid="admin-section-users"
+        >
+          <AdminUsers />
+        </div>
       </div>
     </div>
   </div>
@@ -187,6 +196,7 @@ import AdminInvites from './admin/AdminInvites.vue';
 import AdminInviteRequests from './admin/AdminInviteRequests.vue';
 import AdminPlayoffs from './admin/AdminPlayoffs.vue';
 import AdminCache from './admin/AdminCache.vue';
+import AdminUsers from './admin/AdminUsers.vue';
 
 export default {
   name: 'AdminPanel',
@@ -204,6 +214,7 @@ export default {
     AdminInviteRequests,
     AdminPlayoffs,
     AdminCache,
+    AdminUsers,
   },
   setup() {
     const authStore = useAuthStore();
@@ -224,6 +235,7 @@ export default {
       { id: 'playoffs', name: 'Playoffs', adminOnly: true },
       { id: 'invites', name: 'Invites', adminOnly: false },
       { id: 'cache', name: 'Cache', adminOnly: true },
+      { id: 'users', name: 'Users', adminOnly: true },
     ];
 
     // Filter sections based on user role

--- a/frontend/src/components/admin/AdminUsers.vue
+++ b/frontend/src/components/admin/AdminUsers.vue
@@ -1,0 +1,354 @@
+<template>
+  <div class="admin-users">
+    <div class="flex justify-between items-center mb-6">
+      <h2 class="text-xl font-semibold text-gray-900">User Login Activity</h2>
+      <button
+        @click="activeTab === 'users' ? fetchUsers() : fetchLoginEvents()"
+        :disabled="loading"
+        class="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200 disabled:opacity-50"
+      >
+        {{ loading ? 'Loading...' : 'Refresh' }}
+      </button>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-if="error"
+      class="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm"
+    >
+      {{ error }}
+    </div>
+
+    <!-- Tabs -->
+    <div class="mb-4 border-b border-gray-200">
+      <nav class="flex space-x-4">
+        <button
+          @click="
+            activeTab = 'users';
+            fetchUsers();
+          "
+          :class="[
+            activeTab === 'users'
+              ? 'border-b-2 border-blue-600 text-blue-600'
+              : 'text-gray-500 hover:text-gray-700',
+            'pb-2 text-sm font-medium',
+          ]"
+        >
+          Users ({{ userTotal }})
+        </button>
+        <button
+          @click="
+            activeTab = 'events';
+            fetchLoginEvents();
+          "
+          :class="[
+            activeTab === 'events'
+              ? 'border-b-2 border-blue-600 text-blue-600'
+              : 'text-gray-500 hover:text-gray-700',
+            'pb-2 text-sm font-medium',
+          ]"
+        >
+          Login History ({{ eventTotal }})
+        </button>
+      </nav>
+    </div>
+
+    <!-- Users Tab -->
+    <div v-if="activeTab === 'users'">
+      <div v-if="loading" class="text-center py-8 text-gray-500">
+        Loading users...
+      </div>
+      <div
+        v-else-if="users.length === 0"
+        class="text-center py-8 text-gray-500"
+      >
+        No users found.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left text-gray-500 border-b border-gray-200">
+              <th class="pb-2 pr-4 font-medium">Username</th>
+              <th class="pb-2 pr-4 font-medium">Display Name</th>
+              <th class="pb-2 pr-4 font-medium">Role</th>
+              <th class="pb-2 pr-4 font-medium">Last Login</th>
+              <th class="pb-2 font-medium">Joined</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="user in users" :key="user.id" class="hover:bg-gray-50">
+              <td class="py-2 pr-4 font-mono text-gray-900">
+                {{ user.username }}
+              </td>
+              <td class="py-2 pr-4 text-gray-700">
+                {{ user.display_name || '—' }}
+              </td>
+              <td class="py-2 pr-4">
+                <span :class="roleBadgeClass(user.role)">{{
+                  user.role || 'user'
+                }}</span>
+              </td>
+              <td class="py-2 pr-4 text-gray-600">
+                <span v-if="user.last_login_at">
+                  <span
+                    :class="
+                      user.last_login_success
+                        ? 'text-green-600'
+                        : 'text-red-500'
+                    "
+                    class="mr-1"
+                    >{{ user.last_login_success ? '✓' : '✗' }}</span
+                  >
+                  {{ formatDate(user.last_login_at) }}
+                </span>
+                <span v-else class="text-gray-400 italic">Never</span>
+              </td>
+              <td class="py-2 text-gray-500">
+                {{ formatDate(user.created_at) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Login Events Tab -->
+    <div v-if="activeTab === 'events'">
+      <!-- Filters -->
+      <div class="flex flex-wrap gap-3 mb-4">
+        <input
+          v-model="filterUsername"
+          @input="debouncedFetch"
+          type="text"
+          placeholder="Filter by username..."
+          class="px-3 py-1.5 text-sm border border-gray-300 rounded w-48 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <select
+          v-model="filterSuccess"
+          @change="fetchLoginEvents"
+          class="px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="">All results</option>
+          <option value="true">Success only</option>
+          <option value="false">Failures only</option>
+        </select>
+      </div>
+
+      <div v-if="loading" class="text-center py-8 text-gray-500">
+        Loading events...
+      </div>
+      <div
+        v-else-if="events.length === 0"
+        class="text-center py-8 text-gray-500"
+      >
+        No login events found.
+      </div>
+      <div v-else>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr class="text-left text-gray-500 border-b border-gray-200">
+                <th class="pb-2 pr-4 font-medium">Time</th>
+                <th class="pb-2 pr-4 font-medium">Username</th>
+                <th class="pb-2 pr-4 font-medium">Result</th>
+                <th class="pb-2 pr-4 font-medium">IP Address</th>
+                <th class="pb-2 font-medium">Role</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="ev in events" :key="ev.id" class="hover:bg-gray-50">
+                <td class="py-2 pr-4 text-gray-600 whitespace-nowrap">
+                  {{ formatDate(ev.created_at) }}
+                </td>
+                <td class="py-2 pr-4 font-mono text-gray-900">
+                  {{ ev.username }}
+                </td>
+                <td class="py-2 pr-4">
+                  <span
+                    v-if="ev.success"
+                    class="text-green-700 bg-green-50 px-2 py-0.5 rounded text-xs font-medium"
+                    >Success</span
+                  >
+                  <span
+                    v-else
+                    class="text-red-700 bg-red-50 px-2 py-0.5 rounded text-xs font-medium"
+                  >
+                    Failed{{
+                      ev.failure_reason ? ` (${ev.failure_reason})` : ''
+                    }}
+                  </span>
+                </td>
+                <td class="py-2 pr-4 font-mono text-gray-500 text-xs">
+                  {{ ev.client_ip || '—' }}
+                </td>
+                <td class="py-2 text-gray-600 text-xs">{{ ev.role || '—' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        <div
+          class="flex items-center justify-between mt-4 text-sm text-gray-600"
+        >
+          <span>Showing {{ events.length }} of {{ eventTotal }} events</span>
+          <div class="flex gap-2">
+            <button
+              @click="prevPage"
+              :disabled="currentPage === 0"
+              class="px-3 py-1 border border-gray-300 rounded disabled:opacity-40 hover:bg-gray-50"
+            >
+              Previous
+            </button>
+            <button
+              @click="nextPage"
+              :disabled="(currentPage + 1) * pageSize >= eventTotal"
+              class="px-3 py-1 border border-gray-300 rounded disabled:opacity-40 hover:bg-gray-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import { getApiBaseUrl } from '@/config/api';
+
+export default {
+  name: 'AdminUsers',
+  setup() {
+    const authStore = useAuthStore();
+    const loading = ref(false);
+    const error = ref(null);
+    const activeTab = ref('users');
+
+    const users = ref([]);
+    const userTotal = ref(0);
+
+    const events = ref([]);
+    const eventTotal = ref(0);
+    const currentPage = ref(0);
+    const pageSize = 100;
+    const filterUsername = ref('');
+    const filterSuccess = ref('');
+
+    let debounceTimer = null;
+
+    const fetchUsers = async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const data = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/admin/users`,
+          { method: 'GET' }
+        );
+        users.value = data.users || [];
+        userTotal.value = data.total || 0;
+      } catch (err) {
+        error.value = err.message || 'Failed to fetch users';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const fetchLoginEvents = async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const params = new URLSearchParams({
+          limit: pageSize,
+          offset: currentPage.value * pageSize,
+        });
+        if (filterUsername.value) params.set('username', filterUsername.value);
+        if (filterSuccess.value !== '')
+          params.set('success', filterSuccess.value);
+
+        const data = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/admin/users/login-events?${params}`,
+          { method: 'GET' }
+        );
+        events.value = data.events || [];
+        eventTotal.value = data.total || 0;
+      } catch (err) {
+        error.value = err.message || 'Failed to fetch login events';
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    const debouncedFetch = () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        currentPage.value = 0;
+        fetchLoginEvents();
+      }, 400);
+    };
+
+    const prevPage = () => {
+      if (currentPage.value > 0) {
+        currentPage.value--;
+        fetchLoginEvents();
+      }
+    };
+
+    const nextPage = () => {
+      currentPage.value++;
+      fetchLoginEvents();
+    };
+
+    const formatDate = iso => {
+      if (!iso) return '—';
+      return new Date(iso).toLocaleString();
+    };
+
+    const roleBadgeClass = role => {
+      const map = {
+        admin:
+          'bg-purple-100 text-purple-800 px-2 py-0.5 rounded text-xs font-medium',
+        club_manager:
+          'bg-blue-100 text-blue-800 px-2 py-0.5 rounded text-xs font-medium',
+        team_manager:
+          'bg-indigo-100 text-indigo-800 px-2 py-0.5 rounded text-xs font-medium',
+        'team-manager':
+          'bg-indigo-100 text-indigo-800 px-2 py-0.5 rounded text-xs font-medium',
+        team_player:
+          'bg-green-100 text-green-800 px-2 py-0.5 rounded text-xs font-medium',
+        'team-player':
+          'bg-green-100 text-green-800 px-2 py-0.5 rounded text-xs font-medium',
+      };
+      return (
+        map[role] ||
+        'bg-gray-100 text-gray-700 px-2 py-0.5 rounded text-xs font-medium'
+      );
+    };
+
+    onMounted(fetchUsers);
+
+    return {
+      loading,
+      error,
+      activeTab,
+      users,
+      userTotal,
+      events,
+      eventTotal,
+      currentPage,
+      pageSize,
+      filterUsername,
+      filterSuccess,
+      fetchUsers,
+      fetchLoginEvents,
+      debouncedFetch,
+      prevPage,
+      nextPage,
+      formatDate,
+      roleBadgeClass,
+    };
+  },
+};
+</script>

--- a/supabase-local/migrations/20260326000000_add_login_events.sql
+++ b/supabase-local/migrations/20260326000000_add_login_events.sql
@@ -1,0 +1,28 @@
+-- Migration: Add login_events table for admin user login tracking
+-- Created: 2026-03-26
+
+CREATE TABLE public.login_events (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid,                           -- NULL for failed logins where user not found
+    username varchar(100) NOT NULL,
+    client_ip varchar(45),                  -- IPv4 or IPv6
+    success boolean NOT NULL,
+    failure_reason varchar(100),            -- e.g. 'invalid_credentials', 'account_error'
+    role varchar(50),                       -- user's role at time of login (NULL if failed)
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX login_events_user_id_idx ON public.login_events(user_id);
+CREATE INDEX login_events_created_at_idx ON public.login_events(created_at DESC);
+CREATE INDEX login_events_username_idx ON public.login_events(username);
+CREATE INDEX login_events_success_idx ON public.login_events(success);
+
+-- RLS: only service role and admin users can read login events
+ALTER TABLE public.login_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on login_events"
+    ON public.login_events
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
## Summary

- New `login_events` table records every login attempt (username, IP, success/failure, role, timestamp)
- Login endpoint now persists events to DB on both success and failure
- Two new admin-only API endpoints: `GET /api/admin/users` and `GET /api/admin/users/login-events`
- New **Users** tab in Admin Panel with two sub-views:
  - **Users** — all users with role badge and last login time (✓/✗ indicator)
  - **Login History** — paginated log with username filter, success/failure filter, IP address, role

## Test plan

- [ ] Apply migration locally: `./scripts/db_tools.sh migrate local`
- [ ] Log in as a user → verify a row appears in `login_events` with `success=true`
- [ ] Attempt login with wrong password → verify `success=false`, `failure_reason=invalid_credentials`
- [ ] Go to Admin Panel → Users tab → confirm user list loads with last login info
- [ ] Click Login History tab → confirm events appear with correct IP and result badges
- [ ] Test username filter and success/failure filter
- [ ] Confirm non-admin users cannot access the Users tab (tab not shown) or the API endpoints (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)