### PR TITLE
feat: Match detail UX improvements

### DIFF
--- a/frontend/src/__tests__/components/MatchDetailView.spec.js
+++ b/frontend/src/__tests__/components/MatchDetailView.spec.js
@@ -417,7 +417,7 @@ describe('MatchDetailView', () => {
       expect(wrapper.find('[data-testid="share-button"]').exists()).toBe(true);
     });
 
-    it('shows "Copy to Clipboard" text initially', async () => {
+    it('shows "Copy Scoreboard" text initially', async () => {
       mockAuthStore.apiRequest = vi.fn(() =>
         Promise.resolve(createMockMatch())
       );
@@ -425,7 +425,7 @@ describe('MatchDetailView', () => {
       await flushPromises();
 
       expect(wrapper.find('[data-testid="share-button"]').text()).toContain(
-        'Copy to Clipboard'
+        'Copy Scoreboard'
       );
     });
   });
@@ -540,7 +540,7 @@ describe('MatchDetailView', () => {
       );
     });
 
-    it('toggle button expands lineup content', async () => {
+    it('lineup section is open by default and loads rosters automatically', async () => {
       mockAuthStore.apiRequest = vi.fn(url => {
         if (url.includes('/roster')) return Promise.resolve({ roster: [] });
         if (url.includes('/lineup')) return Promise.resolve(null);
@@ -549,18 +549,17 @@ describe('MatchDetailView', () => {
       const wrapper = mountMatchDetailView();
       await flushPromises();
 
-      // Lineup content should not be visible initially
-      expect(wrapper.find('[data-testid="lineup-tab-home"]').exists()).toBe(
-        false
+      // Lineup section open by default; rosters auto-load → no-roster message visible
+      expect(wrapper.find('[data-testid="no-roster-message"]').exists()).toBe(
+        true
       );
 
-      // Click toggle
+      // Clicking the toggle collapses the section
       await wrapper.find('[data-testid="lineup-toggle"]').trigger('click');
       await flushPromises();
 
-      // After expanding and loading, should show no-roster message (empty rosters)
       expect(wrapper.find('[data-testid="no-roster-message"]').exists()).toBe(
-        true
+        false
       );
     });
   });

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -985,6 +985,21 @@ export default {
     const lineupDataLoading = ref(false);
     const savingLineup = ref(false);
 
+    // Auto-load rosters once canManageLineup is known and section is open
+    watch(canManageLineup, async canManage => {
+      if (canManage && showLineupSection.value && !rostersLoaded.value) {
+        lineupDataLoading.value = true;
+        try {
+          await Promise.all([fetchTeamRosters(), fetchLineups()]);
+          rostersLoaded.value = true;
+        } catch (err) {
+          console.error('Failed to load lineups and rosters:', err);
+        } finally {
+          lineupDataLoading.value = false;
+        }
+      }
+    });
+
     // Toggle lineup section and lazy-load rosters/lineups
     const toggleLineupSection = async () => {
       showLineupSection.value = !showLineupSection.value;

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -59,492 +59,594 @@
     </div>
 
     <!-- Match content -->
-    <div v-else-if="match" class="max-w-sm mx-auto" data-testid="match-content">
-      <!-- Capture container for share -->
+    <div v-else-if="match" class="max-w-5xl" data-testid="match-content">
       <div
-        ref="scoreboardRef"
-        class="bg-slate-800 rounded-lg p-2"
-        data-testid="scoreboard"
+        class="flex flex-col md:grid md:grid-cols-[2fr_3fr] md:gap-6 md:items-start"
       >
-        <!-- Stadium Scoreboard -->
-        <div
-          class="scoreboard bg-gradient-to-r from-slate-800 via-slate-700 to-slate-800 rounded-lg p-3 mb-2"
-        >
-          <!-- LIVE indicator -->
-          <div
-            v-if="match.match_status === 'live'"
-            class="flex justify-center mb-3"
-          >
-            <div
-              class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-red-600 text-white font-bold uppercase tracking-wider text-xs animate-pulse shadow-[0_0_15px_rgba(220,38,38,0.7)]"
-              data-testid="status-badge"
-            >
-              <span
-                class="w-1.5 h-1.5 rounded-full bg-white animate-ping"
-              ></span>
-              LIVE
-            </div>
-          </div>
-
-          <!-- Status badge for non-live matches -->
-          <div v-else class="flex justify-center mb-3">
-            <div
-              class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider"
-              :class="statusBadgeClass"
-              data-testid="status-badge"
-            >
-              {{ match.match_status || 'scheduled' }}
-            </div>
-          </div>
-
-          <!-- Teams and Score -->
-          <div class="flex flex-row items-start justify-center gap-4 lg:gap-8">
-            <!-- Home Team -->
-            <div class="flex flex-col items-center text-center flex-1 min-w-0">
-              <!-- Club Logo -->
+        <!-- Left column: scoreboard + share -->
+        <div>
+          <!-- Capture container for share -->
+          <div class="bg-slate-800 rounded-lg overflow-hidden">
+            <div ref="scoreboardRef" class="p-2" data-testid="scoreboard">
+              <!-- Stadium Scoreboard -->
               <div
-                class="w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white/10 backdrop-blur-sm overflow-hidden mb-2 border border-slate-500 flex-shrink-0"
-                :style="{ boxShadow: `0 0 20px ${homeTeamColor}40` }"
+                class="scoreboard bg-gradient-to-r from-slate-800 via-slate-700 to-slate-800 rounded-lg p-3 mb-2"
               >
-                <img
-                  v-if="match.home_team_club?.logo_url"
-                  :src="match.home_team_club.logo_url"
-                  :alt="`${match.home_team_name} logo`"
-                  class="w-12 h-12 lg:w-14 lg:h-14 object-contain"
-                />
-                <div v-else class="text-lg lg:text-xl font-bold text-slate-400">
-                  {{ getTeamInitials(match.home_team_name) }}
+                <!-- LIVE indicator -->
+                <div
+                  v-if="match.match_status === 'live'"
+                  class="flex justify-center mb-3"
+                >
+                  <div
+                    class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-red-600 text-white font-bold uppercase tracking-wider text-xs animate-pulse shadow-[0_0_15px_rgba(220,38,38,0.7)]"
+                    data-testid="status-badge"
+                  >
+                    <span
+                      class="w-1.5 h-1.5 rounded-full bg-white animate-ping"
+                    ></span>
+                    LIVE
+                  </div>
+                </div>
+
+                <!-- Status badge for non-live matches -->
+                <div v-else class="flex justify-center mb-3">
+                  <div
+                    class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider"
+                    :class="statusBadgeClass"
+                    data-testid="status-badge"
+                  >
+                    {{ match.match_status || 'scheduled' }}
+                  </div>
+                </div>
+
+                <!-- Countdown to kickoff -->
+                <div
+                  v-if="
+                    (match.match_status === 'scheduled' ||
+                      match.match_status === 'tbd') &&
+                    match.scheduled_kickoff &&
+                    !countdown.expired
+                  "
+                  class="flex justify-center gap-4 mb-3"
+                  data-testid="countdown"
+                >
+                  <div v-if="countdown.days > 0" class="text-center">
+                    <span class="text-2xl font-bold text-white block">{{
+                      countdown.days
+                    }}</span>
+                    <span
+                      class="text-[10px] text-slate-400 uppercase tracking-wider"
+                      >days</span
+                    >
+                  </div>
+                  <div class="text-center">
+                    <span class="text-2xl font-bold text-white block">{{
+                      String(countdown.hours).padStart(2, '0')
+                    }}</span>
+                    <span
+                      class="text-[10px] text-slate-400 uppercase tracking-wider"
+                      >hrs</span
+                    >
+                  </div>
+                  <div class="text-center">
+                    <span class="text-2xl font-bold text-white block">{{
+                      String(countdown.minutes).padStart(2, '0')
+                    }}</span>
+                    <span
+                      class="text-[10px] text-slate-400 uppercase tracking-wider"
+                      >min</span
+                    >
+                  </div>
+                </div>
+
+                <!-- Teams and Score -->
+                <div
+                  class="flex flex-row items-start justify-center gap-4 lg:gap-8"
+                >
+                  <!-- Home Team -->
+                  <div
+                    class="flex flex-col items-center text-center flex-1 min-w-0"
+                  >
+                    <!-- Club Logo -->
+                    <div
+                      class="w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white/10 backdrop-blur-sm overflow-hidden mb-2 border border-slate-500 flex-shrink-0"
+                      :style="{ boxShadow: `0 0 20px ${homeTeamColor}40` }"
+                    >
+                      <img
+                        v-if="match.home_team_club?.logo_url"
+                        :src="match.home_team_club.logo_url"
+                        :alt="`${match.home_team_name} logo`"
+                        class="w-12 h-12 lg:w-14 lg:h-14 object-contain"
+                      />
+                      <div
+                        v-else
+                        class="text-lg lg:text-xl font-bold text-slate-400"
+                      >
+                        {{ getTeamInitials(match.home_team_name) }}
+                      </div>
+                    </div>
+                    <h2
+                      class="text-sm font-bold text-white mb-0.5 line-clamp-2"
+                    >
+                      {{ match.home_team_name }}
+                    </h2>
+                    <span
+                      class="text-[10px] text-slate-400 uppercase tracking-wider"
+                      >Home</span
+                    >
+                  </div>
+
+                  <!-- Score Display -->
+                  <div class="flex items-center gap-2 lg:gap-3 pt-4 lg:pt-5">
+                    <span
+                      class="score-number text-3xl lg:text-5xl font-bold text-white"
+                      data-testid="home-score"
+                    >
+                      {{ match.home_score ?? '-' }}
+                    </span>
+                    <span class="text-xl lg:text-2xl font-light text-slate-500"
+                      >-</span
+                    >
+                    <span
+                      class="score-number text-3xl lg:text-5xl font-bold text-white"
+                      data-testid="away-score"
+                    >
+                      {{ match.away_score ?? '-' }}
+                    </span>
+                  </div>
+
+                  <!-- Away Team -->
+                  <div
+                    class="flex flex-col items-center text-center flex-1 min-w-0"
+                  >
+                    <!-- Club Logo -->
+                    <div
+                      class="w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white/10 backdrop-blur-sm overflow-hidden mb-2 border border-slate-500 flex-shrink-0"
+                      :style="{ boxShadow: `0 0 20px ${awayTeamColor}40` }"
+                    >
+                      <img
+                        v-if="match.away_team_club?.logo_url"
+                        :src="match.away_team_club.logo_url"
+                        :alt="`${match.away_team_name} logo`"
+                        class="w-12 h-12 lg:w-14 lg:h-14 object-contain"
+                      />
+                      <div
+                        v-else
+                        class="text-lg lg:text-xl font-bold text-slate-400"
+                      >
+                        {{ getTeamInitials(match.away_team_name) }}
+                      </div>
+                    </div>
+                    <h2
+                      class="text-sm font-bold text-white mb-0.5 line-clamp-2"
+                    >
+                      {{ match.away_team_name }}
+                    </h2>
+                    <span
+                      class="text-[10px] text-slate-400 uppercase tracking-wider"
+                      >Away</span
+                    >
+                  </div>
+                </div>
+
+                <!-- Goal Scorers -->
+                <div
+                  v-if="homeGoals.length || awayGoals.length"
+                  class="flex justify-center gap-4 mt-3 pt-3 border-t border-slate-600"
+                >
+                  <div class="flex-1 text-right max-w-[140px]">
+                    <div
+                      v-for="goal in homeGoals"
+                      :key="goal.id"
+                      class="text-xs text-slate-300 mb-1"
+                    >
+                      {{ goal.player_name }} {{ formatMinute(goal) }}
+                    </div>
+                  </div>
+                  <div class="w-px bg-slate-600 flex-shrink-0"></div>
+                  <div class="flex-1 text-left max-w-[140px]">
+                    <div
+                      v-for="goal in awayGoals"
+                      :key="goal.id"
+                      class="text-xs text-slate-300 mb-1"
+                    >
+                      {{ goal.player_name }} {{ formatMinute(goal) }}
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Cards -->
+                <div
+                  v-if="homeCards.length || awayCards.length"
+                  class="flex justify-center gap-4 mt-2 pt-2 border-t border-slate-700"
+                >
+                  <div class="flex-1 text-right max-w-[140px]">
+                    <div
+                      v-for="card in homeCards"
+                      :key="card.id"
+                      class="text-xs text-slate-300 mb-1"
+                    >
+                      {{ card.player_name }}
+                      <svg
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle mx-0.5"
+                      >
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          :fill="
+                            card.event_type === 'red_card'
+                              ? '#EA3323'
+                              : '#FBBF24'
+                          "
+                        />
+                      </svg>
+                      {{ formatMinute(card) }}
+                    </div>
+                  </div>
+                  <div class="w-px bg-slate-600 flex-shrink-0"></div>
+                  <div class="flex-1 text-left max-w-[140px]">
+                    <div
+                      v-for="card in awayCards"
+                      :key="card.id"
+                      class="text-xs text-slate-300 mb-1"
+                    >
+                      {{ card.player_name }}
+                      <svg
+                        width="10"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        class="inline-block align-middle mx-0.5"
+                      >
+                        <rect
+                          x="4"
+                          width="16"
+                          height="24"
+                          rx="2"
+                          :fill="
+                            card.event_type === 'red_card'
+                              ? '#EA3323'
+                              : '#FBBF24'
+                          "
+                        />
+                      </svg>
+                      {{ formatMinute(card) }}
+                    </div>
+                  </div>
                 </div>
               </div>
-              <h2 class="text-sm lg:text-base font-bold text-white mb-0.5">
-                {{ match.home_team_name }}
-              </h2>
-              <span class="text-[10px] text-slate-400 uppercase tracking-wider"
-                >Home</span
-              >
-            </div>
 
-            <!-- Score Display -->
-            <div class="flex items-center gap-2 lg:gap-3 pt-4 lg:pt-5">
-              <span
-                class="score-number text-3xl lg:text-5xl font-bold text-white"
-                data-testid="home-score"
-              >
-                {{ match.home_score ?? '-' }}
-              </span>
-              <span class="text-xl lg:text-2xl font-light text-slate-500"
-                >-</span
-              >
-              <span
-                class="score-number text-3xl lg:text-5xl font-bold text-white"
-                data-testid="away-score"
-              >
-                {{ match.away_score ?? '-' }}
-              </span>
-            </div>
-
-            <!-- Away Team -->
-            <div class="flex flex-col items-center text-center flex-1 min-w-0">
-              <!-- Club Logo -->
-              <div
-                class="w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white/10 backdrop-blur-sm overflow-hidden mb-2 border border-slate-500 flex-shrink-0"
-                :style="{ boxShadow: `0 0 20px ${awayTeamColor}40` }"
-              >
-                <img
-                  v-if="match.away_team_club?.logo_url"
-                  :src="match.away_team_club.logo_url"
-                  :alt="`${match.away_team_name} logo`"
-                  class="w-12 h-12 lg:w-14 lg:h-14 object-contain"
-                />
-                <div v-else class="text-lg lg:text-xl font-bold text-slate-400">
-                  {{ getTeamInitials(match.away_team_name) }}
+              <!-- Match Details Card -->
+              <div class="bg-slate-700/50 rounded-lg p-3">
+                <h3 class="text-sm font-semibold text-white mb-3">
+                  Match Details
+                </h3>
+                <div class="grid grid-cols-2 lg:grid-cols-3 gap-2">
+                  <div class="detail-item">
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Date</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      formatDate(match.match_date)
+                    }}</span>
+                  </div>
+                  <div
+                    v-if="formatLocalTime(match.scheduled_kickoff)"
+                    class="detail-item"
+                  >
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Kickoff</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      formatLocalTime(match.scheduled_kickoff)
+                    }}</span>
+                  </div>
+                  <div class="detail-item">
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Type</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      match.match_type_name || 'League'
+                    }}</span>
+                  </div>
+                  <div class="detail-item">
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Season</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      match.season_name
+                    }}</span>
+                  </div>
+                  <div class="detail-item">
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Age Group</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      match.age_group_name
+                    }}</span>
+                  </div>
+                  <div
+                    v-if="
+                      match.division_name &&
+                      match.match_type_name !== 'Friendly'
+                    "
+                    class="detail-item"
+                  >
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Division</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      match.division_name
+                    }}</span>
+                  </div>
+                  <div v-if="leagueName" class="detail-item">
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >League</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      leagueName
+                    }}</span>
+                  </div>
                 </div>
               </div>
