### PR TITLE
feat: QoP standings — point delta, qualification zones, Salt Lake City cutoff

### DIFF
--- a/backend/dao/qop_rankings_dao.py
+++ b/backend/dao/qop_rankings_dao.py
@@ -344,21 +344,30 @@ class QoPRankingsDAO:
             current_rows = current_rows_resp.data or []
 
             prior_rank_by_team: dict[str, int] = {}
+            prior_qop_by_team: dict[str, float] = {}
             if prior is not None:
                 prior_rows_resp = (
                     client.table("qop_rankings")
-                    .select("rank, team_name")
+                    .select("rank, team_name, qop_score")
                     .eq("snapshot_id", prior["id"])
                     .execute()
                 )
                 for row in prior_rows_resp.data or []:
                     prior_rank_by_team[row["team_name"]] = row["rank"]
+                    if row.get("qop_score") is not None:
+                        prior_qop_by_team[row["team_name"]] = row["qop_score"]
 
             rankings = []
             for row in current_rows:
                 prior_rank = prior_rank_by_team.get(row["team_name"])
                 rank_change = (
                     (prior_rank - row["rank"]) if prior_rank is not None else None
+                )
+                prior_qop = prior_qop_by_team.get(row["team_name"])
+                qop_change = (
+                    round(row["qop_score"] - prior_qop, 1)
+                    if prior_qop is not None and row.get("qop_score") is not None
+                    else None
                 )
                 rankings.append(
                     {
@@ -370,6 +379,7 @@ class QoPRankingsDAO:
                         "def_score": row.get("def_score"),
                         "qop_score": row["qop_score"],
                         "rank_change": rank_change,
+                        "qop_change": qop_change,
                     }
                 )
 

--- a/frontend/src/components/QoPStandings.vue
+++ b/frontend/src/components/QoPStandings.vue
@@ -123,52 +123,104 @@
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-slate-100">
-          <tr
-            v-for="entry in rankings"
-            :key="entry.rank"
-            class="hover:bg-slate-50 transition-colors"
-          >
-            <td class="px-3 py-3 text-sm text-gray-500">
-              {{ entry.rank }}
-            </td>
-            <td class="px-3 py-3 text-xs text-center">
-              <span
-                v-if="entry.rank_change > 0"
-                class="text-green-600 font-medium"
-                :title="`Up ${entry.rank_change}`"
-              >
-                ▲{{ entry.rank_change }}
-              </span>
-              <span
-                v-else-if="entry.rank_change < 0"
-                class="text-red-600 font-medium"
-                :title="`Down ${Math.abs(entry.rank_change)}`"
-              >
-                ▼{{ Math.abs(entry.rank_change) }}
-              </span>
-              <span v-else class="text-gray-400">—</span>
-            </td>
-            <td class="px-4 py-3 text-sm font-medium text-gray-900">
-              {{ entry.team_name }}
-            </td>
-            <td class="px-4 py-3 text-sm text-center text-gray-500">
-              {{ entry.matches_played ?? '—' }}
-            </td>
-            <td
-              class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
-            >
-              {{ entry.att_score != null ? entry.att_score.toFixed(1) : '—' }}
-            </td>
-            <td
-              class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
-            >
-              {{ entry.def_score != null ? entry.def_score.toFixed(1) : '—' }}
-            </td>
-            <td class="px-4 py-3 text-sm text-center font-bold text-brand-600">
-              {{ entry.qop_score != null ? entry.qop_score.toFixed(1) : '—' }}
+        <tbody class="bg-white">
+          <!-- Championship Qualification label before first row -->
+          <tr v-if="rankings.length" class="border-0">
+            <td colspan="7" class="px-0 py-0">
+              <div class="flex items-center gap-2 pb-1 pt-1 px-3 bg-blue-50">
+                <span
+                  class="text-xs font-semibold text-blue-700 uppercase tracking-wide whitespace-nowrap"
+                  >Championship Qualification</span
+                >
+              </div>
             </td>
           </tr>
