### PR TITLE
fix: Fix player profile showing wrong age group for multi-age-group clubs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1448,6 +1448,7 @@ async def create_player_history(
             positions=history_data.positions,
             notes=history_data.notes,
             is_current=history_data.is_current,
+            age_group_id=history_data.age_group_id,
         )
 
         if entry:
@@ -1607,6 +1608,7 @@ async def add_admin_player_team(
             season_id=data.season_id,
             jersey_number=data.jersey_number,
             is_current=data.is_current,
+            age_group_id=data.age_group_id,
         )
 
         if not entry:

--- a/backend/dao/player_dao.py
+++ b/backend/dao/player_dao.py
@@ -402,6 +402,7 @@ class PlayerDAO(BaseDAO):
         positions: list[str] | None = None,
         notes: str | None = None,
         is_current: bool = False,
+        age_group_id: int | None = None,
     ) -> dict | None:
         """
         Create or update a player team history entry.
@@ -421,6 +422,9 @@ class PlayerDAO(BaseDAO):
             positions: Optional list of positions played
             notes: Optional notes about the assignment
             is_current: Whether this is the current assignment
+            age_group_id: Explicit age group override. Required for clubs with multiple
+                age groups (e.g. IFA runs U13/U14/U15/U16). When omitted, falls back
+                to the first team_mapping row — unreliable for multi-age-group clubs.
 
         Returns:
             Created/updated history entry dict, or None on error
@@ -433,11 +437,20 @@ class PlayerDAO(BaseDAO):
 
             team_data = team_response.data[0] if team_response.data else {}
 
-            # Get age_group_id from team_mappings (teams.age_group_id is deprecated/never populated)
-            mapping_response = (
-                self.client.table("team_mappings").select("age_group_id").eq("team_id", team_id).limit(1).execute()
-            )
-            age_group_id = mapping_response.data[0]["age_group_id"] if mapping_response.data else None
+            # Resolve age_group_id: use caller-supplied value when available.
+            # Falling back to team_mappings is only reliable for teams with a single
+            # age-group mapping; clubs like IFA have multiple rows and limit(1) is
+            # non-deterministic without an explicit age_group_id.
+            if age_group_id is None:
+                mapping_response = (
+                    self.client.table("team_mappings")
+                    .select("age_group_id")
+                    .eq("team_id", team_id)
+                    .order("age_group_id")
+                    .limit(1)
+                    .execute()
+                )
+                age_group_id = mapping_response.data[0]["age_group_id"] if mapping_response.data else None
 
             upsert_data = {
                 "player_id": player_id,

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -207,6 +207,7 @@ class PlayerHistoryCreate(BaseModel):
     positions: list[str] | None = None
     notes: str | None = None
     is_current: bool = False
+    age_group_id: int | None = None
 
     @field_validator("jersey_number")
     @classmethod
@@ -258,6 +259,7 @@ class AdminPlayerTeamAssignment(BaseModel):
     jersey_number: int | None = None
     start_date: str | None = None
     is_current: bool = True
+    age_group_id: int | None = None
 
     @field_validator("jersey_number")
     @classmethod

--- a/supabase-local/migrations/20260416000000_fix_gabe35_age_group.sql
+++ b/supabase-local/migrations/20260416000000_fix_gabe35_age_group.sql
@@ -1,0 +1,19 @@
+-- Fix player_team_history for gabe35 (player_id: 4a4c4b2b-caf3-4ca2-b5f5-c1e3b414b61d)
+--
+-- Root cause: create_player_history_entry used limit(1) on team_mappings without ordering,
+-- so for team_id=19 (IFA) which has mappings for U13/U14/U15/U16, it non-deterministically
+-- picked U13 instead of U14. The IFA Academy entry (correct HG team) was also left with
+-- is_current=false when it should be the primary current assignment.
+--
+-- Entry 28: IFA team, 2025-2026 — wrong age_group (U13), correct to U14
+UPDATE player_team_history
+SET age_group_id = 2  -- U14
+WHERE id = 28
+  AND player_id = '4a4c4b2b-caf3-4ca2-b5f5-c1e3b414b61d'
+  AND age_group_id = 1;  -- safety check: only update if still U13
+
+-- Entry 26: IFA Academy (HG Northeast), 2025-2026 — mark as current
+UPDATE player_team_history
+SET is_current = true
+WHERE id = 26
+  AND player_id = '4a4c4b2b-caf3-4ca2-b5f5-c1e3b414b61d';


### PR DESCRIPTION
## Summary

- **Root cause**: `create_player_history_entry` used `.limit(1)` on `team_mappings` without ordering — for clubs like IFA that have U13/U14/U15/U16 mappings, this non-deterministically assigned the wrong age group (U13 instead of U14 for gabe35)
- **Data fix**: Migration corrects gabe35's 2025-2026 IFA entry (age_group U13→U14) and marks IFA Academy (HG Northeast, his primary team) as `is_current=true`
- **Code fix**: `age_group_id` is now an explicit parameter on `create_player_history_entry`, `PlayerHistoryCreate`, and `AdminPlayerTeamAssignment`; the fallback team_mappings lookup now uses `order("age_group_id")` for determinism

## What was wrong (gabe35)

| ID | Team | Age Group | is_current | Issue |
|----|------|-----------|------------|-------|
| 28 | IFA | **U13** ❌ | true | Wrong age group — IFA has 4 mappings, limit(1) picked U13 |
| 26 | IFA Academy (HG) | U14 ✓ | **false** ❌ | Primary current team marked not-current |
| 27 | IFA Elite Futsal | U14 ✓ | true | Correct |

`PlayerProfile.vue` uses `playerHistory.find(h => h.is_current)` — entry 28 landed first and won.

## Test plan

- [ ] Apply migration to prod via `./scripts/db_tools.sh migrate prod`
- [ ] Verify gabe35 profile now shows U14 and IFA Academy as current team
- [ ] Confirm other players on single-age-group teams are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)