### PR TITLE
fix: age_group_id never populated on player_team_history (#286)

### DIFF
--- a/backend/dao/player_dao.py
+++ b/backend/dao/player_dao.py
@@ -377,7 +377,6 @@ class PlayerDAO(BaseDAO):
                 *,
                 team:teams(id, name, city,
                     club:clubs(id, name, logo_url, primary_color, secondary_color),
-                    age_group:age_groups(id, name),
                     league:leagues(id, name),
                     division:divisions(id, name)
                 ),
@@ -427,18 +426,24 @@ class PlayerDAO(BaseDAO):
             Created/updated history entry dict, or None on error
         """
         try:
-            # Get team details for age_group_id, league_id, division_id
+            # Get team details for league_id, division_id
             team_response = (
-                self.client.table("teams").select("age_group_id, league_id, division_id").eq("id", team_id).execute()
+                self.client.table("teams").select("league_id, division_id").eq("id", team_id).execute()
             )
 
             team_data = team_response.data[0] if team_response.data else {}
+
+            # Get age_group_id from team_mappings (teams.age_group_id is deprecated/never populated)
+            mapping_response = (
+                self.client.table("team_mappings").select("age_group_id").eq("team_id", team_id).limit(1).execute()
+            )
+            age_group_id = mapping_response.data[0]["age_group_id"] if mapping_response.data else None
 
             upsert_data = {
                 "player_id": player_id,
                 "team_id": team_id,
                 "season_id": season_id,
-                "age_group_id": team_data.get("age_group_id"),
+                "age_group_id": age_group_id,
                 "league_id": team_data.get("league_id"),
                 "division_id": team_data.get("division_id"),
                 "jersey_number": jersey_number,

--- a/backend/scripts/manage_users.py
+++ b/backend/scripts/manage_users.py
@@ -653,13 +653,60 @@ def get_user_info(supabase, email):
             return False
 
         user_id = user_found.id if hasattr(user_found, "id") else user_found.get("id")
-        user_found.created_at if hasattr(user_found, "created_at") else user_found.get("created_at")
+        auth_email = user_found.email if hasattr(user_found, "email") else user_found.get("email")
+        created_at = user_found.created_at if hasattr(user_found, "created_at") else user_found.get("created_at")
 
-        # Get profile info
-        profile_result = supabase.table("user_profiles").select("*").eq("id", user_id).execute()
+        # Get profile info with team, club, age group, and division
+        # Note: teams.age_group_id is deprecated/never populated; use team_mappings instead
+        profile_result = (
+            supabase.table("user_profiles")
+            .select("*, teams(id, name, team_mappings(age_groups(name)), divisions(name)), clubs(id, name)")
+            .eq("id", user_id)
+            .execute()
+        )
+
+        console.print("\n[bold cyan]👤 User Info[/bold cyan]")
+        console.print(f"  Auth ID:    [dim]{user_id}[/dim]")
+        console.print(f"  Auth Email: [magenta]{auth_email}[/magenta]")
+        console.print(f"  Created:    {str(created_at)[:10] if created_at else 'Unknown'}")
 
         if profile_result.data:
-            profile_result.data[0]
+            p = profile_result.data[0]
+            console.print("\n[bold cyan]📋 Profile[/bold cyan]")
+            console.print(f"  Username:     [green]{p.get('username') or 'N/A'}[/green]")
+            console.print(f"  Display Name: {p.get('display_name') or 'N/A'}")
+            console.print(f"  Email:        [magenta]{p.get('email') or 'N/A'}[/magenta]")
+            console.print(f"  Role:         [yellow]{p.get('role') or 'N/A'}[/yellow]")
+
+            team = p.get("teams")
+            club = p.get("clubs")
+            if team:
+                team_mappings = team.get("team_mappings") or []
+                age_group_name = team_mappings[0]["age_groups"]["name"] if team_mappings and team_mappings[0].get("age_groups") else None
+                division = team.get("divisions", {}) or {}
+                team_parts = [team.get("name")]
+                if age_group_name:
+                    team_parts.append(age_group_name)
+                if division.get("name"):
+                    team_parts.append(division["name"])
+                console.print(f"  Team:         [blue]{' · '.join(team_parts)} (ID: {p.get('team_id')})[/blue]")
+            elif p.get("team_id"):
+                console.print(f"  Team ID:      [blue]{p.get('team_id')}[/blue]")
+            else:
+                console.print("  Team:         —")
+
+            if club:
+                console.print(f"  Club:         [blue]{club.get('name')} (ID: {p.get('club_id')})[/blue]")
+            elif p.get("club_id"):
+                console.print(f"  Club ID:      [blue]{p.get('club_id')}[/blue]")
+            else:
+                console.print("  Club:         —")
+
+            console.print(f"  Telegram:     {p.get('telegram_handle') or 'N/A'}")
+            console.print(f"  Discord:      {p.get('discord_handle') or 'N/A'}")
+            console.print(f"  Instagram:    {p.get('instagram_handle') or 'N/A'}")
+            console.print(f"  Snapchat:     {p.get('snapchat_handle') or 'N/A'}")
+            console.print(f"  TikTok:       {p.get('tiktok_handle') or 'N/A'}")
         else:
             pass
 

--- a/backend/services/invite_service.py
+++ b/backend/services/invite_service.py
@@ -360,6 +360,18 @@ class InviteService:
                     league_id = league_id or team.get("league_id")
                     division_id = division_id or team.get("division_id")
 
+            # Get age_group_id from team_mappings if not provided by the invite
+            if team_id and age_group_id is None:
+                mapping_response = (
+                    self.supabase.table("team_mappings")
+                    .select("age_group_id")
+                    .eq("team_id", team_id)
+                    .limit(1)
+                    .execute()
+                )
+                if mapping_response.data:
+                    age_group_id = mapping_response.data[0]["age_group_id"]
+
             # Update the players table to link user_profile_id
             response = self.supabase.table("players").update({"user_profile_id": user_id}).eq("id", player_id).execute()
 
@@ -447,6 +459,18 @@ class InviteService:
             if team_response.data:
                 league_id = team_response.data[0].get("league_id")
                 division_id = team_response.data[0].get("division_id")
+
+            # Get age_group_id from team_mappings if not provided by the invite
+            if age_group_id is None:
+                mapping_response = (
+                    self.supabase.table("team_mappings")
+                    .select("age_group_id")
+                    .eq("team_id", team_id)
+                    .limit(1)
+                    .execute()
+                )
+                if mapping_response.data:
+                    age_group_id = mapping_response.data[0]["age_group_id"]
 
             # Check if a player with this jersey number already exists
             existing_response = (

--- a/supabase-local/migrations/20260409000000_fix_age_group_from_team_mappings.sql
+++ b/supabase-local/migrations/20260409000000_fix_age_group_from_team_mappings.sql
@@ -1,0 +1,71 @@
+-- Fix age_group_id lookup: use team_mappings as source of truth
+--
+-- Context: teams.age_group_id is always NULL because add_team() writes to
+-- team_mappings (many-to-many) instead. The DB function create_player_history_entry
+-- and player_dao.py both read from teams.age_group_id, so player_team_history
+-- records never get an age group. This migration fixes the DB function and
+-- backfills all existing NULL records.
+
+-- Step 1: Replace create_player_history_entry to read age_group_id from team_mappings
+CREATE OR REPLACE FUNCTION public.create_player_history_entry(
+    p_player_id uuid,
+    p_team_id integer,
+    p_season_id integer,
+    p_jersey_number integer DEFAULT NULL::integer,
+    p_positions text[] DEFAULT NULL::text[]
+) RETURNS public.player_team_history
+    LANGUAGE plpgsql SECURITY DEFINER
+    AS $$
+DECLARE
+    v_team RECORD;
+    v_age_group_id integer;
+    v_result player_team_history;
+BEGIN
+    -- Get team details (league_id and division_id are populated on the teams table)
+    SELECT league_id, division_id INTO v_team
+    FROM teams WHERE id = p_team_id;
+
+    -- Get age_group_id from team_mappings (teams.age_group_id is deprecated/never populated)
+    SELECT age_group_id INTO v_age_group_id
+    FROM team_mappings WHERE team_id = p_team_id LIMIT 1;
+
+    -- Mark any existing current entries as not current
+    UPDATE player_team_history
+    SET is_current = false, updated_at = NOW()
+    WHERE player_id = p_player_id AND is_current = true;
+
+    -- Insert new history entry
+    INSERT INTO player_team_history (
+        player_id, team_id, season_id,
+        age_group_id, league_id, division_id,
+        jersey_number, positions, is_current
+    ) VALUES (
+        p_player_id, p_team_id, p_season_id,
+        v_age_group_id, v_team.league_id, v_team.division_id,
+        p_jersey_number, p_positions, true
+    )
+    ON CONFLICT (player_id, team_id, season_id)
+    DO UPDATE SET
+        jersey_number = COALESCE(EXCLUDED.jersey_number, player_team_history.jersey_number),
+        positions = COALESCE(EXCLUDED.positions, player_team_history.positions),
+        is_current = true,
+        updated_at = NOW()
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+-- Step 2: Backfill existing player_team_history records where age_group_id is NULL
+UPDATE player_team_history pth
+SET age_group_id = (
+    SELECT tm.age_group_id
+    FROM team_mappings tm
+    WHERE tm.team_id = pth.team_id
+    LIMIT 1
+)
+WHERE pth.age_group_id IS NULL;
+
+-- Step 3: Deprecate the teams.age_group_id column
+COMMENT ON COLUMN public.teams.age_group_id IS
+    'DEPRECATED: Always NULL. Use team_mappings table for age group relationships (supports many-to-many).';


### PR DESCRIPTION
## Summary

- **Root cause**: `teams.age_group_id` is always NULL — `add_team()` writes to `team_mappings` (many-to-many) but the DB function `create_player_history_entry` and `player_dao.py` both read from `teams.age_group_id`, so `player_team_history.age_group_id` is also always NULL
- **Fix**: Use `team_mappings` as the single source of truth for age group lookups throughout the stack
- **Backfill**: Migration backfills all existing `player_team_history` records where `age_group_id IS NULL`

## Changes

| File | Change |
|------|--------|
| `supabase-local/migrations/20260409000000_fix_age_group_from_team_mappings.sql` | Replace `create_player_history_entry` function to look up from `team_mappings`; backfill existing NULL records; deprecate `teams.age_group_id` column |
| `backend/dao/player_dao.py` | Read `age_group_id` from `team_mappings` in `create_or_update_player_history()`; remove dead `teams.age_group_id` join in `get_all_current_player_teams()` |
| `backend/services/invite_service.py` | Add `team_mappings` fallback in both roster-linking methods when invite lacks `age_group_id` |
| `backend/scripts/manage_users.py` | Fix `info` command PostgREST join to go through `team_mappings` instead of null `teams→age_groups` FK |

## Test plan

- [ ] Apply migration to prod: `./scripts/db_tools.sh migrate prod`
- [ ] Verify backfill: `SELECT count(*) as total, count(age_group_id) as with_ag FROM player_team_history`
- [ ] `manage_users.py info <user>` shows age group for team-players (e.g. "IFA · U13 · Northeast")
- [ ] PlayerProfile hero card shows actual age group ("U13") not just league name
- [ ] New invite redemptions create history entries with correct `age_group_id`

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)