-              <h2 class="text-sm lg:text-base font-bold text-white mb-0.5">
-                {{ match.away_team_name }}
-              </h2>
-              <span class="text-[10px] text-slate-400 uppercase tracking-wider"
-                >Away</span
-              >
             </div>
-          </div>
+            <!-- End inner capture area -->
 
-          <!-- Goal Scorers -->
-          <div
-            v-if="homeGoals.length || awayGoals.length"
-            class="flex justify-center gap-4 mt-3 pt-3 border-t border-slate-600"
-          >
-            <div class="flex-1 text-right max-w-[140px]">
-              <div
-                v-for="goal in homeGoals"
-                :key="goal.id"
-                class="text-xs text-slate-300 mb-1"
+            <!-- Copy button footer inside wrapper card -->
+            <div
+              class="px-3 pb-2 pt-2 border-t border-slate-700 flex justify-end"
+            >
+              <button
+                @click="shareScoreboard"
+                :disabled="shareStatus === 'copying'"
+                data-testid="share-button"
+                class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors"
+                :class="{
+                  'bg-green-600 text-white': shareStatus === 'success',
+                  'bg-red-600 text-white': shareStatus === 'error',
+                  'bg-gray-200 text-gray-700 hover:bg-gray-300':
+                    !shareStatus || shareStatus === 'copying',
+                }"
               >
