### PR TITLE
feat: Match preview component (recent form, common opponents, head-to-head)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2241,6 +2241,34 @@ async def get_live_matches(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+@app.get("/api/matches/preview/{home_team_id}/{away_team_id}")
+async def get_match_preview(
+    home_team_id: int,
+    away_team_id: int,
+    season_id: int | None = Query(None, description="Season ID for recent form and common opponents"),
+    age_group_id: int | None = Query(None, description="Filter by age group"),
+    recent_count: int = Query(5, ge=1, le=20, description="Number of recent matches per team"),
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+):
+    """Get match preview data for two teams.
+
+    Returns recent form for each team, common opponents (with match results), and
+    head-to-head history spanning all seasons.
+    """
+    try:
+        preview = match_dao.get_match_preview(
+            home_team_id=home_team_id,
+            away_team_id=away_team_id,
+            season_id=season_id,
+            age_group_id=age_group_id,
+            recent_count=recent_count,
+        )
+        return preview
+    except Exception as e:
+        logger.error(f"Error building match preview: {e!s}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 @app.get("/api/matches/{match_id}")
 async def get_match(
     request: Request,

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -616,6 +616,156 @@ class MatchDAO(BaseDAO):
             logger.exception("Error querying matches by team")
             return []
 
+    def get_match_preview(
+        self,
+        home_team_id: int,
+        away_team_id: int,
+        season_id: int | None = None,
+        age_group_id: int | None = None,
+        recent_count: int = 5,
+    ) -> dict:
+        """Get match preview data: recent form, common opponents, and head-to-head history.
+
+        Args:
+            home_team_id: ID of the home team in the upcoming match
+            away_team_id: ID of the away team in the upcoming match
+            season_id: Season for recent form and common opponents (None = all seasons)
+            age_group_id: Optional filter to restrict to a specific age group
+            recent_count: How many recent matches to return per team
+
+        Returns:
+            Dict with home_team_recent, away_team_recent, common_opponents, head_to_head
+        """
+        select_str = """
+            *,
+            home_team:teams!matches_home_team_id_fkey(id, name),
+            away_team:teams!matches_away_team_id_fkey(id, name),
+            season:seasons(id, name),
+            age_group:age_groups(id, name),
+            match_type:match_types(id, name),
+            division:divisions(id, name)
+        """
+
+        def flatten(match: dict) -> dict:
+            return {
+                "id": match["id"],
+                "match_date": match["match_date"],
+                "scheduled_kickoff": match.get("scheduled_kickoff"),
+                "home_team_id": match["home_team_id"],
+                "away_team_id": match["away_team_id"],
+                "home_team_name": match["home_team"]["name"] if match.get("home_team") else "Unknown",
+                "away_team_name": match["away_team"]["name"] if match.get("away_team") else "Unknown",
+                "home_score": match["home_score"],
+                "away_score": match["away_score"],
+                "season_id": match["season_id"],
+                "season_name": match["season"]["name"] if match.get("season") else "Unknown",
+                "age_group_id": match["age_group_id"],
+                "age_group_name": match["age_group"]["name"] if match.get("age_group") else "Unknown",
+                "match_type_id": match["match_type_id"],
+                "match_type_name": match["match_type"]["name"] if match.get("match_type") else "Unknown",
+                "division_id": match.get("division_id"),
+                "division_name": match["division"]["name"] if match.get("division") else "Unknown",
+                "match_status": match.get("match_status"),
+                "source": match.get("source", "manual"),
+                "match_id": match.get("match_id"),
+                "created_at": match.get("created_at"),
+                "updated_at": match.get("updated_at"),
+            }
+
+        def build_base_query(team_id: int):
+            q = (
+                self.client.table("matches")
+                .select(select_str)
+                .or_(f"home_team_id.eq.{team_id},away_team_id.eq.{team_id}")
+                .in_("match_status", ["completed", "forfeit"])
+            )
+            if season_id:
+                q = q.eq("season_id", season_id)
+            if age_group_id:
+                q = q.eq("age_group_id", age_group_id)
+            return q
+
+        try:
+            # --- Recent form for each team ---
+            home_resp = build_base_query(home_team_id).order("match_date", desc=True).limit(recent_count).execute()
+            away_resp = build_base_query(away_team_id).order("match_date", desc=True).limit(recent_count).execute()
+            home_recent = [flatten(m) for m in (home_resp.data or [])]
+            away_recent = [flatten(m) for m in (away_resp.data or [])]
+
+            # --- Common opponents (season-scoped) ---
+            # Fetch all season matches for both teams to find shared opponents
+            home_all_resp = build_base_query(home_team_id).order("match_date", desc=True).execute()
+            away_all_resp = build_base_query(away_team_id).order("match_date", desc=True).execute()
+            home_all = [flatten(m) for m in (home_all_resp.data or [])]
+            away_all = [flatten(m) for m in (away_all_resp.data or [])]
+
+            def extract_opponents(matches: list[dict], team_id: int) -> dict[int, str]:
+                """Return {opponent_id: opponent_name} excluding the two preview teams."""
+                opps: dict[int, str] = {}
+                for m in matches:
+                    if m["home_team_id"] == team_id:
+                        opp_id, opp_name = m["away_team_id"], m["away_team_name"]
+                    else:
+                        opp_id, opp_name = m["home_team_id"], m["home_team_name"]
+                    # Exclude head-to-head matches between the two preview teams
+                    if opp_id not in (home_team_id, away_team_id):
+                        opps[opp_id] = opp_name
+                return opps
+
+            home_opps = extract_opponents(home_all, home_team_id)
+            away_opps = extract_opponents(away_all, away_team_id)
+            common_ids = sorted(set(home_opps) & set(away_opps), key=lambda i: home_opps[i])
+
+            common_opponents = []
+            for opp_id in common_ids:
+                home_vs = [m for m in home_all if opp_id in (m["home_team_id"], m["away_team_id"])]
+                away_vs = [m for m in away_all if opp_id in (m["home_team_id"], m["away_team_id"])]
+                common_opponents.append(
+                    {
+                        "opponent_id": opp_id,
+                        "opponent_name": home_opps[opp_id],
+                        "home_team_matches": home_vs,
+                        "away_team_matches": away_vs,
+                    }
+                )
+
+            # --- Head-to-head history (all seasons, cross-season) ---
+            # Fetch all matches for home_team and filter to those against away_team
+            h2h_query = (
+                self.client.table("matches")
+                .select(select_str)
+                .or_(f"home_team_id.eq.{home_team_id},away_team_id.eq.{home_team_id}")
+                .in_("match_status", ["completed", "forfeit"])
+            )
+            if age_group_id:
+                h2h_query = h2h_query.eq("age_group_id", age_group_id)
+            h2h_resp = h2h_query.order("match_date", desc=True).execute()
+            head_to_head = [
+                flatten(m)
+                for m in (h2h_resp.data or [])
+                if away_team_id in (m["home_team_id"], m["away_team_id"])
+            ]
+
+            return {
+                "home_team_id": home_team_id,
+                "away_team_id": away_team_id,
+                "home_team_recent": home_recent,
+                "away_team_recent": away_recent,
+                "common_opponents": common_opponents,
+                "head_to_head": head_to_head,
+            }
+
+        except Exception:
+            logger.exception("Error building match preview")
+            return {
+                "home_team_id": home_team_id,
+                "away_team_id": away_team_id,
+                "home_team_recent": [],
+                "away_team_recent": [],
+                "common_opponents": [],
+                "head_to_head": [],
+            }
+
     @invalidates_cache(MATCHES_CACHE_PATTERN)
     def add_match(
         self,

--- a/frontend/src/__tests__/components/MatchDetailView.spec.js
+++ b/frontend/src/__tests__/components/MatchDetailView.spec.js
@@ -67,6 +67,16 @@ const createMockApiRequestForMatch = (match, events = []) => {
     if (url.includes('/live/events')) {
       return Promise.resolve(events);
     }
+    if (url.includes('/preview/')) {
+      return Promise.resolve({
+        home_team_id: match.home_team_id,
+        away_team_id: match.away_team_id,
+        home_team_recent: [],
+        away_team_recent: [],
+        common_opponents: [],
+        head_to_head: [],
+      });
+    }
     return Promise.resolve(match);
   });
 };

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -417,6 +417,24 @@
         </button>
       </div>
 
+      <!-- Match Preview (scheduled/tbd matches only) -->
+      <div
+        v-if="
+          match.match_status === 'scheduled' || match.match_status === 'tbd'
+        "
+        class="mt-4"
+        data-testid="match-preview-section"
+      >
+        <MatchPreview
+          :homeTeamId="match.home_team_id"
+          :homeTeamName="match.home_team_name"
+          :awayTeamId="match.away_team_id"
+          :awayTeamName="match.away_team_name"
+          :seasonId="match.season_id"
+          :ageGroupId="match.age_group_id"
+        />
+      </div>
+
       <!-- Pre-match Lineup Section (scheduled matches, authorized users only) -->
       <div
         v-if="canManageLineup && match.match_status === 'scheduled'"
@@ -556,12 +574,14 @@ import html2canvas from 'html2canvas';
 import { useMatchLineup } from '../composables/useMatchLineup';
 import LineupManager from './live/LineupManager.vue';
 import PostMatchEditor from './PostMatchEditor.vue';
+import MatchPreview from './MatchPreview.vue';
 
 export default {
   name: 'MatchDetailView',
   components: {
     LineupManager,
     PostMatchEditor,
+    MatchPreview,
   },
   props: {
     matchId: {

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -1,0 +1,453 @@
+<template>
+  <div class="match-preview">
+    <!-- Loading -->
+    <div
+      v-if="loading"
+      class="flex flex-col items-center justify-center py-12"
+      data-testid="preview-loading"
+    >
+      <div
+        class="w-8 h-8 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin mb-3"
+      ></div>
+      <p class="text-gray-500 text-sm">Loading match preview...</p>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="error"
+      class="flex flex-col items-center justify-center py-12 text-center"
+      data-testid="preview-error"
+    >
+      <div
+        class="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center text-red-500 font-bold mb-3"
+      >
+        !
+      </div>
+      <p class="text-gray-500 text-sm mb-3">{{ error }}</p>
+      <button
+        @click="fetchPreview"
+        class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
+      >
+        Retry
+      </button>
+    </div>
+
+    <!-- Content -->
+    <div v-else-if="preview" data-testid="preview-content">
+      <!-- Tab bar -->
+      <div class="border-b border-gray-200 mb-4">
+        <nav class="flex space-x-1" aria-label="Match preview sections">
+          <button
+            v-for="tab in tabs"
+            :key="tab.id"
+            @click="activeTab = tab.id"
+            :data-testid="`tab-${tab.id}`"
+            :class="[
+              'py-2 px-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap',
+              activeTab === tab.id
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+            ]"
+          >
+            {{ tab.label }}
+            <span
+              v-if="tab.count !== null"
+              class="ml-1 text-xs px-1.5 py-0.5 rounded-full"
+              :class="
+                activeTab === tab.id
+                  ? 'bg-blue-100 text-blue-700'
+                  : 'bg-gray-100 text-gray-500'
+              "
+              >{{ tab.count }}</span
+            >
+          </button>
+        </nav>
+      </div>
+
+      <!-- ── Recent Form ── -->
+      <div v-if="activeTab === 'form'" data-testid="tab-panel-form">
+        <div class="grid grid-cols-2 gap-3">
+          <!-- Home team column -->
+          <div>
+            <h3
+              class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2 truncate"
+            >
+              {{ homeTeamName }}
+            </h3>
+            <div
+              v-if="preview.home_team_recent.length === 0"
+              class="text-xs text-gray-400 italic"
+            >
+              No recent matches
+            </div>
+            <div
+              v-for="match in preview.home_team_recent"
+              :key="match.id"
+              class="mb-2"
+              data-testid="home-recent-match"
+            >
+              <MatchResultCard :match="match" :perspectiveTeamId="homeTeamId" />
+            </div>
+          </div>
+
+          <!-- Away team column -->
+          <div>
+            <h3
+              class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2 truncate"
+            >
+              {{ awayTeamName }}
+            </h3>
+            <div
+              v-if="preview.away_team_recent.length === 0"
+              class="text-xs text-gray-400 italic"
+            >
+              No recent matches
+            </div>
+            <div
+              v-for="match in preview.away_team_recent"
+              :key="match.id"
+              class="mb-2"
+              data-testid="away-recent-match"
+            >
+              <MatchResultCard :match="match" :perspectiveTeamId="awayTeamId" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Common Opponents ── -->
+      <div v-else-if="activeTab === 'common'" data-testid="tab-panel-common">
+        <div
+          v-if="preview.common_opponents.length === 0"
+          class="text-sm text-gray-500 text-center py-8"
+        >
+          No common opponents found for this season.
+        </div>
+        <div
+          v-for="opp in preview.common_opponents"
+          :key="opp.opponent_id"
+          class="mb-5"
+          data-testid="common-opponent-section"
+        >
+          <!-- Opponent header -->
+          <div
+            class="flex items-center gap-2 mb-2 pb-1 border-b border-gray-100"
+          >
+            <span class="inline-block w-2 h-2 rounded-full bg-gray-400"></span>
+            <span class="text-sm font-semibold text-gray-800"
+              >vs {{ opp.opponent_name }}</span
+            >
+          </div>
+
+          <div class="grid grid-cols-2 gap-3">
+            <!-- Home team vs opponent -->
+            <div>
+              <p class="text-xs text-gray-400 mb-1 truncate">
+                {{ homeTeamName }}
+              </p>
+              <div
+                v-if="opp.home_team_matches.length === 0"
+                class="text-xs text-gray-400 italic"
+              >
+                No matches
+              </div>
+              <div
+                v-for="match in opp.home_team_matches"
+                :key="match.id"
+                class="mb-1.5"
+              >
+                <MatchResultCard
+                  :match="match"
+                  :perspectiveTeamId="homeTeamId"
+                  compact
+                />
+              </div>
+            </div>
+            <!-- Away team vs opponent -->
+            <div>
+              <p class="text-xs text-gray-400 mb-1 truncate">
+                {{ awayTeamName }}
+              </p>
+              <div
+                v-if="opp.away_team_matches.length === 0"
+                class="text-xs text-gray-400 italic"
+              >
+                No matches
+              </div>
+              <div
+                v-for="match in opp.away_team_matches"
+                :key="match.id"
+                class="mb-1.5"
+              >
+                <MatchResultCard
+                  :match="match"
+                  :perspectiveTeamId="awayTeamId"
+                  compact
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Head-to-Head ── -->
+      <div v-else-if="activeTab === 'h2h'" data-testid="tab-panel-h2h">
+        <div
+          v-if="preview.head_to_head.length === 0"
+          class="text-sm text-gray-500 text-center py-8"
+        >
+          No previous meetings found.
+        </div>
+
+        <!-- Summary row -->
+        <div
+          v-if="preview.head_to_head.length > 0"
+          class="flex justify-around text-center mb-4 p-3 bg-gray-50 rounded-lg"
+        >
+          <div>
+            <span class="block text-xl font-bold text-blue-600">{{
+              h2hStats.homeWins
+            }}</span>
+            <span class="text-xs text-gray-500 truncate block max-w-[80px]">{{
+              homeTeamName
+            }}</span>
+          </div>
+          <div>
+            <span class="block text-xl font-bold text-gray-500">{{
+              h2hStats.draws
+            }}</span>
+            <span class="text-xs text-gray-500">Draws</span>
+          </div>
+          <div>
+            <span class="block text-xl font-bold text-red-500">{{
+              h2hStats.awayWins
+            }}</span>
+            <span class="text-xs text-gray-500 truncate block max-w-[80px]">{{
+              awayTeamName
+            }}</span>
+          </div>
+        </div>
+
+        <!-- Match list -->
+        <div
+          v-for="match in preview.head_to_head"
+          :key="match.id"
+          class="mb-2"
+          data-testid="h2h-match"
+        >
+          <H2HMatchRow
+            :match="match"
+            :homeTeamId="homeTeamId"
+            :awayTeamId="awayTeamId"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import { getApiBaseUrl } from '@/config/api';
+
+// ─── Sub-components defined inline ────────────────────────────────────────────
+
+/**
+ * MatchResultCard - compact match result from one team's perspective.
+ * Shows: W/L/D chip | score | opponent name | date
+ */
+const MatchResultCard = {
+  props: {
+    match: { type: Object, required: true },
+    perspectiveTeamId: { type: Number, required: true },
+    compact: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const outcome = computed(() => {
+      const m = props.match;
+      if (m.home_score === null || m.away_score === null) return null;
+      const isHome = m.home_team_id === props.perspectiveTeamId;
+      const teamScore = isHome ? m.home_score : m.away_score;
+      const oppScore = isHome ? m.away_score : m.home_score;
+      if (teamScore > oppScore) return 'W';
+      if (teamScore < oppScore) return 'L';
+      return 'D';
+    });
+
+    const opponent = computed(() => {
+      const m = props.match;
+      return m.home_team_id === props.perspectiveTeamId
+        ? m.away_team_name
+        : m.home_team_name;
+    });
+
+    const scoreDisplay = computed(() => {
+      const m = props.match;
+      if (m.home_score === null || m.away_score === null) return '- : -';
+      return `${m.home_score} - ${m.away_score}`;
+    });
+
+    const outcomeClass = computed(() => {
+      if (outcome.value === 'W') return 'bg-green-100 text-green-700';
+      if (outcome.value === 'L') return 'bg-red-100 text-red-700';
+      if (outcome.value === 'D') return 'bg-gray-100 text-gray-600';
+      return 'bg-gray-100 text-gray-400';
+    });
+
+    const formattedDate = computed(() => {
+      if (!props.match.match_date) return '';
+      const d = new Date(props.match.match_date + 'T00:00:00');
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    });
+
+    return { outcome, opponent, scoreDisplay, outcomeClass, formattedDate };
+  },
+  template: `
+    <div class="flex items-center gap-1.5 p-1.5 rounded bg-white border border-gray-100 shadow-sm text-xs">
+      <span :class="['font-bold w-4 text-center shrink-0', outcomeClass]" style="border-radius:2px">
+        {{ outcome ?? '?' }}
+      </span>
+      <span class="font-mono font-semibold text-gray-700 shrink-0">{{ scoreDisplay }}</span>
+      <span class="text-gray-600 truncate flex-1">{{ opponent }}</span>
+      <span class="text-gray-400 shrink-0">{{ formattedDate }}</span>
+    </div>
+  `,
+};
+
+/**
+ * H2HMatchRow - single head-to-head match row.
+ * Shows home and away team with score centred, plus season and date.
+ */
+const H2HMatchRow = {
+  props: {
+    match: { type: Object, required: true },
+    homeTeamId: { type: Number, required: true },
+    awayTeamId: { type: Number, required: true },
+  },
+  setup(props) {
+    const formattedDate = computed(() => {
+      if (!props.match.match_date) return '';
+      const d = new Date(props.match.match_date + 'T00:00:00');
+      return d.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    });
+
+    const winnerClass = teamId => {
+      const m = props.match;
+      if (m.home_score === null || m.away_score === null) return '';
+      const isHome = m.home_team_id === teamId;
+      const score = isHome ? m.home_score : m.away_score;
+      const opp = isHome ? m.away_score : m.home_score;
+      if (score > opp) return 'font-bold text-gray-900';
+      if (score < opp) return 'text-gray-400';
+      return 'text-gray-700';
+    };
+
+    return { formattedDate, winnerClass };
+  },
+  template: `
+    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-white border border-gray-100 shadow-sm text-xs">
+      <span :class="['flex-1 text-right truncate', winnerClass(match.home_team_id)]">{{ match.home_team_name }}</span>
+      <span class="font-mono font-semibold text-gray-800 shrink-0 bg-gray-50 px-2 py-0.5 rounded">
+        {{ match.home_score ?? '-' }} – {{ match.away_score ?? '-' }}
+      </span>
+      <span :class="['flex-1 truncate', winnerClass(match.away_team_id)]">{{ match.away_team_name }}</span>
+      <div class="text-right shrink-0 ml-2">
+        <div class="text-gray-400">{{ formattedDate }}</div>
+        <div class="text-gray-300">{{ match.season_name }}</div>
+      </div>
+    </div>
+  `,
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+const props = defineProps({
+  homeTeamId: { type: Number, required: true },
+  homeTeamName: { type: String, default: 'Home Team' },
+  awayTeamId: { type: Number, required: true },
+  awayTeamName: { type: String, default: 'Away Team' },
+  /** Season ID scopes "recent form" and "common opponents". Null = all seasons. */
+  seasonId: { type: Number, default: null },
+  /** Optional: narrow to a specific age group */
+  ageGroupId: { type: Number, default: null },
+  /** How many recent matches to fetch per team */
+  recentCount: { type: Number, default: 5 },
+});
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+const authStore = useAuthStore();
+const preview = ref(null);
+const loading = ref(false);
+const error = ref(null);
+const activeTab = ref('form');
+
+// ─── Tabs ────────────────────────────────────────────────────────────────────
+
+const tabs = computed(() => [
+  { id: 'form', label: 'Recent Form', count: null },
+  {
+    id: 'common',
+    label: 'Common Opponents',
+    count: preview.value ? preview.value.common_opponents.length : null,
+  },
+  {
+    id: 'h2h',
+    label: 'Head-to-Head',
+    count: preview.value ? preview.value.head_to_head.length : null,
+  },
+]);
+
+// ─── Head-to-head summary stats ───────────────────────────────────────────────
+
+const h2hStats = computed(() => {
+  if (!preview.value) return { homeWins: 0, awayWins: 0, draws: 0 };
+  return preview.value.head_to_head.reduce(
+    (acc, m) => {
+      if (m.home_score === null || m.away_score === null) return acc;
+      const homeIsOurHome = m.home_team_id === props.homeTeamId;
+      const homeScore = homeIsOurHome ? m.home_score : m.away_score;
+      const awayScore = homeIsOurHome ? m.away_score : m.home_score;
+      if (homeScore > awayScore) acc.homeWins++;
+      else if (homeScore < awayScore) acc.awayWins++;
+      else acc.draws++;
+      return acc;
+    },
+    { homeWins: 0, awayWins: 0, draws: 0 }
+  );
+});
+
+// ─── Data fetching ───────────────────────────────────────────────────────────
+
+async function fetchPreview() {
+  loading.value = true;
+  error.value = null;
+  try {
+    const params = new URLSearchParams();
+    if (props.seasonId) params.set('season_id', props.seasonId);
+    if (props.ageGroupId) params.set('age_group_id', props.ageGroupId);
+    params.set('recent_count', props.recentCount);
+
+    const url = `${getApiBaseUrl()}/api/matches/preview/${props.homeTeamId}/${props.awayTeamId}?${params}`;
+    preview.value = await authStore.apiRequest(url);
+  } catch (err) {
+    error.value = err.message || 'Failed to load match preview';
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Refetch when key props change
+watch(
+  () => [props.homeTeamId, props.awayTeamId, props.seasonId, props.ageGroupId],
+  () => fetchPreview(),
+  { immediate: false }
+);
+
+onMounted(fetchPreview);
+</script>

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -394,12 +394,12 @@ const tabs = computed(() => [
   {
     id: 'common',
     label: 'Common Opponents',
-    count: preview.value ? preview.value.common_opponents.length : null,
+    count: preview.value ? (preview.value.common_opponents?.length ?? 0) : null,
   },
   {
     id: 'h2h',
     label: 'Head-to-Head',
-    count: preview.value ? preview.value.head_to_head.length : null,
+    count: preview.value ? (preview.value.head_to_head?.length ?? 0) : null,
   },
 ]);
 
@@ -434,7 +434,22 @@ async function fetchPreview() {
     params.set('recent_count', props.recentCount);
 
     const url = `${getApiBaseUrl()}/api/matches/preview/${props.homeTeamId}/${props.awayTeamId}?${params}`;
-    preview.value = await authStore.apiRequest(url);
+    const data = await authStore.apiRequest(url);
+    // Normalize to guarantee expected arrays are always present
+    preview.value = {
+      home_team_id: data?.home_team_id ?? props.homeTeamId,
+      away_team_id: data?.away_team_id ?? props.awayTeamId,
+      home_team_recent: Array.isArray(data?.home_team_recent)
+        ? data.home_team_recent
+        : [],
+      away_team_recent: Array.isArray(data?.away_team_recent)
+        ? data.away_team_recent
+        : [],
+      common_opponents: Array.isArray(data?.common_opponents)
+        ? data.common_opponents
+        : [],
+      head_to_head: Array.isArray(data?.head_to_head) ? data.head_to_head : [],
+    };
   } catch (err) {
     error.value = err.message || 'Failed to load match preview';
   } finally {

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -514,6 +514,8 @@
                   v-for="(match, index) in homegrownMatches"
                   :key="`homegrown-${match.id}`"
                   :class="{ 'bg-gray-100': index % 2 === 0 }"
+                  class="cursor-pointer hover:bg-blue-50"
+                  @click="viewMatch(match)"
                 >
                   <td class="border-b text-center">{{ match.match_date }}</td>
                   <td class="border-b text-center text-sm text-gray-600">
@@ -679,7 +681,7 @@
                     </button>
                     <button
                       v-if="canEditGame(match)"
-                      @click="editMatch(match)"
+                      @click.stop="editMatch(match)"
                       class="text-blue-600 hover:text-blue-800 text-sm font-medium"
                     >
                       Edit
@@ -700,6 +702,8 @@
                   v-for="(match, index) in academyMatches"
                   :key="`academy-${match.id}`"
                   :class="{ 'bg-gray-100': index % 2 === 0 }"
+                  class="cursor-pointer hover:bg-blue-50"
+                  @click="viewMatch(match)"
                 >
                   <td class="border-b text-center">{{ match.match_date }}</td>
                   <td class="border-b text-center text-sm text-gray-600">
@@ -865,7 +869,7 @@
                     </button>
                     <button
                       v-if="canEditGame(match)"
-                      @click="editMatch(match)"
+                      @click.stop="editMatch(match)"
                       class="text-blue-600 hover:text-blue-800 text-sm font-medium"
                     >
                       Edit
@@ -886,6 +890,8 @@
                   v-for="(match, index) in otherMatches"
                   :key="`other-${match.id}`"
                   :class="{ 'bg-gray-100': index % 2 === 0 }"
+                  class="cursor-pointer hover:bg-blue-50"
+                  @click="viewMatch(match)"
                 >
                   <td class="border-b text-center">{{ match.match_date }}</td>
                   <td class="border-b text-center text-sm text-gray-600">
@@ -1051,7 +1057,7 @@
                     </button>
                     <button
                       v-if="canEditGame(match)"
-                      @click="editMatch(match)"
+                      @click.stop="editMatch(match)"
                       class="text-blue-600 hover:text-blue-800 text-sm font-medium"
                     >
                       Edit
@@ -1066,6 +1072,8 @@
                 v-for="(match, index) in sortedGames"
                 :key="match.id"
                 :class="{ 'bg-gray-100': index % 2 === 0 }"
+                class="cursor-pointer hover:bg-blue-50"
+                @click="viewMatch(match)"
               >
                 <td
                   v-if="selectedViewTab === 'myclub'"
@@ -1211,7 +1219,7 @@
                   </button>
                   <button
                     v-if="canEditGame(match)"
-                    @click="editMatch(match)"
+                    @click.stop="editMatch(match)"
                     class="text-blue-600 hover:text-blue-800 text-sm font-medium"
                   >
                     Edit
@@ -1235,7 +1243,8 @@
               <div
                 v-for="(match, index) in homegrownMatches"
                 :key="`homegrown-${match.id}`"
-                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm cursor-pointer hover:border-blue-300"
+                @click="viewMatch(match)"
               >
                 <!-- Match Number and Date -->
                 <div
@@ -1415,7 +1424,7 @@
                   </button>
                   <button
                     v-if="canEditGame(match)"
-                    @click="editMatch(match)"
+                    @click.stop="editMatch(match)"
                     class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
                     Edit Match
@@ -1433,7 +1442,8 @@
               <div
                 v-for="(match, index) in academyMatches"
                 :key="`academy-${match.id}`"
-                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm cursor-pointer hover:border-blue-300"
+                @click="viewMatch(match)"
               >
                 <!-- Match Number and Date -->
                 <div
@@ -1613,7 +1623,7 @@
                   </button>
                   <button
                     v-if="canEditGame(match)"
-                    @click="editMatch(match)"
+                    @click.stop="editMatch(match)"
                     class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
                     Edit Match
@@ -1631,7 +1641,8 @@
               <div
                 v-for="(match, index) in otherMatches"
                 :key="`other-${match.id}`"
-                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+                class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm cursor-pointer hover:border-blue-300"
+                @click="viewMatch(match)"
               >
                 <!-- Match Number and Date -->
                 <div
@@ -1811,7 +1822,7 @@
                   </button>
                   <button
                     v-if="canEditGame(match)"
-                    @click="editMatch(match)"
+                    @click.stop="editMatch(match)"
                     class="w-full bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700"
                   >
                     Edit Match
@@ -1825,7 +1836,8 @@
               v-else
               v-for="(match, index) in sortedGames"
               :key="match.id"
-              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm cursor-pointer hover:border-blue-300"
+              @click="viewMatch(match)"
             >
               <!-- Match Number and Date -->
               <div
@@ -1966,7 +1978,7 @@
                   </button>
                   <button
                     v-if="canEditGame(match)"
-                    @click="editMatch(match)"
+                    @click.stop="editMatch(match)"
                     class="text-blue-600 font-medium text-sm active:text-blue-800"
                   >
                     Edit


### PR DESCRIPTION
## Summary

- **Backend**: New `get_match_preview()` DAO method and `GET /api/matches/preview/{home_team_id}/{away_team_id}` endpoint
- **Frontend**: New `MatchPreview.vue` component with three tabs
- **Head-to-head** spans all seasons; **recent form** and **common opponents** are scoped to the provided `season_id`

## What's included

### API endpoint
`GET /api/matches/preview/{home_team_id}/{away_team_id}`

Query params:
| Param | Description |
|---|---|
| `season_id` | Season for recent form + common opponents (omit for all seasons) |
| `age_group_id` | Optional age-group filter |
| `recent_count` | Recent matches per team (1–20, default 5) |

Response shape:
```json
{
  "home_team_id": 1,
  "away_team_id": 2,
  "home_team_recent": [...],
  "away_team_recent": [...],
  "common_opponents": [
    {
      "opponent_id": 3,
      "opponent_name": "Boston Bolts",
      "home_team_matches": [...],
      "away_team_matches": [...]
    }
  ],
  "head_to_head": [...]
}
```

### Frontend component `MatchPreview.vue`

**Recent Form tab** — side-by-side last N completed matches for each team, each showing W/L/D chip, score, opponent, date.

**Common Opponents tab** — lists every team both sides have played this season (e.g. IFA and NEFC both played Boston Bolts). For each shared opponent the component shows both teams' results against them side-by-side.

**Head-to-Head tab** — all-time meetings between the two teams across seasons, with a W/D/L summary banner at the top.

### Usage
```vue
<MatchPreview
  :homeTeamId="1"
  homeTeamName="IFA"
  :awayTeamId="2"
  awayTeamName="NEFC"
  :seasonId="5"
  :ageGroupId="3"
  :recentCount="5"
/>
```

## Test plan
- [ ] Import `MatchPreview` in a view (e.g. `MatchDetailView`) and verify all three tabs render
- [ ] Confirm Boston Bolts appears under Common Opponents when both IFA and NEFC have played them in the season
- [ ] Confirm head-to-head shows matches from previous seasons
- [ ] Verify loading / error / empty states render correctly
- [ ] Check with `age_group_id` filter to confirm cross-age-group matches are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)