### PR TITLE
fix: include club object in user profile query for club managers

### DIFF
--- a/backend/dao/player_dao.py
+++ b/backend/dao/player_dao.py
@@ -39,7 +39,8 @@ class PlayerDAO(BaseDAO):
                 self.client.table("user_profiles")
                 .select("""
                 *,
-                team:teams(id, name, city)
+                team:teams(id, name, city, club:clubs(id, name, primary_color, secondary_color, logo_url)),
+                club:clubs(id, name, primary_color, secondary_color, logo_url)
             """)
                 .eq("id", user_id)
                 .execute()


### PR DESCRIPTION
## Problem

`ClubManagerProfile.vue` checks `authStore.state.profile?.club` to show/hide the "No Club Assigned" banner and to get club colors. But the profile query in `get_user_profile_with_relationships` only joined `teams` — never `clubs` — so `profile.club` was always `undefined` even when `club_id` was set.

Result: club managers always saw the "No Club Assigned" banner.

## Fix

Add `club:clubs(id, name, primary_color, secondary_color, logo_url)` to the profile select query. Also adds it nested under the team join so team members get club colors too.

## Test

- Log in as `tom_club` (club manager, assigned to IFA) — "No Club Assigned" banner should be gone
- Club hero card should show IFA club colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)