-                {{ goal.player_name }} {{ formatMinute(goal) }}
-              </div>
-            </div>
-            <div class="w-px bg-slate-600 flex-shrink-0"></div>
-            <div class="flex-1 text-left max-w-[140px]">
-              <div
-                v-for="goal in awayGoals"
-                :key="goal.id"
-                class="text-xs text-slate-300 mb-1"
-              >
-                {{ goal.player_name }} {{ formatMinute(goal) }}
-              </div>
-            </div>
-          </div>
-
-          <!-- Cards -->
-          <div
-            v-if="homeCards.length || awayCards.length"
-            class="flex justify-center gap-4 mt-2 pt-2 border-t border-slate-700"
-          >
-            <div class="flex-1 text-right max-w-[140px]">
-              <div
-                v-for="card in homeCards"
-                :key="card.id"
-                class="text-xs text-slate-300 mb-1"
-              >
-                {{ card.player_name }}
+                <!-- Copy icon -->
                 <svg
-                  width="10"
-                  height="14"
+                  v-if="!shareStatus"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
                   viewBox="0 0 24 24"
-                  class="inline-block align-middle mx-0.5"
+                  stroke="currentColor"
+                  class="w-3.5 h-3.5"
                 >
-                  <rect
-                    x="4"
-                    width="16"
-                    height="24"
-                    rx="2"
-                    :fill="
-                      card.event_type === 'red_card' ? '#EA3323' : '#FBBF24'
-                    "
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
                   />
                 </svg>
-                {{ formatMinute(card) }}
-              </div>
-            </div>
-            <div class="w-px bg-slate-600 flex-shrink-0"></div>
-            <div class="flex-1 text-left max-w-[140px]">
-              <div
-                v-for="card in awayCards"
-                :key="card.id"
-                class="text-xs text-slate-300 mb-1"
-              >
-                {{ card.player_name }}
+                <!-- Loading spinner -->
                 <svg
