### PR TITLE
feat: Add note field and used-by display to invite management

### DIFF
--- a/backend/api/invites.py
+++ b/backend/api/invites.py
@@ -42,11 +42,13 @@ class CreateInviteRequest(BaseModel):
     email: str | None = None
     player_id: int | None = None  # Links to existing roster entry (for team_player invites)
     jersey_number: int | None = Field(None, ge=1, le=99)  # Creates roster entry on redemption
+    note: str | None = Field(None, max_length=500)  # Personal note about who the invite was sent to
 
 
 class CreateClubManagerInviteRequest(BaseModel):
     club_id: int
     email: str | None = None
+    note: str | None = Field(None, max_length=500)  # Personal note about who the invite was sent to
 
 
 class ClubManagerInviteResponse(BaseModel):
@@ -117,6 +119,7 @@ async def create_club_manager_invite(
             invite_type="club_manager",
             club_id=request.club_id,
             email=request.email,
+            note=request.note,
         )
 
         return invitation
@@ -155,6 +158,7 @@ async def create_team_manager_invite(request: CreateInviteRequest, current_user=
             team_id=request.team_id,
             age_group_id=request.age_group_id,
             email=request.email,
+            note=request.note,
         )
 
         return invitation
@@ -186,6 +190,7 @@ async def create_club_fan_invite_admin(
             invite_type="club_fan",
             club_id=request.club_id,
             email=request.email,
+            note=request.note,
         )
 
         return invitation
@@ -216,6 +221,7 @@ async def create_team_fan_invite_admin(request: CreateInviteRequest, current_use
             team_id=request.team_id,
             age_group_id=request.age_group_id,
             email=request.email,
+            note=request.note,
         )
 
         return invitation
@@ -256,6 +262,7 @@ async def create_team_player_invite_admin(
             email=request.email,
             player_id=request.player_id,
             jersey_number=request.jersey_number,
+            note=request.note,
         )
 
         return invitation
@@ -293,6 +300,7 @@ async def create_club_fan_invite_club_manager(
             invite_type="club_fan",
             club_id=request.club_id,
             email=request.email,
+            note=request.note,
         )
 
         return invitation
@@ -333,6 +341,7 @@ async def create_team_fan_invite(request: CreateInviteRequest, current_user=Depe
             team_id=request.team_id,
             age_group_id=request.age_group_id,
             email=request.email,
+            note=request.note,
         )
 
         return invitation
@@ -380,6 +389,7 @@ async def create_team_player_invite(request: CreateInviteRequest, current_user=D
             email=request.email,
             player_id=request.player_id,
             jersey_number=request.jersey_number,
+            note=request.note,
         )
 
         return invitation

--- a/backend/services/invite_service.py
+++ b/backend/services/invite_service.py
@@ -48,6 +48,7 @@ class InviteService:
         player_id: int | None = None,
         jersey_number: int | None = None,
         expires_in_days: int = 7,
+        note: str | None = None,
     ) -> dict:
         """
         Create a new invitation
@@ -103,6 +104,7 @@ class InviteService:
                 "jersey_number": jersey_number,
                 "status": "pending",
                 "expires_at": expires_at.isoformat(),
+                "note": note,
             }
 
             response = self.supabase.table("invitations").insert(invitation_data).execute()
@@ -695,7 +697,7 @@ class InviteService:
             user_id: ID of the user
 
         Returns:
-            List of invitations
+            List of invitations, with used_by_user profile info merged in for used invites
         """
         try:
             response = (
@@ -706,7 +708,29 @@ class InviteService:
                 .execute()
             )
 
-            return response.data if response.data else []
+            invitations = response.data if response.data else []
+
+            # Fetch user profiles for any "used" invites so we can show who redeemed them
+            used_user_ids = list({
+                inv["used_by_user_id"]
+                for inv in invitations
+                if inv.get("used_by_user_id")
+            })
+
+            if used_user_ids:
+                profiles_response = (
+                    self.supabase.table("user_profiles")
+                    .select("id, username, display_name")
+                    .in_("id", used_user_ids)
+                    .execute()
+                )
+                profiles_by_id = {p["id"]: p for p in (profiles_response.data or [])}
+
+                for inv in invitations:
+                    uid = inv.get("used_by_user_id")
+                    inv["used_by_user"] = profiles_by_id.get(uid) if uid else None
+
+            return invitations
 
         except Exception as e:
             logger.error(f"Error getting user invitations: {e}")

--- a/frontend/src/components/admin/AdminInvites.vue
+++ b/frontend/src/components/admin/AdminInvites.vue
@@ -146,6 +146,24 @@
           />
         </div>
 
+        <!-- Note (Optional) -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2"
+            >Note (Optional)</label
+          >
+          <input
+            v-model="newInvite.note"
+            type="text"
+            maxlength="500"
+            placeholder="Who is this invite for? e.g., John Smith - U13 coach"
+            data-testid="invite-note-input"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p class="mt-1 text-xs text-gray-500">
+            Personal reminder — visible only to you, not sent to the recipient.
+          </p>
+        </div>
+
         <!-- Submit Button -->
         <button
           type="submit"
