### PR TITLE
fix: correct Valeo U14 division data and season summary filtering

### DIFF
--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -575,8 +575,9 @@ class MatchDAO(BaseDAO):
                 match_type:match_types(id, name),
                 division:divisions(id, name)
             """)
-                .or_(f"home_team_id.eq.{team_id},away_team_id.eq.{team_id}")
             )
+
+            query = query.or_(f"home_team_id.eq.{team_id},away_team_id.eq.{team_id}")
 
             if season_id:
                 query = query.eq("season_id", season_id)

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -2824,6 +2824,13 @@ export default {
         );
       }
 
+      // Apply division filter so season summary is consistent with the displayed match list
+      if (selectedDivisionId.value !== null) {
+        sortedGames = sortedGames.filter(
+          match => match.division_id === selectedDivisionId.value
+        );
+      }
+
       sortedGames = sortedGames.sort((a, b) => {
         const dateDiff = new Date(a.match_date) - new Date(b.match_date);
         if (dateDiff !== 0) return dateDiff;


### PR DESCRIPTION
## Summary

- **Data fix (prod DB, applied directly):** Reassigned 19 New England division U14 matches from team 27 (Valeo Futbol Club / Homegrown Northeast) to team 179 (Valeo Futbol Club Academy). The match-scraper was resolving 'Valeo Futbol Club' by name and always matching team 27 regardless of league/division context, causing the HG team's match page to show matches from both divisions and inflate GP from 14 to 26.
- **Frontend fix:** `seasonStats` in `MatchesView.vue` now applies `selectedDivisionId` filter so the Season Summary (GP/W/D/L) is always consistent with the division tab currently selected.

## Root Cause

The match-scraper performs team resolution by name only. Since both the HG Northeast team (27) and the Academy/New England team (179) are named "Valeo Futbol Club", all matches were assigned to team 27. The `team_mappings` table correctly mapped team 179 to the New England division but the scraper never used it.

## Test plan

- [ ] Navigate to Matches → My Club → Valeo Futbol Club (Homegrown - Northeast) → U14 → League
- [ ] Confirm only Northeast division matches appear (no New England tab)
- [ ] Confirm Season Summary shows 14 GP (not 26)
- [ ] Navigate to Valeo Futbol Club Academy → U14 → confirm 19 New England matches appear
- [ ] Select a division tab and verify Season Summary updates to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)