-                  width="10"
-                  height="14"
+                  v-else-if="shareStatus === 'copying'"
+                  class="w-3.5 h-3.5 animate-spin"
+                  fill="none"
                   viewBox="0 0 24 24"
-                  class="inline-block align-middle mx-0.5"
                 >
-                  <rect
-                    x="4"
-                    width="16"
-                    height="24"
-                    rx="2"
-                    :fill="
-                      card.event_type === 'red_card' ? '#EA3323' : '#FBBF24'
-                    "
+                  <circle
+                    class="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                  ></circle>
+                  <path
+                    class="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  ></path>
+                </svg>
+                <!-- Check icon -->
+                <svg
+                  v-else-if="shareStatus === 'success'"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  class="w-3.5 h-3.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M5 13l4 4L19 7"
                   />
                 </svg>
-                {{ formatMinute(card) }}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Match Details Card -->
-        <div class="bg-slate-700/50 rounded-lg p-3">
-          <h3 class="text-sm font-semibold text-white mb-3">Match Details</h3>
-          <div class="grid grid-cols-2 lg:grid-cols-3 gap-2">
-            <div class="detail-item">
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >Date</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                formatDate(match.match_date)
-              }}</span>
-            </div>
-            <div
-              v-if="formatLocalTime(match.scheduled_kickoff)"
-              class="detail-item"
-            >
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >Kickoff</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                formatLocalTime(match.scheduled_kickoff)
-              }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >Type</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                match.match_type_name || 'League'
-              }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >Season</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                match.season_name
-              }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >Age Group</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                match.age_group_name
-              }}</span>
-            </div>
-            <div
-              v-if="match.division_name && match.match_type_name !== 'Friendly'"
-              class="detail-item"
-            >
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >Division</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                match.division_name
-              }}</span>
-            </div>
-            <div v-if="leagueName" class="detail-item">
-              <span class="text-[10px] text-slate-500 uppercase tracking-wider"
-                >League</span
-              >
-              <span class="text-xs font-medium text-white">{{
-                leagueName
-              }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <!-- End capture container -->
-
-      <!-- Share Button (at bottom, not captured in image) -->
-      <div class="flex justify-center mt-3">
-        <button
-          @click="shareScoreboard"
-          :disabled="shareStatus === 'copying'"
-          data-testid="share-button"
-          class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors"
-          :class="{
-            'bg-green-600 text-white': shareStatus === 'success',
-            'bg-red-600 text-white': shareStatus === 'error',
-            'bg-gray-200 text-gray-700 hover:bg-gray-300':
-              !shareStatus || shareStatus === 'copying',
-          }"
-        >
-          <!-- Copy icon -->
-          <svg
-            v-if="!shareStatus"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            class="w-3.5 h-3.5"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-            />
-          </svg>
-          <!-- Loading spinner -->
-          <svg
-            v-else-if="shareStatus === 'copying'"
-            class="w-3.5 h-3.5 animate-spin"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              class="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
-            ></circle>
-            <path
-              class="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            ></path>
-          </svg>
-          <!-- Check icon -->
-          <svg
-            v-else-if="shareStatus === 'success'"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            class="w-3.5 h-3.5"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M5 13l4 4L19 7"
-            />
-          </svg>
-          <!-- Error icon -->
-          <svg
-            v-else-if="shareStatus === 'error'"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            class="w-3.5 h-3.5"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-          <span v-if="!shareStatus">Copy to Clipboard</span>
-          <span v-else-if="shareStatus === 'copying'">Copying...</span>
-          <span v-else-if="shareStatus === 'success'">Copied!</span>
-          <span v-else-if="shareStatus === 'error'">Failed</span>
-        </button>
-      </div>
-
-      <!-- Match Preview (scheduled/tbd matches only) -->
-      <div
-        v-if="
-          match.match_status === 'scheduled' || match.match_status === 'tbd'
-        "
-        class="mt-4"
-        data-testid="match-preview-section"
-      >
-        <MatchPreview
-          :homeTeamId="match.home_team_id"
-          :homeTeamName="match.home_team_name"
-          :awayTeamId="match.away_team_id"
-          :awayTeamName="match.away_team_name"
-          :seasonId="match.season_id"
-          :ageGroupId="match.age_group_id"
-        />
-      </div>
-
-      <!-- Pre-match Lineup Section (scheduled matches, authorized users only) -->
-      <div
-        v-if="canManageLineup && match.match_status === 'scheduled'"
-        class="mt-3"
-        data-testid="lineup-section"
-      >
-        <button
-          @click="toggleLineupSection"
-          data-testid="lineup-toggle"
-          class="w-full flex items-center gap-2 px-3 py-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-semibold rounded-lg transition-colors"
-          :class="{ 'bg-slate-600': showLineupSection }"
-        >
-          <span class="text-base font-bold w-5 text-center">{{
-            showLineupSection ? '-' : '+'
-          }}</span>
-          Starting Lineup
-        </button>
-
-        <div v-if="showLineupSection" class="mt-2 bg-slate-800 rounded-lg p-3">
-          <!-- No roster for either team -->
-          <div
-            v-if="rostersLoaded && !homeRoster.length && !awayRoster.length"
-            class="text-slate-400 text-sm text-center py-4"
-            data-testid="no-roster-message"
-          >
-            No roster available for either team. Add players to a team roster
-            before setting lineups.
-          </div>
-
-          <!-- Loading state -->
-          <div
-            v-else-if="lineupDataLoading"
-            class="text-slate-400 text-sm text-center py-4"
-          >
-            Loading lineups...
-          </div>
-
-          <!-- Team tabs + LineupManager -->
-          <template v-else-if="rostersLoaded">
-            <div class="flex gap-2 mb-3">
-              <button
-                @click="activeLineupTab = 'home'"
-                data-testid="lineup-tab-home"
-                class="flex-1 py-2 px-3 text-sm font-medium rounded-lg border-2 transition-colors truncate"
-                :class="
-                  activeLineupTab === 'home'
-                    ? 'border-blue-500 bg-blue-500/20 text-white'
-                    : 'border-slate-600 text-slate-400 hover:border-slate-500'
-                "
-              >
-                {{ match.home_team_name }}
-              </button>
-              <button
-                @click="activeLineupTab = 'away'"
-                data-testid="lineup-tab-away"
-                class="flex-1 py-2 px-3 text-sm font-medium rounded-lg border-2 transition-colors truncate"
-                :class="
-                  activeLineupTab === 'away'
-                    ? 'border-blue-500 bg-blue-500/20 text-white'
-                    : 'border-slate-600 text-slate-400 hover:border-slate-500'
-                "
-              >
-                {{ match.away_team_name }}
+                <!-- Error icon -->
+                <svg
+                  v-else-if="shareStatus === 'error'"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  class="w-3.5 h-3.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+                <span v-if="!shareStatus">Copy Scoreboard</span>
+                <span v-else-if="shareStatus === 'copying'">Copying...</span>
+                <span v-else-if="shareStatus === 'success'">Copied!</span>
+                <span v-else-if="shareStatus === 'error'">Failed</span>
               </button>
             </div>