+          <template v-for="entry in rankings" :key="entry.rank">
+            <tr
+              class="hover:bg-slate-50 transition-colors border-b border-slate-100"
+            >
+              <td class="px-3 py-3 text-sm text-gray-500">
+                {{ entry.rank }}
+              </td>
+              <td class="px-3 py-3 text-xs text-center">
+                <span
+                  v-if="entry.rank_change > 0"
+                  class="text-green-600 font-medium"
+                  :title="`Up ${entry.rank_change}`"
+                >
+                  ▲{{ entry.rank_change }}
+                </span>
+                <span
+                  v-else-if="entry.rank_change < 0"
+                  class="text-red-600 font-medium"
+                  :title="`Down ${Math.abs(entry.rank_change)}`"
+                >
+                  ▼{{ Math.abs(entry.rank_change) }}
+                </span>
+                <span v-else class="text-gray-400">—</span>
+              </td>
+              <td class="px-4 py-3 text-sm font-medium text-gray-900">
+                {{ entry.team_name }}
+              </td>
+              <td class="px-4 py-3 text-sm text-center text-gray-500">
+                {{ entry.matches_played ?? '—' }}
+              </td>
+              <td
+                class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
+              >
+                {{ entry.att_score != null ? entry.att_score.toFixed(1) : '—' }}
+              </td>
+              <td
+                class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
+              >
+                {{ entry.def_score != null ? entry.def_score.toFixed(1) : '—' }}
+              </td>
+              <td
+                class="px-4 py-3 text-sm text-center font-bold text-brand-600"
+              >
+                {{ entry.qop_score != null ? entry.qop_score.toFixed(1) : '—' }}
+                <span
+                  v-if="entry.qop_change != null && entry.qop_change > 0"
+                  class="ml-1 text-xs font-normal text-green-600"
+                  :title="`QoP up ${entry.qop_change} from prior week`"
+                  >+{{ entry.qop_change.toFixed(1) }}</span
+                >
+                <span
+                  v-else-if="entry.qop_change != null && entry.qop_change < 0"
+                  class="ml-1 text-xs font-normal text-red-500"
+                  :title="`QoP down ${Math.abs(entry.qop_change)} from prior week`"
+                  >{{ entry.qop_change.toFixed(1) }}</span
+                >
+              </td>
+            </tr>
+            <!-- Championship Qualification cutoff: after rank 5 -->
+            <tr v-if="entry.rank === 5" class="border-0">
+              <td colspan="7" class="px-0 py-0">
+                <div
+                  class="flex items-center gap-2 border-t-2 border-blue-500 pt-1 pb-1 px-3"
+                >
+                  <span
+                    class="text-xs font-semibold text-blue-600 uppercase tracking-wide whitespace-nowrap"
+                    >Premier Qualification</span
+                  >
+                </div>
+              </td>
+            </tr>
+            <!-- Tournament cutoff: after rank 10 -->
+            <tr v-if="entry.rank === 10" class="border-0">
+              <td colspan="7" class="px-0 py-0">
+                <div
+                  class="flex items-center gap-2 border-t-2 border-red-400 pt-1 pb-1 px-3"
+                >
+                  <span
+                    class="text-xs font-semibold text-red-500 uppercase tracking-wide whitespace-nowrap"
+                    >Not Invited — MLS NEXT Cup Tournament · Salt Lake City,
+                    UT</span
+                  >
+                </div>
+              </td>
+            </tr>
+          </template>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary

- **QoP point delta**: Each team now shows a `+X.X` / `-X.X` change in their QoP score vs the prior week snapshot, displayed inline in the QoP column (green for up, red for down)
- **Qualification zone banners**: Blue "Championship Qualification" label above ranks 1–5; blue "Premier Qualification" divider appears after rank 5
- **Tournament cutoff line**: Red divider after rank 10 labeled "Not Invited — MLS NEXT Cup Tournament · Salt Lake City, UT"

## Changes

- `backend/dao/qop_rankings_dao.py`: Fetches prior snapshot `qop_score` alongside rank, computes `qop_change` rounded to 1 decimal, added to each ranking entry in the API response
- `frontend/src/components/QoPStandings.vue`: Renders the delta inline in the QoP cell; adds section banners using injected table rows at ranks 1, 5, and 10

## Test plan

- [ ] Verify QoP delta shows green `+X.X` when score improved vs prior week
- [ ] Verify QoP delta shows red `-X.X` when score dropped
- [ ] Verify no delta shown when no prior snapshot exists (new team / first snapshot)
- [ ] Confirm "Championship Qualification" banner appears above rank 1
- [ ] Confirm "Premier Qualification" divider appears between ranks 5 and 6
- [ ] Confirm red "Not Invited" cutoff appears between ranks 10 and 11
- [ ] Test with fewer than 10 or 5 teams (banners should only appear when rank exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)