### PR TITLE
fix: resolve 8 Supabase Security Advisor errors

### DIFF
--- a/supabase-local/migrations/20260402000000_fix_security_advisor_errors.sql
+++ b/supabase-local/migrations/20260402000000_fix_security_advisor_errors.sql
@@ -1,0 +1,29 @@
+-- Fix 8 Supabase Security Advisor errors
+--
+-- 1. teams_with_league_badges view: set security_invoker=true so the view
+--    respects the querying user's RLS policies, not the view creator's.
+--
+-- 2. FreeRADIUS tables (radcheck, radreply, radusergroup, radgroupcheck,
+--    radgroupreply, radacct, radpostauth): enable RLS with no policies, so
+--    PostgREST (anon/authenticated roles) cannot access them. FreeRADIUS
+--    connects directly as the DB owner and bypasses RLS via service_role.
+
+-- ============================================================================
+-- Fix 1: teams_with_league_badges view — use SECURITY INVOKER
+-- ============================================================================
+ALTER VIEW public.teams_with_league_badges SET (security_invoker = true);
+
+
+-- ============================================================================
+-- Fix 2: Enable RLS on FreeRADIUS tables (deny PostgREST access)
+-- ============================================================================
+ALTER TABLE public.radcheck      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.radreply      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.radusergroup  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.radgroupcheck ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.radgroupreply ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.radacct       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.radpostauth   ENABLE ROW LEVEL SECURITY;
+
+-- No policies added — RLS with zero policies = implicit deny for all roles
+-- except service_role (which bypasses RLS by default in Supabase).


### PR DESCRIPTION
## Summary

- Enable RLS on 7 FreeRADIUS tables (`radcheck`, `radreply`, `radusergroup`, `radgroupcheck`, `radgroupreply`, `radacct`, `radpostauth`) with no policies — implicit deny for PostgREST; FreeRADIUS connects as DB owner which bypasses RLS
- Set `security_invoker=true` on `teams_with_league_badges` view so it respects the querying user's RLS policies rather than the view creator's

## Test plan

- [x] `npx supabase db reset` applies all 21 migrations cleanly
- [x] Verified RLS enabled on all 7 rad tables via `pg_class.relrowsecurity`
- [x] Verified `teams_with_league_badges` has `reloptions = {security_invoker=true}`
- [ ] Confirm Security Advisor errors clear in Supabase dashboard after prod migration

## Notes

Migration: `supabase-local/migrations/20260402000000_fix_security_advisor_errors.sql`

Prod deployment: after merge, run `./scripts/db_tools.sh migrate prod` to apply the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)