-
-            <!-- Home team tab -->
-            <div v-if="activeLineupTab === 'home'">
-              <div
-                v-if="!homeRoster.length"
-                class="text-slate-400 text-sm text-center py-4"
-                data-testid="no-roster-home"
-              >
-                No roster available for {{ match.home_team_name }}.
-              </div>
-              <LineupManager
-                v-else
-                :team-id="match.home_team_id"
-                :team-name="match.home_team_name"
-                :roster="homeRoster"
-                :initial-lineup="homeLineup"
-                :saving="savingLineup"
-                :sport-type="sportType"
-                @save="handleSaveLineup(match.home_team_id, $event)"
-              />
-            </div>
-
-            <!-- Away team tab -->
-            <div v-if="activeLineupTab === 'away'">
-              <div
-                v-if="!awayRoster.length"
-                class="text-slate-400 text-sm text-center py-4"
-                data-testid="no-roster-away"
-              >
-                No roster available for {{ match.away_team_name }}.
-              </div>
-              <LineupManager
-                v-else
-                :team-id="match.away_team_id"
-                :team-name="match.away_team_name"
-                :roster="awayRoster"
-                :initial-lineup="awayLineup"
-                :saving="savingLineup"
-                :sport-type="sportType"
-                @save="handleSaveLineup(match.away_team_id, $event)"
-              />
-            </div>
-          </template>
+          </div>
+          <!-- End capture container wrapper -->
         </div>
+        <!-- End left column -->
+
+        <!-- Right column: preview + lineup (expands to fill available space) -->
+        <div class="mt-4 md:mt-0">
+          <!-- Match Preview (scheduled/tbd matches only) -->
+          <div
+            v-if="
+              match.match_status === 'scheduled' || match.match_status === 'tbd'
+            "
+            data-testid="match-preview-section"
+          >
+            <MatchPreview
+              :homeTeamId="match.home_team_id"
+              :homeTeamName="match.home_team_name"
+              :awayTeamId="match.away_team_id"
+              :awayTeamName="match.away_team_name"
+              :seasonId="match.season_id"
+              :ageGroupId="match.age_group_id"
+            />
+          </div>
+
+          <!-- Pre-match Lineup Section (scheduled matches, authorized users only) -->
+          <div
+            v-if="canManageLineup && match.match_status === 'scheduled'"
+            class="mt-3"
+            data-testid="lineup-section"
+          >
+            <button
+              @click="toggleLineupSection"
+              data-testid="lineup-toggle"
+              class="w-full flex items-center gap-2 px-3 py-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-semibold rounded-lg transition-colors"
+              :class="{ 'bg-slate-600': showLineupSection }"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                class="w-4 h-4 transition-transform flex-shrink-0"
+                :class="{ 'rotate-180': showLineupSection }"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+              Starting Lineup
+            </button>
+
+            <div
+              v-if="showLineupSection"
+              class="mt-2 bg-slate-800 rounded-lg p-3"
+            >
+              <!-- No roster for either team -->
+              <div
+                v-if="rostersLoaded && !homeRoster.length && !awayRoster.length"
+                class="text-slate-400 text-sm text-center py-4"
+                data-testid="no-roster-message"
+              >
+                No roster available for either team. Add players to a team
+                roster before setting lineups.
+              </div>
+
+              <!-- Loading state -->
+              <div
+                v-else-if="lineupDataLoading"
+                class="text-slate-400 text-sm text-center py-4"
+              >
+                Loading lineups...
+              </div>
+
+              <!-- Team tabs + LineupManager -->
+              <template v-else-if="rostersLoaded">
+                <div class="flex gap-2 mb-3">
+                  <button
+                    @click="activeLineupTab = 'home'"
+                    data-testid="lineup-tab-home"
+                    class="flex-1 py-2 px-3 text-sm font-medium rounded-lg border-2 transition-colors truncate"
+                    :class="
+                      activeLineupTab === 'home'
+                        ? 'border-blue-500 bg-blue-500/20 text-white'
+                        : 'border-slate-600 text-slate-400 hover:border-slate-500'
+                    "
+                  >
+                    {{ match.home_team_name }}
+                  </button>
+                  <button
+                    @click="activeLineupTab = 'away'"
+                    data-testid="lineup-tab-away"
+                    class="flex-1 py-2 px-3 text-sm font-medium rounded-lg border-2 transition-colors truncate"
+                    :class="
+                      activeLineupTab === 'away'
+                        ? 'border-blue-500 bg-blue-500/20 text-white'
+                        : 'border-slate-600 text-slate-400 hover:border-slate-500'
+                    "
+                  >
+                    {{ match.away_team_name }}
+                  </button>
+                </div>
+
+                <!-- Home team tab -->
+                <div v-if="activeLineupTab === 'home'">
+                  <div
+                    v-if="!homeRoster.length"
+                    class="text-slate-400 text-sm text-center py-4"
+                    data-testid="no-roster-home"
+                  >
+                    No roster available for {{ match.home_team_name }}.
+                  </div>
+                  <LineupManager
+                    v-else
+                    :team-id="match.home_team_id"
+                    :team-name="match.home_team_name"
+                    :roster="homeRoster"
+                    :initial-lineup="homeLineup"
+                    :saving="savingLineup"
+                    :sport-type="sportType"
+                    @save="handleSaveLineup(match.home_team_id, $event)"
+                  />
+                </div>
+
+                <!-- Away team tab -->
+                <div v-if="activeLineupTab === 'away'">
+                  <div
+                    v-if="!awayRoster.length"
+                    class="text-slate-400 text-sm text-center py-4"
+                    data-testid="no-roster-away"
+                  >
+                    No roster available for {{ match.away_team_name }}.
+                  </div>
+                  <LineupManager
+                    v-else
+                    :team-id="match.away_team_id"
+                    :team-name="match.away_team_name"
+                    :roster="awayRoster"
+                    :initial-lineup="awayLineup"
+                    :saving="savingLineup"
+                    :sport-type="sportType"
+                    @save="handleSaveLineup(match.away_team_id, $event)"
+                  />
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+        <!-- End right column -->
       </div>
