### PR TITLE
feat: QoP standings tab for Homegrown U13/U14 divisions

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -90,10 +90,10 @@ from dao.match_type_dao import MatchTypeDAO
 from dao.player_dao import PlayerDAO
 from dao.player_stats_dao import PlayerStatsDAO
 from dao.playoff_dao import PlayoffDAO
+from dao.qop_rankings_dao import QoPRankingsDAO
 from dao.roster_dao import RosterDAO
 from dao.season_dao import SeasonDAO
 from dao.team_dao import TeamDAO
-from dao.qop_rankings_dao import QoPRankingsDAO
 from dao.tournament_dao import TournamentDAO
 
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -382,6 +382,11 @@
             <GoalsLeaderboard />
           </div>
 
+          <!-- QoP Rankings -->
+          <div v-if="currentTab === 'qop'" class="p-4">
+            <QoPStandings />
+          </div>
+
           <!-- Add Match Form (auth required) -->
           <div v-if="currentTab === 'add-match'" class="p-4">
             <div v-if="!authStore.isAuthenticated" class="auth-required">
@@ -488,6 +493,7 @@ import ProfileRouter from './components/ProfileRouter.vue';
 import TeamRosterRouter from './components/profiles/TeamRosterRouter.vue';
 import AdminPanel from './components/AdminPanel.vue';
 import TournamentMatchCenter from './components/TournamentMatchCenter.vue';
+import QoPStandings from './components/QoPStandings.vue';
 import VersionFooter from './components/VersionFooter.vue';
 import { LiveMatchView } from './components/live';
 
@@ -506,6 +512,7 @@ export default {
     TeamRosterRouter,
     AdminPanel,
     TournamentMatchCenter,
+    QoPStandings,
     VersionFooter,
     LiveMatchView,
   },
