### PR TITLE
feat: QoP rankings — migration, API endpoints, and frontend integration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2256,8 +2256,8 @@ async def get_match_preview(
 ):
     """Get match preview data for two teams.
 
-    Returns recent form for each team, common opponents (with match results), and
-    head-to-head history spanning all seasons.
+    Returns recent form for each team, common opponents (with match results),
+    head-to-head history spanning all seasons, and QoP ranking data for both teams.
     """
     try:
         preview = match_dao.get_match_preview(
@@ -2267,6 +2267,69 @@ async def get_match_preview(
             age_group_id=age_group_id,
             recent_count=recent_count,
         )
+
+        # Augment preview with QoP ranking data
+        qop_defaults = {
+            "has_qop_data": False,
+            "home_qop_rank": None,
+            "home_qop_rank_change": None,
+            "away_qop_rank": None,
+            "away_qop_rank_change": None,
+        }
+        try:
+            home_team = team_dao.get_team_with_details(home_team_id)
+            away_team = team_dao.get_team_with_details(away_team_id)
+
+            home_division = home_team.get("division") if home_team else None
+            away_division = away_team.get("division") if away_team else None
+            home_division_id = home_division.get("id") if home_division else None
+            away_division_id = away_division.get("id") if away_division else None
+            home_age_group = home_team.get("age_group") if home_team else None
+            home_age_group_id = home_age_group.get("id") if home_age_group else None
+
+            if (
+                home_division_id is None
+                or away_division_id is None
+                or home_division_id != away_division_id
+                or home_age_group_id is None
+            ):
+                preview.update(qop_defaults)
+            else:
+                qop_data = QoPRankingsDAO.get_latest_with_delta(
+                    match_dao.client, home_division_id, home_age_group_id
+                )
+                if not qop_data.get("has_data"):
+                    preview.update(qop_defaults)
+                else:
+                    rankings = qop_data["rankings"]
+
+                    def find_team_rank(team_id: int, team_name: str | None) -> tuple[int | None, int | None]:
+                        """Find rank and rank_change for a team, by team_id first then name."""
+                        for entry in rankings:
+                            if entry.get("team_id") == team_id:
+                                return entry["rank"], entry.get("rank_change")
+                        if team_name:
+                            for entry in rankings:
+                                if entry.get("team_name", "").lower() == team_name.lower():
+                                    return entry["rank"], entry.get("rank_change")
+                        return None, None
+
+                    home_name = home_team.get("name") if home_team else None
+                    away_name = away_team.get("name") if away_team else None
+                    home_rank, home_rank_change = find_team_rank(home_team_id, home_name)
+                    away_rank, away_rank_change = find_team_rank(away_team_id, away_name)
+
+                    preview.update({
+                        "has_qop_data": True,
+                        "home_qop_rank": home_rank,
+                        "home_qop_rank_change": home_rank_change,
+                        "away_qop_rank": away_rank,
+                        "away_qop_rank_change": away_rank_change,
+                    })
+        except Exception:
+            logger.warning("Failed to fetch QoP data for match preview", exc_info=True)
+            preview.update(qop_defaults)
+
         return preview
     except Exception as e:
         logger.error(f"Error building match preview: {e!s}", exc_info=True)
@@ -3614,7 +3677,67 @@ async def get_table(
             rows_returned=len(table) if isinstance(table, list) else "N/A",
         )
 
-        return table
+        # Enrich standings with QoP rankings data when division and age group are known
+        has_qop_data = False
+        qop_week_of = None
+        if division_id and age_group_id:
+            try:
+                qop_data = QoPRankingsDAO.get_latest_with_delta(
+                    match_dao.client, division_id, age_group_id
+                )
+                has_qop_data = qop_data.get("has_data", False)
+                qop_week_of = qop_data.get("week_of")
+
+                if has_qop_data:
+                    # Build lookups: team_id -> entry and team_name -> entry
+                    qop_by_team_id: dict[int, dict] = {}
+                    qop_by_team_name: dict[str, dict] = {}
+                    for entry in qop_data.get("rankings", []):
+                        tid = entry.get("team_id")
+                        if tid is not None:
+                            qop_by_team_id[tid] = entry
+                        tname = entry.get("team_name", "")
+                        if tname:
+                            qop_by_team_name[tname.lower()] = entry
+
+                    for row in table:
+                        qop_entry = None
+                        # Try team_id first
+                        row_team_id = row.get("team_id")
+                        if row_team_id is not None:
+                            qop_entry = qop_by_team_id.get(row_team_id)
+                        # Fallback to team_name (case-insensitive)
+                        if qop_entry is None:
+                            row_team_name = (row.get("team") or "").lower()
+                            qop_entry = qop_by_team_name.get(row_team_name)
+
+                        row["qop_rank"] = qop_entry["rank"] if qop_entry else None
+                        row["qop_rank_change"] = qop_entry["rank_change"] if qop_entry else None
+                else:
+                    for row in table:
+                        row["qop_rank"] = None
+                        row["qop_rank_change"] = None
+            except Exception:
+                logger.exception(
+                    "qop_enrichment_error",
+                    division_id=division_id,
+                    age_group_id=age_group_id,
+                )
+                has_qop_data = False
+                qop_week_of = None
+                for row in table:
+                    row["qop_rank"] = None
+                    row["qop_rank_change"] = None
+        else:
+            for row in table:
+                row["qop_rank"] = None
+                row["qop_rank_change"] = None
+
+        return {
+            "has_qop_data": has_qop_data,
+            "qop_week_of": qop_week_of,
+            "standings": table,
+        }
     except Exception as e:
         logger.error(f"Error generating league table: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,7 @@ from auth import (
     AuthManager,
     get_current_user_required,
     require_admin,
+    require_admin_or_service_account,
     require_match_management_permission,
     require_team_manager_or_admin,
 )
@@ -92,6 +93,7 @@ from dao.playoff_dao import PlayoffDAO
 from dao.roster_dao import RosterDAO
 from dao.season_dao import SeasonDAO
 from dao.team_dao import TeamDAO
+from dao.qop_rankings_dao import QoPRankingsDAO
 from dao.tournament_dao import TournamentDAO
 
 
@@ -6221,6 +6223,49 @@ async def admin_delete_tournament_match(
     try:
         tournament_dao.delete_tournament_match(match_id)
     except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+# === QoP Rankings Endpoints ===
+
+
+class QoPSnapshot(BaseModel):
+    """Request body for POST /api/qop-rankings."""
+
+    week_of: str
+    division: str
+    age_group: str
+    scraped_at: str | None = None
+    rankings: list[dict]
+
+
+@app.post("/api/qop-rankings")
+async def ingest_qop_rankings(
+    snapshot: QoPSnapshot,
+    current_user: dict[str, Any] = Depends(require_admin_or_service_account),
+):
+    """Ingest a weekly QoP rankings snapshot (admin or service account only)."""
+    try:
+        count = QoPRankingsDAO.upsert_snapshot(match_dao.client, snapshot.model_dump())
+        return {"inserted": count, "week_of": snapshot.week_of}
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"Error ingesting QoP rankings: {e!s}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.get("/api/qop-rankings")
+async def get_qop_rankings(
+    division_id: int = Query(..., description="Division ID"),
+    age_group_id: int = Query(..., description="Age group ID"),
+):
+    """Get the latest QoP rankings for a division/age_group with week-over-week rank delta."""
+    try:
+        result = QoPRankingsDAO.get_latest_with_delta(match_dao.client, division_id, age_group_id)
+        return result
+    except Exception as e:
+        logger.error(f"Error retrieving QoP rankings: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 

--- a/backend/dao/qop_rankings_dao.py
+++ b/backend/dao/qop_rankings_dao.py
@@ -1,0 +1,247 @@
+"""
+Quality of Play (QoP) Rankings data access layer for MissingTable.
+
+Provides upsert and query functionality for weekly QoP ranking snapshots
+scraped from MLS Next standings pages.
+"""
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+class QoPRankingsDAO:
+    """Data Access Object for Quality of Play rankings."""
+
+    @staticmethod
+    def _resolve_division_id(client, division: str) -> int | None:
+        """Resolve a division name to its database ID (case-insensitive)."""
+        try:
+            response = client.table("divisions").select("id, name").execute()
+            for row in response.data:
+                if row["name"].lower() == division.lower():
+                    return row["id"]
+            logger.warning("qop_rankings_division_not_found", division=division)
+            return None
+        except Exception:
+            logger.exception("qop_rankings_division_lookup_error", division=division)
+            return None
+
+    @staticmethod
+    def _resolve_age_group_id(client, age_group: str) -> int | None:
+        """Resolve an age group name to its database ID (case-insensitive)."""
+        try:
+            response = client.table("age_groups").select("id, name").execute()
+            for row in response.data:
+                if row["name"].lower() == age_group.lower():
+                    return row["id"]
+            logger.warning("qop_rankings_age_group_not_found", age_group=age_group)
+            return None
+        except Exception:
+            logger.exception("qop_rankings_age_group_lookup_error", age_group=age_group)
+            return None
+
+    @staticmethod
+    def _resolve_team_id(client, team_name: str) -> int | None:
+        """Resolve a team name to its database ID (case-insensitive). Returns None if no match."""
+        try:
+            response = client.table("teams").select("id, name").ilike("name", team_name).limit(1).execute()
+            if response.data:
+                return response.data[0]["id"]
+            return None
+        except Exception:
+            logger.warning("qop_rankings_team_lookup_error", team_name=team_name)
+            return None
+
+    @staticmethod
+    def upsert_snapshot(client, snapshot: dict) -> int:
+        """
+        Upsert a weekly QoP rankings snapshot.
+
+        Args:
+            client: Supabase client instance
+            snapshot: Dict with shape:
+                {
+                    "week_of": "2026-04-14",
+                    "division": "Northeast",
+                    "age_group": "U14",
+                    "scraped_at": "2026-04-16T12:00:00Z",  # optional, defaults to NOW()
+                    "rankings": [
+                        {
+                            "rank": 1,
+                            "team_name": "New York City FC",
+                            "matches_played": 16,
+                            "att_score": 89.6,
+                            "def_score": 83.1,
+                            "qop_score": 87.6
+                        },
+                        ...
+                    ]
+                }
+
+        Returns:
+            Count of rows upserted
+
+        Raises:
+            ValueError: If division or age_group cannot be resolved
+        """
+        week_of = snapshot["week_of"]
+        division_name = snapshot["division"]
+        age_group_name = snapshot["age_group"]
+        scraped_at = snapshot.get("scraped_at")
+        rankings = snapshot.get("rankings", [])
+
+        division_id = QoPRankingsDAO._resolve_division_id(client, division_name)
+        if division_id is None:
+            raise ValueError(f"Division not found: {division_name!r}")
+
+        age_group_id = QoPRankingsDAO._resolve_age_group_id(client, age_group_name)
+        if age_group_id is None:
+            raise ValueError(f"Age group not found: {age_group_name!r}")
+
+        if not rankings:
+            return 0
+
+        rows = []
+        for entry in rankings:
+            team_id = QoPRankingsDAO._resolve_team_id(client, entry["team_name"])
+            row = {
+                "week_of": week_of,
+                "division_id": division_id,
+                "age_group_id": age_group_id,
+                "rank": entry["rank"],
+                "team_name": entry["team_name"],
+                "team_id": team_id,
+                "matches_played": entry.get("matches_played"),
+                "att_score": entry.get("att_score"),
+                "def_score": entry.get("def_score"),
+                "qop_score": entry["qop_score"],
+            }
+            if scraped_at:
+                row["scraped_at"] = scraped_at
+            rows.append(row)
+
+        response = (
+            client.table("qop_rankings")
+            .upsert(rows, on_conflict="week_of,division_id,age_group_id,rank")
+            .execute()
+        )
+
+        count = len(response.data) if response.data else 0
+        logger.info(
+            "qop_rankings_upserted",
+            week_of=week_of,
+            division=division_name,
+            age_group=age_group_name,
+            count=count,
+        )
+        return count
+
+    @staticmethod
+    def get_latest_with_delta(client, division_id: int, age_group_id: int) -> dict:
+        """
+        Fetch the two most recent weeks of rankings for a division/age_group
+        and compute week-over-week rank changes.
+
+        Args:
+            client: Supabase client instance
+            division_id: Division database ID
+            age_group_id: Age group database ID
+
+        Returns:
+            Dict with keys:
+                has_data (bool), week_of (str|None), prior_week_of (str|None),
+                rankings (list of dicts with rank_change field)
+        """
+        empty = {
+            "has_data": False,
+            "week_of": None,
+            "prior_week_of": None,
+            "rankings": [],
+        }
+
+        try:
+            # Find the two most recent distinct week_of values
+            weeks_response = (
+                client.table("qop_rankings")
+                .select("week_of")
+                .eq("division_id", division_id)
+                .eq("age_group_id", age_group_id)
+                .order("week_of", desc=True)
+                .execute()
+            )
+
+            if not weeks_response.data:
+                return empty
+
+            # Extract distinct week_of values in descending order
+            seen = []
+            for row in weeks_response.data:
+                wk = row["week_of"]
+                if wk not in seen:
+                    seen.append(wk)
+                if len(seen) == 2:
+                    break
+
+            current_week = seen[0]
+            prior_week = seen[1] if len(seen) > 1 else None
+
+            # Fetch current week rows
+            current_response = (
+                client.table("qop_rankings")
+                .select("rank, team_name, team_id, matches_played, att_score, def_score, qop_score")
+                .eq("division_id", division_id)
+                .eq("age_group_id", age_group_id)
+                .eq("week_of", current_week)
+                .order("rank")
+                .execute()
+            )
+            current_rows = current_response.data or []
+
+            # Build prior week lookup: team_name -> rank
+            prior_rank_by_team: dict[str, int] = {}
+            if prior_week:
+                prior_response = (
+                    client.table("qop_rankings")
+                    .select("rank, team_name")
+                    .eq("division_id", division_id)
+                    .eq("age_group_id", age_group_id)
+                    .eq("week_of", prior_week)
+                    .execute()
+                )
+                for row in (prior_response.data or []):
+                    prior_rank_by_team[row["team_name"]] = row["rank"]
+
+            # Build enriched rankings with rank_change
+            rankings = []
+            for row in current_rows:
+                team_name = row["team_name"]
+                current_rank = row["rank"]
+                prior_rank = prior_rank_by_team.get(team_name)
+                rank_change = (prior_rank - current_rank) if prior_rank is not None else None
+
+                rankings.append({
+                    "rank": current_rank,
+                    "team_name": team_name,
+                    "team_id": row.get("team_id"),
+                    "matches_played": row.get("matches_played"),
+                    "att_score": row.get("att_score"),
+                    "def_score": row.get("def_score"),
+                    "qop_score": row["qop_score"],
+                    "rank_change": rank_change,
+                })
+
+            return {
+                "has_data": True,
+                "week_of": current_week,
+                "prior_week_of": prior_week,
+                "rankings": rankings,
+            }
+
+        except Exception:
+            logger.exception(
+                "qop_rankings_get_latest_error",
+                division_id=division_id,
+                age_group_id=age_group_id,
+            )
+            return empty

--- a/backend/tests/unit/test_qop_rankings.py
+++ b/backend/tests/unit/test_qop_rankings.py
@@ -1,0 +1,258 @@
+"""
+Unit tests for QoP Rankings DAO and API endpoints.
+
+Tests:
+- upsert_snapshot: valid snapshot returns inserted count
+- get_latest_with_delta: no data returns has_data=False
+- rank delta: prior rank 5, current rank 3 → rank_change = 2 (moved up)
+- new entry with no prior week → rank_change = None
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+# ─── DAO helpers ───────────────────────────────────────────────────────────────
+
+def _make_client(table_responses: dict):
+    """
+    Build a mock Supabase client where table(name) returns a pre-configured
+    mock chain. table_responses maps table name → list of row dicts returned
+    by .execute().data for that table.
+
+    For tables that need chained filtering (eq, order, ilike, limit), the mock
+    always returns the preconfigured .execute() result regardless of filter
+    arguments.
+    """
+    client = MagicMock()
+
+    def table_side_effect(name):
+        rows = table_responses.get(name, [])
+        mock_response = Mock()
+        mock_response.data = rows
+
+        chain = MagicMock()
+        # Any attribute access on the chain (select, eq, order, ilike, limit,
+        # upsert, desc) returns the chain itself so calls can be chained freely.
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.order.return_value = chain
+        chain.ilike.return_value = chain
+        chain.limit.return_value = chain
+        chain.upsert.return_value = chain
+        chain.execute.return_value = mock_response
+        return chain
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+# ─── upsert_snapshot ───────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+class TestUpsertSnapshot:
+
+    def test_upsert_returns_inserted_count(self):
+        """POST with valid snapshot data returns the count of rows upserted."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        divisions = [{"id": 1, "name": "Northeast"}]
+        age_groups = [{"id": 2, "name": "U14"}]
+        teams = []  # no team match — team_id should be None
+        upserted_rows = [
+            {"id": 10, "rank": 1},
+            {"id": 11, "rank": 2},
+        ]
+
+        client = _make_client({
+            "divisions": divisions,
+            "age_groups": age_groups,
+            "teams": teams,
+            "qop_rankings": upserted_rows,
+        })
+
+        snapshot = {
+            "week_of": "2026-04-14",
+            "division": "Northeast",
+            "age_group": "U14",
+            "scraped_at": "2026-04-16T00:00:00Z",
+            "rankings": [
+                {"rank": 1, "team_name": "Team A", "matches_played": 10, "att_score": 80.0, "def_score": 75.0, "qop_score": 78.0},
+                {"rank": 2, "team_name": "Team B", "matches_played": 10, "att_score": 78.0, "def_score": 70.0, "qop_score": 74.0},
+            ],
+        }
+
+        count = QoPRankingsDAO.upsert_snapshot(client, snapshot)
+        assert count == 2
+
+    def test_upsert_raises_on_unknown_division(self):
+        """upsert_snapshot raises ValueError when division is not found."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        client = _make_client({
+            "divisions": [{"id": 1, "name": "Northeast"}],
+            "age_groups": [{"id": 2, "name": "U14"}],
+        })
+
+        snapshot = {
+            "week_of": "2026-04-14",
+            "division": "Unknown Division",
+            "age_group": "U14",
+            "rankings": [],
+        }
+
+        with pytest.raises(ValueError, match="Division not found"):
+            QoPRankingsDAO.upsert_snapshot(client, snapshot)
+
+    def test_upsert_empty_rankings_returns_zero(self):
+        """upsert_snapshot with empty rankings list returns 0 without hitting qop_rankings table."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        client = _make_client({
+            "divisions": [{"id": 1, "name": "Northeast"}],
+            "age_groups": [{"id": 2, "name": "U14"}],
+            "qop_rankings": [],
+        })
+
+        snapshot = {
+            "week_of": "2026-04-14",
+            "division": "Northeast",
+            "age_group": "U14",
+            "rankings": [],
+        }
+
+        count = QoPRankingsDAO.upsert_snapshot(client, snapshot)
+        assert count == 0
+
+
+# ─── get_latest_with_delta ─────────────────────────────────────────────────────
+
+@pytest.mark.unit
+class TestGetLatestWithDelta:
+
+    def _make_ordered_client(self, week_rows, current_rows, prior_rows=None):
+        """
+        Build a client where qop_rankings returns different data depending on
+        whether the query is for the distinct-weeks fetch, current week, or
+        prior week.  We detect context via call count on the table mock.
+        """
+        client = MagicMock()
+        call_count = {"n": 0}
+
+        def table_side_effect(name):
+            if name != "qop_rankings":
+                mock_resp = Mock()
+                mock_resp.data = []
+                chain = MagicMock()
+                chain.select.return_value = chain
+                chain.eq.return_value = chain
+                chain.order.return_value = chain
+                chain.execute.return_value = mock_resp
+                return chain
+
+            call_count["n"] += 1
+            call_num = call_count["n"]
+
+            if call_num == 1:
+                rows = week_rows
+            elif call_num == 2:
+                rows = current_rows
+            else:
+                rows = prior_rows or []
+
+            mock_resp = Mock()
+            mock_resp.data = rows
+
+            chain = MagicMock()
+            chain.select.return_value = chain
+            chain.eq.return_value = chain
+            chain.order.return_value = chain
+            chain.limit.return_value = chain
+            chain.execute.return_value = mock_resp
+            return chain
+
+        client.table.side_effect = table_side_effect
+        return client
+
+    def test_no_data_returns_has_data_false(self):
+        """GET with no rows for a division/age_group returns has_data=False and empty list."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        client = self._make_ordered_client(week_rows=[], current_rows=[])
+
+        result = QoPRankingsDAO.get_latest_with_delta(client, division_id=1, age_group_id=2)
+
+        assert result["has_data"] is False
+        assert result["week_of"] is None
+        assert result["prior_week_of"] is None
+        assert result["rankings"] == []
+
+    def test_rank_delta_computed_correctly(self):
+        """
+        Prior rank 5, current rank 3 → rank_change = 2 (moved up).
+        Positive rank_change means the team improved its position.
+        """
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        week_rows = [
+            {"week_of": "2026-04-14"},
+            {"week_of": "2026-04-14"},
+            {"week_of": "2026-04-07"},
+            {"week_of": "2026-04-07"},
+        ]
+        current_rows = [
+            {
+                "rank": 3,
+                "team_name": "Team Alpha",
+                "team_id": 42,
+                "matches_played": 16,
+                "att_score": 89.6,
+                "def_score": 83.1,
+                "qop_score": 87.6,
+            }
+        ]
+        prior_rows = [
+            {"rank": 5, "team_name": "Team Alpha"},
+        ]
+
+        client = self._make_ordered_client(week_rows, current_rows, prior_rows)
+
+        result = QoPRankingsDAO.get_latest_with_delta(client, division_id=1, age_group_id=2)
+
+        assert result["has_data"] is True
+        assert result["week_of"] == "2026-04-14"
+        assert result["prior_week_of"] == "2026-04-07"
+        assert len(result["rankings"]) == 1
+
+        entry = result["rankings"][0]
+        assert entry["rank"] == 3
+        assert entry["rank_change"] == 2  # 5 - 3 = 2 (moved up)
+
+    def test_new_entry_no_prior_rank_change_is_none(self):
+        """New entry with no prior week data → rank_change = None."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        # Only one week available → no prior week
+        week_rows = [
+            {"week_of": "2026-04-14"},
+        ]
+        current_rows = [
+            {
+                "rank": 1,
+                "team_name": "Brand New Team",
+                "team_id": None,
+                "matches_played": 5,
+                "att_score": 70.0,
+                "def_score": 65.0,
+                "qop_score": 68.0,
+            }
+        ]
+
+        client = self._make_ordered_client(week_rows, current_rows, prior_rows=[])
+
+        result = QoPRankingsDAO.get_latest_with_delta(client, division_id=1, age_group_id=2)
+
+        assert result["has_data"] is True
+        assert result["prior_week_of"] is None
+        assert result["rankings"][0]["rank_change"] is None

--- a/backend/tests/unit/test_qop_rankings.py
+++ b/backend/tests/unit/test_qop_rankings.py
@@ -6,6 +6,9 @@ Tests:
 - get_latest_with_delta: no data returns has_data=False
 - rank delta: prior rank 5, current rank 3 → rank_change = 2 (moved up)
 - new entry with no prior week → rank_change = None
+- match preview: no QoP data → has_qop_data=False, all QoP fields null
+- match preview: QoP data available → correct ranks attached to home/away
+- match preview: teams from different divisions → has_qop_data=False
 """
 
 from unittest.mock import MagicMock, Mock, patch
@@ -256,3 +259,210 @@ class TestGetLatestWithDelta:
         assert result["has_data"] is True
         assert result["prior_week_of"] is None
         assert result["rankings"][0]["rank_change"] is None
+
+
+# ─── Match Preview QoP enrichment ──────────────────────────────────────────────
+
+def _make_preview_base(home_team_id=1, away_team_id=2):
+    """Return a minimal preview dict as returned by match_dao.get_match_preview."""
+    return {
+        "home_team_id": home_team_id,
+        "away_team_id": away_team_id,
+        "home_team_recent": [],
+        "away_team_recent": [],
+        "common_opponents": [],
+        "head_to_head": [],
+    }
+
+
+def _make_team_with_details(team_id, name, division_id, age_group_id):
+    return {
+        "id": team_id,
+        "name": name,
+        "division": {"id": division_id, "name": "Northeast"},
+        "age_group": {"id": age_group_id, "name": "U14"},
+    }
+
+
+@pytest.mark.unit
+class TestMatchPreviewQoP:
+    """Tests for QoP data enrichment on the match preview endpoint."""
+
+    def _call_preview(self, home_team_id, away_team_id, mock_match_dao, mock_team_dao, mock_qop):
+        """
+        Simulate the QoP enrichment logic from the get_match_preview endpoint
+        without spinning up the full FastAPI app.
+        """
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        preview = mock_match_dao.get_match_preview(
+            home_team_id=home_team_id,
+            away_team_id=away_team_id,
+            season_id=None,
+            age_group_id=None,
+            recent_count=5,
+        )
+
+        qop_defaults = {
+            "has_qop_data": False,
+            "home_qop_rank": None,
+            "home_qop_rank_change": None,
+            "away_qop_rank": None,
+            "away_qop_rank_change": None,
+        }
+
+        try:
+            home_team = mock_team_dao.get_team_with_details(home_team_id)
+            away_team = mock_team_dao.get_team_with_details(away_team_id)
+
+            home_division = home_team.get("division") if home_team else None
+            away_division = away_team.get("division") if away_team else None
+            home_division_id = home_division.get("id") if home_division else None
+            away_division_id = away_division.get("id") if away_division else None
+            home_age_group = home_team.get("age_group") if home_team else None
+            home_age_group_id = home_age_group.get("id") if home_age_group else None
+
+            if (
+                home_division_id is None
+                or away_division_id is None
+                or home_division_id != away_division_id
+                or home_age_group_id is None
+            ):
+                preview.update(qop_defaults)
+            else:
+                qop_data = mock_qop(mock_match_dao.client, home_division_id, home_age_group_id)
+                if not qop_data.get("has_data"):
+                    preview.update(qop_defaults)
+                else:
+                    rankings = qop_data["rankings"]
+
+                    def find_team_rank(team_id, team_name):
+                        for entry in rankings:
+                            if entry.get("team_id") == team_id:
+                                return entry["rank"], entry.get("rank_change")
+                        if team_name:
+                            for entry in rankings:
+                                if entry.get("team_name", "").lower() == team_name.lower():
+                                    return entry["rank"], entry.get("rank_change")
+                        return None, None
+
+                    home_name = home_team.get("name") if home_team else None
+                    away_name = away_team.get("name") if away_team else None
+                    home_rank, home_rank_change = find_team_rank(home_team_id, home_name)
+                    away_rank, away_rank_change = find_team_rank(away_team_id, away_name)
+
+                    preview.update({
+                        "has_qop_data": True,
+                        "home_qop_rank": home_rank,
+                        "home_qop_rank_change": home_rank_change,
+                        "away_qop_rank": away_rank,
+                        "away_qop_rank_change": away_rank_change,
+                    })
+        except Exception:
+            preview.update(qop_defaults)
+
+        return preview
+
+    def test_no_qop_data_returns_false_with_null_fields(self):
+        """When QoPRankingsDAO returns has_data=False, preview gets has_qop_data=False and null fields."""
+        home_id, away_id = 1, 2
+        mock_match_dao = MagicMock()
+        mock_match_dao.get_match_preview.return_value = _make_preview_base(home_id, away_id)
+
+        mock_team_dao = MagicMock()
+        mock_team_dao.get_team_with_details.side_effect = lambda tid: _make_team_with_details(
+            tid, f"Team {tid}", division_id=10, age_group_id=20
+        )
+
+        mock_qop = MagicMock(return_value={"has_data": False, "week_of": None, "rankings": []})
+
+        result = self._call_preview(home_id, away_id, mock_match_dao, mock_team_dao, mock_qop)
+
+        assert result["has_qop_data"] is False
+        assert result["home_qop_rank"] is None
+        assert result["home_qop_rank_change"] is None
+        assert result["away_qop_rank"] is None
+        assert result["away_qop_rank_change"] is None
+        # Existing fields still present
+        assert result["home_team_recent"] == []
+        assert result["head_to_head"] == []
+
+    def test_qop_data_attaches_correct_ranks(self):
+        """When QoP data exists, preview includes correct rank and rank_change for each team."""
+        home_id, away_id = 7, 11
+        mock_match_dao = MagicMock()
+        mock_match_dao.get_match_preview.return_value = _make_preview_base(home_id, away_id)
+
+        mock_team_dao = MagicMock()
+        mock_team_dao.get_team_with_details.side_effect = lambda tid: _make_team_with_details(
+            tid, "Home FC" if tid == home_id else "Away United", division_id=10, age_group_id=20
+        )
+
+        rankings = [
+            {"rank": 8, "team_id": home_id, "team_name": "Home FC", "rank_change": 1},
+            {"rank": 11, "team_id": away_id, "team_name": "Away United", "rank_change": 0},
+        ]
+        mock_qop = MagicMock(return_value={
+            "has_data": True,
+            "week_of": "2026-04-14",
+            "rankings": rankings,
+        })
+
+        result = self._call_preview(home_id, away_id, mock_match_dao, mock_team_dao, mock_qop)
+
+        assert result["has_qop_data"] is True
+        assert result["home_qop_rank"] == 8
+        assert result["home_qop_rank_change"] == 1
+        assert result["away_qop_rank"] == 11
+        assert result["away_qop_rank_change"] == 0
+
+    def test_different_divisions_returns_no_qop_data(self):
+        """Teams in different divisions → has_qop_data=False, no QoP lookup performed."""
+        home_id, away_id = 3, 4
+        mock_match_dao = MagicMock()
+        mock_match_dao.get_match_preview.return_value = _make_preview_base(home_id, away_id)
+
+        mock_team_dao = MagicMock()
+        # Home team in division 10, away team in division 99 (different)
+        mock_team_dao.get_team_with_details.side_effect = lambda tid: _make_team_with_details(
+            tid, f"Team {tid}", division_id=10 if tid == home_id else 99, age_group_id=20
+        )
+
+        mock_qop = MagicMock()  # Should NOT be called
+
+        result = self._call_preview(home_id, away_id, mock_match_dao, mock_team_dao, mock_qop)
+
+        assert result["has_qop_data"] is False
+        assert result["home_qop_rank"] is None
+        assert result["away_qop_rank"] is None
+        mock_qop.assert_not_called()
+
+    def test_qop_lookup_by_name_fallback(self):
+        """If team_id not in rankings, falls back to name match."""
+        home_id, away_id = 5, 6
+        mock_match_dao = MagicMock()
+        mock_match_dao.get_match_preview.return_value = _make_preview_base(home_id, away_id)
+
+        mock_team_dao = MagicMock()
+        mock_team_dao.get_team_with_details.side_effect = lambda tid: _make_team_with_details(
+            tid, "Alpha FC" if tid == home_id else "Beta SC", division_id=10, age_group_id=20
+        )
+
+        # Rankings have team_id=None (name-only entries, as can happen with unresolved teams)
+        rankings = [
+            {"rank": 3, "team_id": None, "team_name": "Alpha FC", "rank_change": 2},
+            {"rank": 7, "team_id": None, "team_name": "Beta SC", "rank_change": -1},
+        ]
+        mock_qop = MagicMock(return_value={
+            "has_data": True,
+            "week_of": "2026-04-14",
+            "rankings": rankings,
+        })
+
+        result = self._call_preview(home_id, away_id, mock_match_dao, mock_team_dao, mock_qop)
+
+        assert result["has_qop_data"] is True
+        assert result["home_qop_rank"] == 3
+        assert result["home_qop_rank_change"] == 2
+        assert result["away_qop_rank"] == 7
+        assert result["away_qop_rank_change"] == -1

--- a/backend/tests/unit/test_table_qop_integration.py
+++ b/backend/tests/unit/test_table_qop_integration.py
@@ -1,0 +1,319 @@
+"""
+Unit tests for the /api/table endpoint QoP enrichment logic.
+
+Tests:
+- With no QoP data: has_qop_data=False and qop_rank=null on all standings rows
+- With QoP data: correct qop_rank attached to matching teams by team_name
+- With QoP data: team_id lookup takes priority over team_name lookup
+- QoP exception: gracefully degrades — has_qop_data=False, qop_rank=null on all rows
+
+These tests exercise the enrichment logic in isolation using the same
+helper pattern as test_qop_rankings.py (mock Supabase client).
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+# ─── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_qop_client_with_data(week_rows, current_rows, prior_rows=None):
+    """
+    Build a mock Supabase client whose qop_rankings table returns responses
+    in sequence: weeks query → current-week rows → prior-week rows.
+    """
+    client = MagicMock()
+    call_count = {"n": 0}
+
+    def table_side_effect(name):
+        if name != "qop_rankings":
+            mock_resp = Mock()
+            mock_resp.data = []
+            chain = MagicMock()
+            chain.select.return_value = chain
+            chain.eq.return_value = chain
+            chain.order.return_value = chain
+            chain.execute.return_value = mock_resp
+            return chain
+
+        call_count["n"] += 1
+        call_num = call_count["n"]
+
+        if call_num == 1:
+            rows = week_rows
+        elif call_num == 2:
+            rows = current_rows
+        else:
+            rows = prior_rows or []
+
+        mock_resp = Mock()
+        mock_resp.data = rows
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.order.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = mock_resp
+        return chain
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+def _make_standings_row(team_name: str, team_id: int | None = None) -> dict:
+    """Return a minimal standings row as produced by calculate_standings_with_extras."""
+    return {
+        "team": team_name,
+        "team_id": team_id,
+        "played": 10,
+        "wins": 5,
+        "draws": 2,
+        "losses": 3,
+        "goals_for": 20,
+        "goals_against": 15,
+        "goal_difference": 5,
+        "points": 17,
+        "form": ["W", "D", "L", "W", "W"],
+        "position_change": 0,
+    }
+
+
+# ─── QoP enrichment: no data ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestTableQoPNoData:
+    """When QoPRankingsDAO returns has_data=False, all qop_rank fields are null."""
+
+    def test_no_qop_data_sets_nulls_on_all_rows(self):
+        """
+        Given a Supabase client with no qop_rankings rows,
+        enriching standings rows sets qop_rank and qop_rank_change to None.
+        """
+        from dao.qop_rankings_dao import QoPRankingsDAO
+
+        client = _make_qop_client_with_data(week_rows=[], current_rows=[])
+
+        qop_data = QoPRankingsDAO.get_latest_with_delta(client, division_id=1, age_group_id=2)
+
+        assert qop_data["has_data"] is False
+        assert qop_data["week_of"] is None
+        assert qop_data["rankings"] == []
+
+        # Simulate what the endpoint does when has_data is False
+        table = [
+            _make_standings_row("Team Alpha"),
+            _make_standings_row("Team Beta"),
+        ]
+        for row in table:
+            row["qop_rank"] = None
+            row["qop_rank_change"] = None
+
+        for row in table:
+            assert row["qop_rank"] is None
+            assert row["qop_rank_change"] is None
+
+
+# ─── QoP enrichment: matching by team_name ─────────────────────────────────
+
+
+@pytest.mark.unit
+class TestTableQoPByTeamName:
+    """When QoP data is present, qop_rank is attached by matching team_name."""
+
+    def test_qop_rank_attached_to_matching_team(self):
+        """
+        NEFC appears in both standings (team_name) and QoP rankings (team_name);
+        enrichment attaches the correct qop_rank and qop_rank_change.
+        """
+        from dao.qop_rankings_dao import QoPRankingsDAO
+
+        week_rows = [
+            {"week_of": "2026-04-14"},
+            {"week_of": "2026-04-07"},
+        ]
+        current_rows = [
+            {
+                "rank": 11,
+                "team_name": "NEFC",
+                "team_id": 7,
+                "matches_played": 18,
+                "att_score": 80.0,
+                "def_score": 75.0,
+                "qop_score": 78.0,
+            },
+            {
+                "rank": 12,
+                "team_name": "Other Club",
+                "team_id": None,
+                "matches_played": 16,
+                "att_score": 70.0,
+                "def_score": 65.0,
+                "qop_score": 68.0,
+            },
+        ]
+        prior_rows = [
+            {"rank": 11, "team_name": "NEFC"},
+            {"rank": 10, "team_name": "Other Club"},
+        ]
+
+        client = _make_qop_client_with_data(week_rows, current_rows, prior_rows)
+        qop_data = QoPRankingsDAO.get_latest_with_delta(client, division_id=1, age_group_id=2)
+
+        assert qop_data["has_data"] is True
+        assert qop_data["week_of"] == "2026-04-14"
+
+        # Build lookups (mirrors endpoint logic)
+        qop_by_team_id: dict[int, dict] = {}
+        qop_by_team_name: dict[str, dict] = {}
+        for entry in qop_data["rankings"]:
+            tid = entry.get("team_id")
+            if tid is not None:
+                qop_by_team_id[tid] = entry
+            tname = entry.get("team_name", "")
+            if tname:
+                qop_by_team_name[tname.lower()] = entry
+
+        table = [
+            _make_standings_row("NEFC", team_id=None),   # no team_id — must match by name
+            _make_standings_row("No Match Team"),
+        ]
+
+        for row in table:
+            qop_entry = None
+            row_team_id = row.get("team_id")
+            if row_team_id is not None:
+                qop_entry = qop_by_team_id.get(row_team_id)
+            if qop_entry is None:
+                row_team_name = (row.get("team") or "").lower()
+                qop_entry = qop_by_team_name.get(row_team_name)
+            row["qop_rank"] = qop_entry["rank"] if qop_entry else None
+            row["qop_rank_change"] = qop_entry["rank_change"] if qop_entry else None
+
+        nefc_row = table[0]
+        assert nefc_row["qop_rank"] == 11
+        assert nefc_row["qop_rank_change"] == 0  # prior 11 - current 11 = 0
+
+        no_match_row = table[1]
+        assert no_match_row["qop_rank"] is None
+        assert no_match_row["qop_rank_change"] is None
+
+    def test_team_id_lookup_takes_priority_over_name(self):
+        """
+        When a standings row has team_id=7 and the QoP entry has team_id=7,
+        the match is made via team_id even if team_name differs.
+        """
+        from dao.qop_rankings_dao import QoPRankingsDAO
+
+        week_rows = [{"week_of": "2026-04-14"}]
+        current_rows = [
+            {
+                "rank": 3,
+                "team_name": "NEFC Academy",
+                "team_id": 7,
+                "matches_played": 18,
+                "att_score": 85.0,
+                "def_score": 80.0,
+                "qop_score": 83.0,
+            }
+        ]
+
+        client = _make_qop_client_with_data(week_rows, current_rows, prior_rows=[])
+        qop_data = QoPRankingsDAO.get_latest_with_delta(client, division_id=1, age_group_id=2)
+
+        assert qop_data["has_data"] is True
+
+        # Build lookups
+        qop_by_team_id: dict[int, dict] = {}
+        qop_by_team_name: dict[str, dict] = {}
+        for entry in qop_data["rankings"]:
+            tid = entry.get("team_id")
+            if tid is not None:
+                qop_by_team_id[tid] = entry
+            tname = entry.get("team_name", "")
+            if tname:
+                qop_by_team_name[tname.lower()] = entry
+
+        # Standings row uses a slightly different name but has team_id=7
+        table = [_make_standings_row("NEFC", team_id=7)]
+
+        for row in table:
+            qop_entry = None
+            row_team_id = row.get("team_id")
+            if row_team_id is not None:
+                qop_entry = qop_by_team_id.get(row_team_id)
+            if qop_entry is None:
+                row_team_name = (row.get("team") or "").lower()
+                qop_entry = qop_by_team_name.get(row_team_name)
+            row["qop_rank"] = qop_entry["rank"] if qop_entry else None
+            row["qop_rank_change"] = qop_entry["rank_change"] if qop_entry else None
+
+        assert table[0]["qop_rank"] == 3
+        # No prior week so rank_change is None
+        assert table[0]["qop_rank_change"] is None
+
+    def test_case_insensitive_team_name_match(self):
+        """Team name comparison is case-insensitive (QoP 'NEFC' matches standings 'nefc')."""
+        qop_rankings = [
+            {"rank": 5, "team_name": "NEFC", "team_id": None, "rank_change": 1}
+        ]
+
+        qop_by_team_name: dict[str, dict] = {}
+        for entry in qop_rankings:
+            tname = entry.get("team_name", "")
+            if tname:
+                qop_by_team_name[tname.lower()] = entry
+
+        # Standings row has lowercase name
+        table = [_make_standings_row("nefc")]
+        for row in table:
+            row_team_name = (row.get("team") or "").lower()
+            qop_entry = qop_by_team_name.get(row_team_name)
+            row["qop_rank"] = qop_entry["rank"] if qop_entry else None
+            row["qop_rank_change"] = qop_entry["rank_change"] if qop_entry else None
+
+        assert table[0]["qop_rank"] == 5
+        assert table[0]["qop_rank_change"] == 1
+
+
+# ─── QoP enrichment: missing division_id or age_group_id ───────────────────
+
+
+@pytest.mark.unit
+class TestTableQoPMissingParams:
+    """When division_id or age_group_id is absent, QoP enrichment is skipped."""
+
+    def test_no_division_id_all_null(self):
+        """Without division_id, all qop fields are null (no DAO call needed)."""
+        table = [
+            _make_standings_row("Team A"),
+            _make_standings_row("Team B"),
+        ]
+        # Simulates the else branch: division_id is None
+        division_id = None
+        age_group_id = 2
+
+        if not (division_id and age_group_id):
+            for row in table:
+                row["qop_rank"] = None
+                row["qop_rank_change"] = None
+
+        for row in table:
+            assert row["qop_rank"] is None
+            assert row["qop_rank_change"] is None
+
+    def test_no_age_group_id_all_null(self):
+        """Without age_group_id, all qop fields are null."""
+        table = [_make_standings_row("Team A")]
+        division_id = 1
+        age_group_id = None
+
+        if not (division_id and age_group_id):
+            for row in table:
+                row["qop_rank"] = None
+                row["qop_rank_change"] = None
+
+        assert table[0]["qop_rank"] is None
+        assert table[0]["qop_rank_change"] is None

--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -211,6 +211,9 @@
             >
               Form
             </th>
+            <th v-if="hasQopData" class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider">
+              <span title="Quality of Play rank — updated weekly by MLS Next">QoP</span>
+            </th>
           </tr>
         </thead>
         <tbody
@@ -320,6 +323,15 @@
                 </span>
               </div>
             </td>
+            <td v-if="hasQopData" class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center">
+              <template v-if="team.qop_rank != null">
+                <span class="font-medium">#{{ team.qop_rank }}</span>
+                <span v-if="team.qop_rank_change > 0" class="ml-1 text-xs text-green-600">▲{{ team.qop_rank_change }}</span>
+                <span v-else-if="team.qop_rank_change < 0" class="ml-1 text-xs text-red-600">▼{{ Math.abs(team.qop_rank_change) }}</span>
+                <span v-else class="ml-1 text-xs text-gray-400">—</span>
+              </template>
+              <span v-else class="text-gray-400">—</span>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -370,6 +382,10 @@ export default {
     const selectedSeasonId = ref(2); // Default to 2024-2025
     const error = ref(null);
     const loading = ref(true);
+
+    // QoP state
+    const hasQopData = ref(false);
+    const qopWeekOf = ref(null);
 
     // Playoff bracket state
     const bracketExists = ref(false);
@@ -548,7 +564,17 @@ export default {
         const data = await authStore.apiRequest(url);
         console.log('Table data received:', data);
 
-        tableData.value = data;
+        // Unwrap new response shape: { has_qop_data, qop_week_of, standings: [...] }
+        if (data && typeof data === 'object' && 'standings' in data) {
+          tableData.value = data.standings;
+          hasQopData.value = data.has_qop_data ?? false;
+          qopWeekOf.value = data.qop_week_of ?? null;
+        } else {
+          // Fallback for bare-array responses (backwards compat)
+          tableData.value = data;
+          hasQopData.value = false;
+          qopWeekOf.value = null;
+        }
         console.log('Table data set:', tableData.value);
       } catch (err) {
         console.error('Error fetching table data:', err);
@@ -700,6 +726,8 @@ export default {
 
     return {
       tableData,
+      hasQopData,
+      qopWeekOf,
       ageGroups,
       leagues,
       divisions,

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -96,10 +96,16 @@
           <!-- Home team column -->
           <div>
             <h3
-              class="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2 truncate"
+              class="text-xs font-semibold text-slate-400 uppercase tracking-wide truncate"
+              :class="preview.has_qop_data && preview.home_qop_rank != null ? 'mb-0.5' : 'mb-2'"
             >
               {{ homeTeamName }}
             </h3>
+            <div v-if="preview.has_qop_data && preview.home_qop_rank != null" class="text-xs text-slate-500 mb-2">
+              QoP <span class="font-medium text-slate-400">#{{ preview.home_qop_rank }}</span>
+              <span v-if="preview.home_qop_rank_change > 0" class="text-green-500 ml-1">▲{{ preview.home_qop_rank_change }}</span>
+              <span v-else-if="preview.home_qop_rank_change < 0" class="text-red-500 ml-1">▼{{ Math.abs(preview.home_qop_rank_change) }}</span>
+            </div>
             <div
               v-if="preview.home_team_recent.length === 0"
               class="text-xs text-slate-500 italic"
@@ -136,10 +142,16 @@
           <!-- Away team column -->
           <div>
             <h3
-              class="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2 truncate"
+              class="text-xs font-semibold text-slate-400 uppercase tracking-wide truncate"
+              :class="preview.has_qop_data && preview.away_qop_rank != null ? 'mb-0.5' : 'mb-2'"
             >
               {{ awayTeamName }}
             </h3>
+            <div v-if="preview.has_qop_data && preview.away_qop_rank != null" class="text-xs text-slate-500 mb-2">
+              QoP <span class="font-medium text-slate-400">#{{ preview.away_qop_rank }}</span>
+              <span v-if="preview.away_qop_rank_change > 0" class="text-green-500 ml-1">▲{{ preview.away_qop_rank_change }}</span>
+              <span v-else-if="preview.away_qop_rank_change < 0" class="text-red-500 ml-1">▼{{ Math.abs(preview.away_qop_rank_change) }}</span>
+            </div>
             <div
               v-if="preview.away_team_recent.length === 0"
               class="text-xs text-slate-500 italic"
@@ -506,6 +518,11 @@ async function fetchPreview() {
         ? data.common_opponents
         : [],
       head_to_head: Array.isArray(data?.head_to_head) ? data.head_to_head : [],
+      has_qop_data: data?.has_qop_data ?? false,
+      home_qop_rank: data?.home_qop_rank ?? null,
+      home_qop_rank_change: data?.home_qop_rank_change ?? null,
+      away_qop_rank: data?.away_qop_rank ?? null,
+      away_qop_rank_change: data?.away_qop_rank_change ?? null,
     };
 
     // Auto-select the tab with the most content

--- a/supabase-local/migrations/20260416000001_add_qop_rankings.sql
+++ b/supabase-local/migrations/20260416000001_add_qop_rankings.sql
@@ -1,0 +1,23 @@
+-- Quality of Play rankings scraped weekly from MLS Next standings page
+CREATE TABLE qop_rankings (
+    id SERIAL PRIMARY KEY,
+    week_of DATE NOT NULL,
+    division_id INTEGER NOT NULL REFERENCES divisions(id),
+    age_group_id INTEGER NOT NULL REFERENCES age_groups(id),
+    rank INTEGER NOT NULL CHECK (rank >= 1),
+    team_name TEXT NOT NULL,
+    team_id INTEGER REFERENCES teams(id),
+    matches_played INTEGER,
+    att_score NUMERIC(5,1),
+    def_score NUMERIC(5,1),
+    qop_score NUMERIC(5,1) NOT NULL,
+    scraped_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (week_of, division_id, age_group_id, rank)
+);
+
+CREATE INDEX idx_qop_rankings_lookup
+    ON qop_rankings (division_id, age_group_id, week_of DESC);
+
+ALTER TABLE qop_rankings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "qop_rankings_select" ON qop_rankings
+    FOR SELECT USING (true);

--- a/supabase/migrations/20260416000001_add_qop_rankings.sql
+++ b/supabase/migrations/20260416000001_add_qop_rankings.sql
@@ -1,0 +1,23 @@
+-- Quality of Play rankings scraped weekly from MLS Next standings page
+CREATE TABLE qop_rankings (
+    id SERIAL PRIMARY KEY,
+    week_of DATE NOT NULL,
+    division_id INTEGER NOT NULL REFERENCES divisions(id),
+    age_group_id INTEGER NOT NULL REFERENCES age_groups(id),
+    rank INTEGER NOT NULL CHECK (rank >= 1),
+    team_name TEXT NOT NULL,
+    team_id INTEGER REFERENCES teams(id),
+    matches_played INTEGER,
+    att_score NUMERIC(5,1),
+    def_score NUMERIC(5,1),
+    qop_score NUMERIC(5,1) NOT NULL,
+    scraped_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (week_of, division_id, age_group_id, rank)
+);
+
+CREATE INDEX idx_qop_rankings_lookup
+    ON qop_rankings (division_id, age_group_id, week_of DESC);
+
+ALTER TABLE qop_rankings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "qop_rankings_select" ON qop_rankings
+    FOR SELECT USING (true);


### PR DESCRIPTION
## Summary
- Adds `qop_rankings` Supabase table migration (with RLS, unique constraint, and index)
- Adds `QoPRankingsDAO` and two new API endpoints: `POST /api/qop-rankings` (ingest) and `GET /api/qop-rankings` (latest with week-over-week rank delta)
- Extends `GET /api/table` to include `qop_rank` and `qop_rank_change` per team when QoP data exists for the selected division
- Extends `GET /api/matches/preview/{home}/{away}` to include `home_qop_rank`, `away_qop_rank`, and change indicators
- Updates `LeagueTable.vue` with a conditional QoP column (hidden when no data for selected division)
- Updates `MatchPreview.vue` with subtle QoP rank badges in each team's header

## Issues closed
Closes #297, #298, #299, #300, #301, #302

## Test plan
- [ ] Run migration locally: `supabase db push`
- [ ] Unit tests pass: `pytest backend/tests/`
- [ ] `GET /api/qop-rankings?division_id=X&age_group_id=Y` returns `has_data: false` before any data is ingested
- [ ] After a `mls-scraper rankings` POST, `GET /api/qop-rankings` returns rankings with correct data
- [ ] `GET /api/table` for U14 Northeast shows QoP column; other divisions do not
- [ ] `LeagueTable.vue` QoP column appears/disappears correctly based on `has_qop_data`
- [ ] `MatchPreview.vue` shows QoP badges for U14 Northeast matches, absent for others

## Merge order
Merge after `match-scraper` PR. Apply Supabase migration before deploying backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)