+      <!-- End flex row -->
 
       <!-- Post-Match Stats Editor (completed matches, authorized users only) -->
       <PostMatchEditor
@@ -567,7 +669,7 @@
 </template>
 
 <script>
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 import html2canvas from 'html2canvas';
@@ -598,6 +700,27 @@ export default {
     const events = ref([]);
     const scoreboardRef = ref(null);
     const shareStatus = ref(null); // 'copying', 'success', 'error'
+
+    // Countdown timer for upcoming matches
+    const countdown = ref({ days: 0, hours: 0, minutes: 0, expired: false });
+    let countdownTimer = null;
+
+    const updateCountdown = () => {
+      const kickoff = match.value?.scheduled_kickoff;
+      if (!kickoff) return;
+      const diff = new Date(kickoff) - Date.now();
+      if (diff <= 0) {
+        countdown.value = { days: 0, hours: 0, minutes: 0, expired: true };
+        clearInterval(countdownTimer);
+        return;
+      }
+      countdown.value = {
+        days: Math.floor(diff / 86400000),
+        hours: Math.floor((diff % 86400000) / 3600000),
+        minutes: Math.floor((diff % 3600000) / 60000),
+        expired: false,
+      };
+    };
 
     // Get home team primary color for glow effect
     const homeTeamColor = computed(() => {
@@ -769,9 +892,23 @@ export default {
       }
     );
 
+    // Start/stop countdown timer as match loads
+    watch(match, m => {
+      clearInterval(countdownTimer);
+      if (
+        m?.scheduled_kickoff &&
+        (m.match_status === 'scheduled' || m.match_status === 'tbd')
+      ) {
+        updateCountdown();
+        countdownTimer = setInterval(updateCountdown, 30000);
+      }
+    });
+
     onMounted(() => {
       fetchMatch();
     });
+
+    onUnmounted(() => clearInterval(countdownTimer));
 
     // Share scoreboard as image to clipboard
     const shareScoreboard = async () => {
@@ -842,7 +979,7 @@ export default {
     });
 
     // Lineup UI state
-    const showLineupSection = ref(false);
+    const showLineupSection = ref(true);
     const activeLineupTab = ref('home');
     const rostersLoaded = ref(false);
     const lineupDataLoading = ref(false);
@@ -889,6 +1026,7 @@ export default {
       error,
       match,
       events,
+      countdown,
       homeGoals,
       awayGoals,
       homeCards,

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="match-preview">
+  <div class="match-preview bg-slate-800 rounded-lg p-3">
     <!-- Loading -->
     <div
       v-if="loading"
@@ -7,9 +7,9 @@
       data-testid="preview-loading"
     >
       <div
-        class="w-8 h-8 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin mb-3"
+        class="w-8 h-8 border-2 border-slate-500 border-t-blue-400 rounded-full animate-spin mb-3"
       ></div>
-      <p class="text-gray-500 text-sm">Loading match preview...</p>
+      <p class="text-slate-400 text-sm">Loading match preview...</p>
     </div>
 
     <!-- Error -->
@@ -19,11 +19,11 @@
       data-testid="preview-error"
     >
       <div
-        class="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center text-red-500 font-bold mb-3"
+        class="w-10 h-10 rounded-full bg-red-900/50 flex items-center justify-center text-red-400 font-bold mb-3"
       >
         !
       </div>
-      <p class="text-gray-500 text-sm mb-3">{{ error }}</p>
+      <p class="text-slate-400 text-sm mb-3">{{ error }}</p>
       <button
         @click="fetchPreview"
         class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
@@ -35,7 +35,7 @@
     <!-- Content -->
     <div v-else-if="preview" data-testid="preview-content">
       <!-- Tab bar -->
-      <div class="border-b border-gray-200 mb-4">
+      <div class="border-b border-slate-600 mb-4">
         <nav class="flex space-x-1" aria-label="Match preview sections">
           <button
             v-for="tab in tabs"
@@ -45,8 +45,8 @@
             :class="[
               'py-2 px-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap',
               activeTab === tab.id
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+                ? 'border-blue-400 text-blue-400'
+                : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500',
             ]"
           >
             {{ tab.label }}
@@ -55,8 +55,8 @@
               class="ml-1 text-xs px-1.5 py-0.5 rounded-full"
               :class="
                 activeTab === tab.id
-                  ? 'bg-blue-100 text-blue-700'
-                  : 'bg-gray-100 text-gray-500'
+                  ? 'bg-blue-900/50 text-blue-300'
+                  : 'bg-slate-700 text-slate-400'
               "
               >{{ tab.count }}</span
             >
@@ -66,17 +66,43 @@
 
       <!-- ── Recent Form ── -->
       <div v-if="activeTab === 'form'" data-testid="tab-panel-form">
-        <div class="grid grid-cols-2 gap-3">
+        <!-- Both teams empty -->
+        <div
+          v-if="
+            preview.home_team_recent.length === 0 &&
+            preview.away_team_recent.length === 0
+          "
+          class="flex flex-col items-center py-10 text-slate-500"
+          data-testid="form-empty"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="w-10 h-10 mb-3 text-slate-600"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <p class="text-sm">No recent form data available.</p>
+        </div>
+        <!-- At least one team has data -->
+        <div v-else class="grid grid-cols-2 gap-3">
           <!-- Home team column -->
           <div>
             <h3
-              class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2 truncate"
+              class="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2 truncate"
             >
               {{ homeTeamName }}
             </h3>
             <div
               v-if="preview.home_team_recent.length === 0"
-              class="text-xs text-gray-400 italic"
+              class="text-xs text-slate-500 italic"
             >
               No recent matches
             </div>
@@ -93,13 +119,13 @@
           <!-- Away team column -->
           <div>
             <h3
-              class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2 truncate"
+              class="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2 truncate"
             >
               {{ awayTeamName }}
             </h3>
             <div
               v-if="preview.away_team_recent.length === 0"
-              class="text-xs text-gray-400 italic"
+              class="text-xs text-slate-500 italic"
             >
               No recent matches
             </div>
@@ -119,9 +145,24 @@
       <div v-else-if="activeTab === 'common'" data-testid="tab-panel-common">
         <div
           v-if="preview.common_opponents.length === 0"
-          class="text-sm text-gray-500 text-center py-8"
+          class="flex flex-col items-center py-10 text-slate-500"
+          data-testid="common-empty"
         >
-          No common opponents found for this season.
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="w-10 h-10 mb-3 text-slate-600"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+          </svg>
+          <p class="text-sm">No common opponents found this season.</p>
         </div>
         <div
           v-for="opp in preview.common_opponents"
@@ -131,10 +172,10 @@
         >
           <!-- Opponent header -->
           <div
-            class="flex items-center gap-2 mb-2 pb-1 border-b border-gray-100"
+            class="flex items-center gap-2 mb-2 pb-1 border-b border-slate-600"
           >
-            <span class="inline-block w-2 h-2 rounded-full bg-gray-400"></span>
-            <span class="text-sm font-semibold text-gray-800"
+            <span class="inline-block w-2 h-2 rounded-full bg-slate-500"></span>
+            <span class="text-sm font-semibold text-slate-200"
               >vs {{ opp.opponent_name }}</span
             >
           </div>
@@ -142,12 +183,12 @@
           <div class="grid grid-cols-2 gap-3">
             <!-- Home team vs opponent -->
             <div>
-              <p class="text-xs text-gray-400 mb-1 truncate">
+              <p class="text-xs text-slate-400 mb-1 truncate">
                 {{ homeTeamName }}
               </p>
               <div
                 v-if="opp.home_team_matches.length === 0"
-                class="text-xs text-gray-400 italic"
+                class="text-xs text-slate-500 italic"
               >
                 No matches
               </div>
@@ -165,12 +206,12 @@
             </div>
             <!-- Away team vs opponent -->
             <div>
-              <p class="text-xs text-gray-400 mb-1 truncate">
+              <p class="text-xs text-slate-400 mb-1 truncate">
                 {{ awayTeamName }}
               </p>
               <div
                 v-if="opp.away_team_matches.length === 0"
-                class="text-xs text-gray-400 italic"
+                class="text-xs text-slate-500 italic"
               >
                 No matches
               </div>
@@ -194,35 +235,50 @@
       <div v-else-if="activeTab === 'h2h'" data-testid="tab-panel-h2h">
         <div
           v-if="preview.head_to_head.length === 0"
-          class="text-sm text-gray-500 text-center py-8"
+          class="flex flex-col items-center py-10 text-slate-500"
+          data-testid="h2h-empty"
         >
-          No previous meetings found.
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            class="w-10 h-10 mb-3 text-slate-600"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            />
+          </svg>
+          <p class="text-sm">No previous meetings found.</p>
         </div>
 
         <!-- Summary row -->
         <div
           v-if="preview.head_to_head.length > 0"
-          class="flex justify-around text-center mb-4 p-3 bg-gray-50 rounded-lg"
+          class="flex justify-around text-center mb-4 p-3 bg-slate-700/50 rounded-lg"
         >
           <div>
-            <span class="block text-xl font-bold text-blue-600">{{
+            <span class="block text-xl font-bold text-blue-400">{{
               h2hStats.homeWins
             }}</span>
-            <span class="text-xs text-gray-500 truncate block max-w-[80px]">{{
+            <span class="text-xs text-slate-400 truncate block max-w-[80px]">{{
               homeTeamName
             }}</span>
           </div>
           <div>
-            <span class="block text-xl font-bold text-gray-500">{{
+            <span class="block text-xl font-bold text-slate-400">{{
               h2hStats.draws
             }}</span>
-            <span class="text-xs text-gray-500">Draws</span>
+            <span class="text-xs text-slate-400">Draws</span>
           </div>
           <div>
-            <span class="block text-xl font-bold text-red-500">{{
+            <span class="block text-xl font-bold text-red-400">{{
               h2hStats.awayWins
             }}</span>
-            <span class="text-xs text-gray-500 truncate block max-w-[80px]">{{
+            <span class="text-xs text-slate-400 truncate block max-w-[80px]">{{
               awayTeamName
             }}</span>
           </div>
@@ -289,10 +345,10 @@ const MatchResultCard = {
     });
 
     const outcomeClass = computed(() => {
-      if (outcome.value === 'W') return 'bg-green-100 text-green-700';
-      if (outcome.value === 'L') return 'bg-red-100 text-red-700';
-      if (outcome.value === 'D') return 'bg-gray-100 text-gray-600';
-      return 'bg-gray-100 text-gray-400';
+      if (outcome.value === 'W') return 'bg-green-900/60 text-green-400';
+      if (outcome.value === 'L') return 'bg-red-900/60 text-red-400';
+      if (outcome.value === 'D') return 'bg-slate-600 text-slate-300';
+      return 'bg-slate-600 text-slate-400';
     });
 
     const formattedDate = computed(() => {
@@ -304,13 +360,13 @@ const MatchResultCard = {
     return { outcome, opponent, scoreDisplay, outcomeClass, formattedDate };
   },
   template: `
-    <div class="flex items-center gap-1.5 p-1.5 rounded bg-white border border-gray-100 shadow-sm text-xs">
+    <div class="flex items-center gap-1.5 p-1.5 rounded bg-slate-700 border border-slate-600 text-xs">
       <span :class="['font-bold w-4 text-center shrink-0', outcomeClass]" style="border-radius:2px">
         {{ outcome ?? '?' }}
       </span>
-      <span class="font-mono font-semibold text-gray-700 shrink-0">{{ scoreDisplay }}</span>
-      <span class="text-gray-600 truncate flex-1">{{ opponent }}</span>
-      <span class="text-gray-400 shrink-0">{{ formattedDate }}</span>
+      <span class="font-mono font-semibold text-slate-200 shrink-0">{{ scoreDisplay }}</span>
+      <span class="text-slate-300 truncate flex-1">{{ opponent }}</span>
+      <span class="text-slate-500 shrink-0">{{ formattedDate }}</span>
     </div>
   `,
 };
@@ -342,23 +398,23 @@ const H2HMatchRow = {
       const isHome = m.home_team_id === teamId;
       const score = isHome ? m.home_score : m.away_score;
       const opp = isHome ? m.away_score : m.home_score;
-      if (score > opp) return 'font-bold text-gray-900';
-      if (score < opp) return 'text-gray-400';
-      return 'text-gray-700';
+      if (score > opp) return 'font-bold text-white';
+      if (score < opp) return 'text-slate-500';
+      return 'text-slate-300';
     };
 
     return { formattedDate, winnerClass };
   },
   template: `
-    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-white border border-gray-100 shadow-sm text-xs">
+    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-700 border border-slate-600 text-xs">
       <span :class="['flex-1 text-right truncate', winnerClass(match.home_team_id)]">{{ match.home_team_name }}</span>
-      <span class="font-mono font-semibold text-gray-800 shrink-0 bg-gray-50 px-2 py-0.5 rounded">
+      <span class="font-mono font-semibold text-slate-200 shrink-0 bg-slate-600 px-2 py-0.5 rounded">
         {{ match.home_score ?? '-' }} – {{ match.away_score ?? '-' }}
       </span>
       <span :class="['flex-1 truncate', winnerClass(match.away_team_id)]">{{ match.away_team_name }}</span>
       <div class="text-right shrink-0 ml-2">
-        <div class="text-gray-400">{{ formattedDate }}</div>
-        <div class="text-gray-300">{{ match.season_name }}</div>
+        <div class="text-slate-400">{{ formattedDate }}</div>
+        <div class="text-slate-500">{{ match.season_name }}</div>
       </div>
     </div>
   `,
@@ -450,6 +506,18 @@ async function fetchPreview() {
         : [],
       head_to_head: Array.isArray(data?.head_to_head) ? data.head_to_head : [],
     };
+
+    // Auto-select the tab with the most content
+    const { home_team_recent, away_team_recent, common_opponents } =
+      preview.value;
+    const hasForm = home_team_recent.length > 0 || away_team_recent.length > 0;
+    if (hasForm) {
+      activeTab.value = 'form';
+    } else if (common_opponents.length > 0) {
+      activeTab.value = 'common';
+    } else {
+      activeTab.value = 'h2h';
+    }
   } catch (err) {
     error.value = err.message || 'Failed to load match preview';
   } finally {

--- a/frontend/src/components/VersionFooter.vue
+++ b/frontend/src/components/VersionFooter.vue
@@ -1,5 +1,34 @@
 <template>
   <footer class="version-footer">
+    <!-- Error banner (teleported to body) -->
+    <Teleport to="body">
+      <div
+        v-if="status === 'error' && !errorDismissed"
+        class="fixed top-0 inset-x-0 z-50 bg-red-900 text-white text-sm px-4 py-2 flex items-center justify-between gap-4"
+        data-testid="api-error-banner"
+      >
+        <span
+          >⚠ Could not reach the API server — some features may be
+          unavailable.</span
+        >
+        <div class="flex items-center gap-3 shrink-0">
+          <button
+            @click="retryFetch"
+            class="underline hover:no-underline font-medium"
+          >
+            Retry
+          </button>
+          <button
+            @click="errorDismissed = true"
+            class="font-bold hover:opacity-75"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+    </Teleport>
+
     <div class="version-container">
       <!-- Version info (left side) -->
       <div class="version-info">
@@ -15,14 +44,12 @@
       <!-- Copyright/branding (center) -->
       <div class="copyright">© {{ currentYear }} Missing Table</div>
 
-      <!-- Status indicator (right side) -->
+      <!-- Status indicator (right side) — only show when healthy -->
       <div class="status-indicator">
-        <span
-          v-if="status === 'healthy'"
-          class="status-dot status-healthy"
-        ></span>
-        <span v-else class="status-dot status-error"></span>
-        <span class="status-text">{{ status }}</span>
+        <template v-if="status === 'healthy'">
+          <span class="status-dot status-healthy"></span>
+          <span class="status-text">Healthy</span>
+        </template>
       </div>
     </div>
   </footer>
@@ -38,6 +65,7 @@ export default {
     const environment = ref('unknown');
     const status = ref('healthy');
     const currentYear = computed(() => new Date().getFullYear());
+    const errorDismissed = ref(false);
 
     // Determine environment based on current hostname
     const determineEnvironment = () => {
@@ -56,9 +84,14 @@ export default {
     };
 
     const fetchVersion = async () => {
+      errorDismissed.value = false;
       try {
-        // Use relative URL - works with ingress routing on same domain
-        const response = await fetch('/api/version');
+        const apiBase =
+          window.location.hostname === 'localhost' ||
+          window.location.hostname === '127.0.0.1'
+            ? 'http://localhost:8000'
+            : '';
+        const response = await fetch(`${apiBase}/api/version`);
 
         if (response.ok) {
           const data = await response.json();
@@ -78,6 +111,11 @@ export default {
       }
     };
 
+    const retryFetch = () => {
+      errorDismissed.value = false;
+      fetchVersion();
+    };
+
     onMounted(() => {
       fetchVersion();
     });
@@ -87,6 +125,9 @@ export default {
       environment,
       status,
       currentYear,
+      errorDismissed,
+      fetchVersion,
+      retryFetch,
     };
   },
 };
@@ -167,11 +208,6 @@ export default {
 .status-healthy {
   background-color: #28a745;
   box-shadow: 0 0 4px rgba(40, 167, 69, 0.5);
-}
-
-.status-error {
-  background-color: #dc3545;
-  box-shadow: 0 0 4px rgba(220, 53, 69, 0.5);
 }
 
 .status-text {


### PR DESCRIPTION
## Summary

- **Desktop layout**: replaced narrow mobile card (`max-w-sm`) with a responsive 2fr/3fr grid; stacks vertically on mobile (`md:` breakpoint)
- **Countdown timer**: live days/hrs/min countdown below the SCHEDULED badge for upcoming matches; auto-clears when expired
- **Dark theme**: MatchPreview panel and all sub-components (result cards, H2H rows, W/L/D chips) now match the dark slate scoreboard
- **Empty tab states**: each preview tab (Recent Form, Common Opponents, Head-to-Head) shows an icon + descriptive message when empty, instead of blank headers
- **Auto-select best tab**: on load, auto-activates the tab with the most data (form → common → h2h)
- **Starting Lineup**: defaults to expanded; `+/-` text replaced with an animated chevron disclosure icon
- **Copy button**: renamed "Copy Scoreboard", moved into the match card footer (aligned right), no longer floating below the card
- **Team names**: constrained to 2 lines (`line-clamp-2`) to prevent long names from breaking the scoreboard layout
- **VersionFooter**: fixed relative `/api/version` URL (was failing in Vite dev); error state now shows a dismissible top-of-page banner instead of a bare red dot in the footer

## Test plan

- [ ] Click a scheduled match — confirm 2-column layout, countdown visible, preview panel loads dark-themed
- [ ] Verify countdown counts down correctly for a future kickoff; hidden for completed matches
- [ ] Switch between Recent Form / Common Opponents / Head-to-Head tabs; confirm icons show when empty
- [ ] Confirm auto-selected tab has data on load
- [ ] Confirm Starting Lineup section opens by default with chevron toggle
- [ ] Click "Copy Scoreboard" — confirm image copies and "Copied!" flash appears in card footer
- [ ] Resize to mobile — confirm columns stack (match card first, preview second)
- [ ] Reload the footer in dev — confirm no red "Error" dot; check banner dismisses and retry works

🤖 Generated with [Claude Code](https://claude.com/claude-code)