@@ -586,6 +593,7 @@ export default {
       { id: 'scores', name: 'Matches', requiresAuth: true },
       { id: 'match-center', name: 'Tournaments', requiresAuth: true },
       { id: 'leaderboard', name: 'Leaderboard', requiresAuth: true },
+      { id: 'qop', name: 'QoP', requiresAuth: true },
       {
         id: 'add-match',
         name: 'Add Match',

--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -211,8 +211,13 @@
             >
               Form
             </th>
-            <th v-if="hasQopData" class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider">
-              <span title="Quality of Play rank — updated weekly by MLS Next">QoP</span>
+            <th
+              v-if="hasQopData"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+            >
+              <span title="Quality of Play rank — updated weekly by MLS Next"
+                >QoP</span
+              >
             </th>
           </tr>
         </thead>
@@ -323,11 +328,22 @@
                 </span>
               </div>
             </td>
-            <td v-if="hasQopData" class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center">
+            <td
+              v-if="hasQopData"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center"
+            >
               <template v-if="team.qop_rank != null">
                 <span class="font-medium">#{{ team.qop_rank }}</span>
-                <span v-if="team.qop_rank_change > 0" class="ml-1 text-xs text-green-600">▲{{ team.qop_rank_change }}</span>
-                <span v-else-if="team.qop_rank_change < 0" class="ml-1 text-xs text-red-600">▼{{ Math.abs(team.qop_rank_change) }}</span>
+                <span
+                  v-if="team.qop_rank_change > 0"
+                  class="ml-1 text-xs text-green-600"
+                  >▲{{ team.qop_rank_change }}</span
+                >
+                <span
+                  v-else-if="team.qop_rank_change < 0"
+                  class="ml-1 text-xs text-red-600"
+                  >▼{{ Math.abs(team.qop_rank_change) }}</span
+                >
                 <span v-else class="ml-1 text-xs text-gray-400">—</span>
               </template>
               <span v-else class="text-gray-400">—</span>

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -97,14 +97,32 @@
           <div>
             <h3
               class="text-xs font-semibold text-slate-400 uppercase tracking-wide truncate"
-              :class="preview.has_qop_data && preview.home_qop_rank != null ? 'mb-0.5' : 'mb-2'"
+              :class="
+                preview.has_qop_data && preview.home_qop_rank != null
+                  ? 'mb-0.5'
+                  : 'mb-2'
+              "
             >
               {{ homeTeamName }}
             </h3>
-            <div v-if="preview.has_qop_data && preview.home_qop_rank != null" class="text-xs text-slate-500 mb-2">
-              QoP <span class="font-medium text-slate-400">#{{ preview.home_qop_rank }}</span>
-              <span v-if="preview.home_qop_rank_change > 0" class="text-green-500 ml-1">▲{{ preview.home_qop_rank_change }}</span>
-              <span v-else-if="preview.home_qop_rank_change < 0" class="text-red-500 ml-1">▼{{ Math.abs(preview.home_qop_rank_change) }}</span>
+            <div
+              v-if="preview.has_qop_data && preview.home_qop_rank != null"
+              class="text-xs text-slate-500 mb-2"
+            >
+              QoP
+              <span class="font-medium text-slate-400"
+                >#{{ preview.home_qop_rank }}</span
+              >
+              <span
+                v-if="preview.home_qop_rank_change > 0"
+                class="text-green-500 ml-1"
+                >▲{{ preview.home_qop_rank_change }}</span
+              >
+              <span
+                v-else-if="preview.home_qop_rank_change < 0"
+                class="text-red-500 ml-1"
+                >▼{{ Math.abs(preview.home_qop_rank_change) }}</span
+              >
             </div>
             <div
               v-if="preview.home_team_recent.length === 0"
@@ -143,14 +161,32 @@
           <div>
             <h3
               class="text-xs font-semibold text-slate-400 uppercase tracking-wide truncate"
-              :class="preview.has_qop_data && preview.away_qop_rank != null ? 'mb-0.5' : 'mb-2'"
+              :class="
+                preview.has_qop_data && preview.away_qop_rank != null
+                  ? 'mb-0.5'
+                  : 'mb-2'
+              "
             >
               {{ awayTeamName }}
             </h3>
-            <div v-if="preview.has_qop_data && preview.away_qop_rank != null" class="text-xs text-slate-500 mb-2">
-              QoP <span class="font-medium text-slate-400">#{{ preview.away_qop_rank }}</span>
-              <span v-if="preview.away_qop_rank_change > 0" class="text-green-500 ml-1">▲{{ preview.away_qop_rank_change }}</span>
-              <span v-else-if="preview.away_qop_rank_change < 0" class="text-red-500 ml-1">▼{{ Math.abs(preview.away_qop_rank_change) }}</span>
+            <div
+              v-if="preview.has_qop_data && preview.away_qop_rank != null"
+              class="text-xs text-slate-500 mb-2"
+            >
+              QoP
+              <span class="font-medium text-slate-400"
+                >#{{ preview.away_qop_rank }}</span
+              >
+              <span
+                v-if="preview.away_qop_rank_change > 0"
+                class="text-green-500 ml-1"
+                >▲{{ preview.away_qop_rank_change }}</span
+              >
+              <span
+                v-else-if="preview.away_qop_rank_change < 0"
+                class="text-red-500 ml-1"
+                >▼{{ Math.abs(preview.away_qop_rank_change) }}</span
+              >
             </div>
             <div
               v-if="preview.away_team_recent.length === 0"

--- a/frontend/src/components/QoPStandings.vue
+++ b/frontend/src/components/QoPStandings.vue
@@ -1,0 +1,279 @@
+<template>
+  <div>
+    <!-- Header -->
+    <div class="mb-6">
+      <h2 class="text-lg font-semibold text-gray-800">
+        Quality of Play Rankings
+      </h2>
+      <p class="text-sm text-gray-500 mt-1">
+        Homegrown · Updated weekly by MLS Next
+      </p>
+    </div>
+
+    <!-- Filters -->
+    <div class="mb-6 space-y-3">
+      <!-- Division -->
+      <div>
+        <h3 class="text-sm font-medium text-gray-700 mb-2">Division</h3>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="div in homegrownDivisions"
+            :key="div.id"
+            @click="selectedDivisionId = div.id"
+            :class="[
+              'px-4 py-2 text-sm rounded-lg font-medium transition-colors',
+              selectedDivisionId === div.id
+                ? 'bg-brand-500 text-white shadow-sm'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+            ]"
+          >
+            {{ div.name }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Age Group -->
+      <div>
+        <h3 class="text-sm font-medium text-gray-700 mb-2">Age Group</h3>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="ag in qopAgeGroups"
+            :key="ag.id"
+            @click="selectedAgeGroupId = ag.id"
+            :class="[
+              'px-4 py-2 text-sm rounded-lg font-medium transition-colors',
+              selectedAgeGroupId === ag.id
+                ? 'bg-brand-500 text-white shadow-sm'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+            ]"
+          >
+            {{ ag.name }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-center py-8 text-gray-500">
+      Loading QoP rankings...
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="text-center py-8 text-red-600">
+      {{ error }}
+    </div>
+
+    <!-- No data -->
+    <div v-else-if="!rankings.length" class="text-center py-8 text-gray-500">
+      No QoP rankings available yet for this age group.
+    </div>
+
+    <!-- Rankings Table -->
+    <div v-else class="overflow-x-auto">
+      <div v-if="weekOf" class="text-xs text-gray-400 mb-2">
+        Week of {{ weekOf
+        }}<span v-if="priorWeekOf">
+          &nbsp;·&nbsp; Prior week: {{ priorWeekOf }}</span
+        >
+      </div>
+
+      <table class="min-w-full divide-y divide-slate-200">
+        <thead class="bg-brand-500">
+          <tr>
+            <th
+              class="px-3 py-3 text-left text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              title="Rank"
+            >
+              #
+            </th>
+            <th
+              class="px-3 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              title="Rank change from prior week"
+            >
+              +/-
+            </th>
+            <th
+              class="px-4 py-3 text-left text-xs font-semibold text-slate-300 uppercase tracking-wider"
+            >
+              Team
+            </th>
+            <th
+              class="px-4 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              title="Matches Played"
+            >
+              MP
+            </th>
+            <th
+              class="hidden sm:table-cell px-4 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              title="Attacking Score"
+            >
+              ATT
+            </th>
+            <th
+              class="hidden sm:table-cell px-4 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              title="Defensive Score"
+            >
+              DEF
+            </th>
+            <th
+              class="px-4 py-3 text-center text-xs font-semibold text-brand-200 uppercase tracking-wider"
+              title="Quality of Play Score"
+            >
+              QoP
+            </th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-slate-100">
+          <tr
+            v-for="entry in rankings"
+            :key="entry.rank"
+            class="hover:bg-slate-50 transition-colors"
+          >
+            <td class="px-3 py-3 text-sm text-gray-500">
+              {{ entry.rank }}
+            </td>
+            <td class="px-3 py-3 text-xs text-center">
+              <span
+                v-if="entry.rank_change > 0"
+                class="text-green-600 font-medium"
+                :title="`Up ${entry.rank_change}`"
+              >
+                ▲{{ entry.rank_change }}
+              </span>
+              <span
+                v-else-if="entry.rank_change < 0"
+                class="text-red-600 font-medium"
+                :title="`Down ${Math.abs(entry.rank_change)}`"
+              >
+                ▼{{ Math.abs(entry.rank_change) }}
+              </span>
+              <span v-else class="text-gray-400">—</span>
+            </td>
+            <td class="px-4 py-3 text-sm font-medium text-gray-900">
+              {{ entry.team_name }}
+            </td>
+            <td class="px-4 py-3 text-sm text-center text-gray-500">
+              {{ entry.matches_played ?? '—' }}
+            </td>
+            <td
+              class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
+            >
+              {{ entry.att_score != null ? entry.att_score.toFixed(1) : '—' }}
+            </td>
+            <td
+              class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
+            >
+              {{ entry.def_score != null ? entry.def_score.toFixed(1) : '—' }}
+            </td>
+            <td class="px-4 py-3 text-sm text-center font-bold text-brand-600">
+              {{ entry.qop_score != null ? entry.qop_score.toFixed(1) : '—' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, watch } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+
+export default {
+  name: 'QoPStandings',
+  setup() {
+    const authStore = useAuthStore();
+
+    const homegrownDivisions = ref([]);
+    const selectedDivisionId = ref(null);
+    const qopAgeGroups = ref([]);
+    const selectedAgeGroupId = ref(null);
+
+    const rankings = ref([]);
+    const weekOf = ref(null);
+    const priorWeekOf = ref(null);
+    const loading = ref(false);
+    const error = ref(null);
+
+    const resolveIds = async () => {
+      const [ageGroupsData, divisionsData, leaguesData] = await Promise.all([
+        authStore.apiRequest(`${getApiBaseUrl()}/api/age-groups`),
+        authStore.apiRequest(`${getApiBaseUrl()}/api/divisions`),
+        authStore.apiRequest(`${getApiBaseUrl()}/api/leagues`),
+      ]);
+
+      const homegrown = leaguesData.find(l => l.name === 'Homegrown');
+      if (!homegrown) {
+        error.value = 'Homegrown league not found.';
+        return false;
+      }
+
+      const divs = divisionsData
+        .filter(d => Number(d.league_id) === Number(homegrown.id))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      if (!divs.length) {
+        error.value = 'No divisions found for Homegrown league.';
+        return false;
+      }
+      homegrownDivisions.value = divs;
+
+      const northeast = divs.find(d => d.name === 'Northeast');
+      selectedDivisionId.value = northeast ? northeast.id : divs[0].id;
+
+      const relevant = ageGroupsData
+        .filter(ag => ag.name === 'U13' || ag.name === 'U14')
+        .sort((a, b) => a.name.localeCompare(b.name));
+      qopAgeGroups.value = relevant;
+
+      const u14 = relevant.find(ag => ag.name === 'U14');
+      selectedAgeGroupId.value = u14 ? u14.id : (relevant[0]?.id ?? null);
+
+      return true;
+    };
+
+    const fetchRankings = async () => {
+      if (!selectedAgeGroupId.value || !selectedDivisionId.value) return;
+
+      loading.value = true;
+      error.value = null;
+
+      try {
+        const params = new URLSearchParams({
+          division_id: selectedDivisionId.value,
+          age_group_id: selectedAgeGroupId.value,
+        });
+        const data = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/qop-rankings?${params}`
+        );
+        rankings.value = data.rankings ?? [];
+        weekOf.value = data.week_of ?? null;
+        priorWeekOf.value = data.prior_week_of ?? null;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    watch([selectedAgeGroupId, selectedDivisionId], fetchRankings);
+
+    onMounted(async () => {
+      const ok = await resolveIds();
+      if (ok) await fetchRankings();
+    });
+
+    return {
+      homegrownDivisions,
+      selectedDivisionId,
+      qopAgeGroups,
+      selectedAgeGroupId,
+      rankings,
+      weekOf,
+      priorWeekOf,
+      loading,
+      error,
+    };
+  },
+};
+</script>


### PR DESCRIPTION
## Summary

- Adds a new **QoP** tab (visible to all authenticated users) with a dedicated `QoPStandings.vue` component
- Dynamically loads all divisions under the Homegrown league — Northeast and Florida (and any future ones) appear automatically
- Division + age group selectors (U13/U14); defaults to Northeast / U14
- Fetches from the existing `/api/qop-rankings` endpoint; shows rank, +/- week-over-week change, team, MP, ATT, DEF, QoP score with the week-of date
- Tab visibility can be gated by role later via the existing `requiresRole` mechanism in `availableTabs`

## Test plan

- [ ] Log in and confirm **QoP** tab appears in the nav
- [ ] Confirm division buttons show Northeast (and Florida once data is loaded)
- [ ] Confirm U13/U14 toggle re-fetches rankings
- [ ] Confirm empty state shows gracefully for divisions/age groups with no data yet
- [ ] Confirm existing tabs (Table, Matches, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)