### PR TITLE
fix: correct UTC timezone handling for tournament kickoff times in admin UI

### DIFF
--- a/frontend/src/components/admin/AdminTournaments.vue
+++ b/frontend/src/components/admin/AdminTournaments.vue
@@ -959,7 +959,10 @@ export default {
         is_home: true,
         match_date: match.match_date,
         scheduled_kickoff: match.scheduled_kickoff
-          ? match.scheduled_kickoff.slice(11, 16)
+          ? (() => {
+              const d = new Date(match.scheduled_kickoff);
+              return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+            })()
           : '',
         tournament_round: match.tournament_round || '',
         tournament_group: match.tournament_group || '',
@@ -994,7 +997,7 @@ export default {
       try {
         const kickoffDatetime = t =>
           t && mForm.value.match_date
-            ? `${mForm.value.match_date}T${t}:00`
+            ? new Date(`${mForm.value.match_date}T${t}:00`).toISOString()
             : t || null;
         if (editingMatch.value) {
           // Update: score/status/round/group/date fields; optionally swap teams


### PR DESCRIPTION
## Summary
- The Admin Tournament edit modal was displaying raw UTC time instead of local time (e.g. 2:00 PM instead of 10:00 AM EDT)
- The save path sent naive datetime strings without timezone info, causing locally-entered times to be stored as UTC
- Fix: on load, convert UTC ISO → local `HH:MM` via `Date.getHours()/getMinutes()`; on save, wrap naive datetime in `new Date().toISOString()` so JS handles local → UTC conversion

## Test plan
- [ ] Open Admin → Tournaments → Edit a match with a known kickoff time
- [ ] Confirm the Kickoff Time field shows the correct local time (not UTC)
- [ ] Update the kickoff time, save, and verify the Matches tab displays the correct local time
- [ ] Verify no regression on matches without a kickoff time (field stays empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)