### PR TITLE
fix: Paginate match-summary query to bypass Supabase 1000-row limit

### DIFF
--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -481,22 +481,32 @@ class MatchDAO(BaseDAO):
             return []
         season_id = season_resp.data[0]["id"]
 
-        # Fetch all non-cancelled matches for this season with joins
-        response = (
-            self.client.table("matches")
-            .select("""
-                match_date, match_status, home_score, away_score, scheduled_kickoff,
-                age_group:age_groups(name),
-                division:divisions(name, league_id, leagues:leagues!divisions_league_id_fkey(name))
-            """)
-            .eq("season_id", season_id)
-            .neq("match_status", "cancelled")
-            .execute()
-        )
+        # Fetch all non-cancelled matches for this season with joins.
+        # Supabase defaults to 1000 rows — paginate to get the full season.
+        _page_size = 1000
+        _offset = 0
+        all_matches: list[dict] = []
+        while True:
+            response = (
+                self.client.table("matches")
+                .select("""
+                    match_date, match_status, home_score, away_score, scheduled_kickoff,
+                    age_group:age_groups(name),
+                    division:divisions(name, league_id, leagues:leagues!divisions_league_id_fkey(name))
+                """)
+                .eq("season_id", season_id)
+                .neq("match_status", "cancelled")
+                .range(_offset, _offset + _page_size - 1)
+                .execute()
+            )
+            all_matches.extend(response.data)
+            if len(response.data) < _page_size:
+                break
+            _offset += _page_size
 
         # Group by (age_group, league, division)
         groups = defaultdict(list)
-        for m in response.data:
+        for m in all_matches:
             ag = m["age_group"]["name"] if m.get("age_group") else "Unknown"
             div_name = m["division"]["name"] if m.get("division") else "Unknown"
             league_name = (

--- a/backend/tests/unit/test_match_summary.py
+++ b/backend/tests/unit/test_match_summary.py
@@ -66,6 +66,7 @@ class TestGetMatchSummary:
                 mock.select.return_value = mock
                 mock.eq.return_value = mock
                 mock.neq.return_value = mock
+                mock.range.return_value = mock
                 mock.execute.return_value = MagicMock(data=matches_data)
             return mock
 
@@ -123,6 +124,7 @@ class TestGetMatchSummary:
                 mock.select.return_value = mock
                 mock.eq.return_value = mock
                 mock.neq.return_value = mock
+                mock.range.return_value = mock
                 mock.execute.return_value = MagicMock(data=matches_data)
             return mock
 
@@ -130,6 +132,78 @@ class TestGetMatchSummary:
 
         result = dao.get_match_summary("2025-26")
         assert result[0]["needs_score"] == 2  # Only past matches count
+
+    def test_paginates_beyond_1000_rows(self):
+        """Regression test: query must paginate past Supabase's 1000-row default limit."""
+        dao = self._make_dao()
+
+        # Simulate two pages: first returns 1000 rows (all U14), second returns 2 rows (U16)
+        page1 = [
+            {
+                "match_date": "2026-03-01",
+                "match_status": "completed",
+                "home_score": 1,
+                "away_score": 0,
+                "scheduled_kickoff": None,
+                "age_group": {"name": "U14"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            }
+        ] * 1000
+        page2 = [
+            {
+                "match_date": "2026-04-11",
+                "match_status": "scheduled",
+                "home_score": None,
+                "away_score": None,
+                "scheduled_kickoff": None,
+                "age_group": {"name": "U16"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+            {
+                "match_date": "2026-04-12",
+                "match_status": "scheduled",
+                "home_score": None,
+                "away_score": None,
+                "scheduled_kickoff": None,
+                "age_group": {"name": "U16"},
+                "division": {"name": "Northeast", "league_id": 1, "leagues": {"name": "Homegrown"}},
+            },
+        ]
+
+        call_count = 0
+
+        def table_side_effect(name):
+            nonlocal call_count
+            mock = MagicMock()
+            if name == "seasons":
+                mock.select.return_value = mock
+                mock.eq.return_value = mock
+                mock.limit.return_value = mock
+                mock.execute.return_value = MagicMock(data=[{"id": 1}])
+            elif name == "matches":
+                mock.select.return_value = mock
+                mock.eq.return_value = mock
+                mock.neq.return_value = mock
+                mock.range.return_value = mock
+
+                def execute_side_effect():
+                    nonlocal call_count
+                    call_count += 1
+                    return MagicMock(data=page1 if call_count == 1 else page2)
+
+                mock.execute.side_effect = execute_side_effect
+            return mock
+
+        dao.client.table = table_side_effect
+
+        result = dao.get_match_summary("2025-2026")
+
+        assert call_count == 2, "Expected exactly two paginated fetches"
+        groups = {r["age_group"]: r for r in result}
+        assert "U14" in groups
+        assert "U16" in groups, "U16 matches from page 2 must appear in the summary"
+        assert groups["U16"]["total"] == 2
+        assert groups["U16"]["needs_score"] == 2  # Both are past unscored matches
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- **Root cause:** `get_match_summary` in `match_dao.py` fetched all season matches in a single unpaginated Supabase query. Supabase silently caps these at 1000 rows.
- **Impact:** The 2025-2026 season hit exactly 1000 rows, causing all U16 spring 2026 matches to be invisible to the scraper planner. The planner saw `needs_score=0` for U16 Homegrown Northeast and skipped it every run — leaving last weekend's scores unsubmitted.
- **Fix:** Loop with `.range(offset, offset + 999)` until a page returns fewer than 1000 rows, accumulating all matches before computing the summary.
- **Test:** Added `test_paginates_beyond_1000_rows` — simulates a full 1000-row first page (U14) and a 2-row second page (U16), asserts both groups appear in the result with correct `needs_score`.

## Test plan
- [x] All 6 unit tests in `test_match_summary.py` pass
- [ ] Deploy to prod and verify `/api/agent/match-summary` returns `total > 12` for U16 Homegrown Northeast with correct `needs_score`
- [ ] Confirm scraper planner picks up U16 on next scheduled run after deploy

🤖 Generated with [Claude Code](https://claude.ai/claude-code)