@@ -188,6 +206,10 @@
           <p v-if="createdInvite.jersey_number">
             <span class="font-medium">Jersey Number:</span>
             #{{ createdInvite.jersey_number }}
+          </p>
+          <p v-if="createdInvite.note">
+            <span class="font-medium">Note:</span>
+            {{ createdInvite.note }}
           </p>
           <p>
             <span class="font-medium">Expires:</span>
@@ -300,6 +322,15 @@
                 {{ invite.teams?.name }} - {{ invite.age_groups?.name }}
               </template>
             </p>
+            <p v-if="invite.used_by_user">
+              <span class="text-gray-500">Used by:</span>
+              {{
+                invite.used_by_user.display_name || invite.used_by_user.username
+              }}
+            </p>
+            <p v-if="invite.note" class="text-gray-700 text-xs italic">
+              {{ invite.note }}
+            </p>
             <p class="text-gray-500 text-xs">
               {{ formatDate(invite.created_at) }}
             </p>
@@ -352,6 +383,16 @@
               <th
                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
               >
+                Used By
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
+                Note
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
                 Created
               </th>
               <th
@@ -400,6 +441,24 @@
                 >
                   {{ invite.status }}
                 </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+                <template v-if="invite.used_by_user">
+                  {{
+                    invite.used_by_user.display_name ||
+                    invite.used_by_user.username
+                  }}
+                </template>
+                <span v-else class="text-gray-300">-</span>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-500 max-w-xs">
+                <span
+                  v-if="invite.note"
+                  :title="invite.note"
+                  class="truncate block"
+                  >{{ invite.note }}</span
+                >
+                <span v-else class="text-gray-300">-</span>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 {{ formatDate(invite.created_at) }}
@@ -516,6 +575,7 @@ const newInvite = ref({
   ageGroupId: '',
   email: '',
   jerseyNumber: null,
+  note: '',
 });
 
 // Fetch teams, age groups, and clubs
@@ -581,6 +641,7 @@ const createInvite = async () => {
       body = JSON.stringify({
         club_id: parseInt(newInvite.value.clubId),
         email: newInvite.value.email || null,
+        note: newInvite.value.note || null,
       });
     } else if (newInvite.value.inviteType === 'club_fan') {
       // Club managers use their own endpoint, admins use admin endpoint
@@ -591,6 +652,7 @@ const createInvite = async () => {
       body = JSON.stringify({
         club_id: parseInt(newInvite.value.clubId),
         email: newInvite.value.email || null,
+        note: newInvite.value.note || null,
       });
     } else {
       endpoint = '/api/invites/admin/';
@@ -604,6 +666,7 @@ const createInvite = async () => {
         team_id: parseInt(newInvite.value.teamId),
         age_group_id: parseInt(newInvite.value.ageGroupId),
         email: newInvite.value.email || null,
+        note: newInvite.value.note || null,
       };
       // Add jersey_number for team_player invites
       if (
@@ -636,6 +699,7 @@ const createInvite = async () => {
       ageGroupId: '',
       email: '',
       jerseyNumber: null,
+      note: '',
     };
 
     // Refresh invites list

--- a/supabase-local/migrations/20260415000000_add_note_to_invitations.sql
+++ b/supabase-local/migrations/20260415000000_add_note_to_invitations.sql
@@ -1,0 +1,4 @@
+-- Add note column to invitations table
+-- Allows admins/managers to record who they sent the invite to (e.g., "John Smith - U13 coach")
+
+ALTER TABLE public.invitations ADD COLUMN IF NOT EXISTS note VARCHAR(500);


### PR DESCRIPTION
## Summary
- Adds optional **Note** field to invite creation so admins can record who each invite was sent to (e.g. "John Smith - U13 coach") — private, not shown to the recipient
- Adds **Used By** column to the invites table showing the display name / username of whoever redeemed the invite

## Changes
- **Migration**: `note VARCHAR(500)` column added to `invitations` table
- **Backend**: `note` flows through all invite creation endpoints and the service layer; `get_user_invitations` now enriches used invites with a batch `user_profiles` lookup so the redeemer's name is returned
- **Frontend**: note input in the create form; Note + Used By shown in both desktop table and mobile card view

## Schema migration required
Run against prod **before or immediately after merging**:
```bash
./scripts/db_tools.sh migrate prod
```

## Test plan
- [ ] Create an invite with a note — note appears in the success banner and in the Existing Invites table
- [ ] Create an invite without a note — table shows `-` in the Note column, no regression
- [ ] Redeem an invite (or check an existing used invite) — Used By column shows the user's display name or username
- [ ] Verify mobile card view shows both note and used-by correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)