### PR TITLE
feat: show week-over-week ATT and DEF deltas in QoP rankings

### DIFF
--- a/backend/dao/qop_rankings_dao.py
+++ b/backend/dao/qop_rankings_dao.py
@@ -345,10 +345,12 @@ class QoPRankingsDAO:
 
             prior_rank_by_team: dict[str, int] = {}
             prior_qop_by_team: dict[str, float] = {}
+            prior_att_by_team: dict[str, float] = {}
+            prior_def_by_team: dict[str, float] = {}
             if prior is not None:
                 prior_rows_resp = (
                     client.table("qop_rankings")
-                    .select("rank, team_name, qop_score")
+                    .select("rank, team_name, att_score, def_score, qop_score")
                     .eq("snapshot_id", prior["id"])
                     .execute()
                 )
@@ -356,6 +358,10 @@ class QoPRankingsDAO:
                     prior_rank_by_team[row["team_name"]] = row["rank"]
                     if row.get("qop_score") is not None:
                         prior_qop_by_team[row["team_name"]] = row["qop_score"]
+                    if row.get("att_score") is not None:
+                        prior_att_by_team[row["team_name"]] = row["att_score"]
+                    if row.get("def_score") is not None:
+                        prior_def_by_team[row["team_name"]] = row["def_score"]
 
             rankings = []
             for row in current_rows:
@@ -369,6 +375,18 @@ class QoPRankingsDAO:
                     if prior_qop is not None and row.get("qop_score") is not None
                     else None
                 )
+                prior_att = prior_att_by_team.get(row["team_name"])
+                att_change = (
+                    round(row["att_score"] - prior_att, 1)
+                    if prior_att is not None and row.get("att_score") is not None
+                    else None
+                )
+                prior_def = prior_def_by_team.get(row["team_name"])
+                def_change = (
+                    round(row["def_score"] - prior_def, 1)
+                    if prior_def is not None and row.get("def_score") is not None
+                    else None
+                )
                 rankings.append(
                     {
                         "rank": row["rank"],
@@ -380,6 +398,8 @@ class QoPRankingsDAO:
                         "qop_score": row["qop_score"],
                         "rank_change": rank_change,
                         "qop_change": qop_change,
+                        "att_change": att_change,
+                        "def_change": def_change,
                     }
                 )
 

--- a/frontend/src/components/QoPStandings.vue
+++ b/frontend/src/components/QoPStandings.vue
@@ -169,11 +169,35 @@
                 class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
               >
                 {{ entry.att_score != null ? entry.att_score.toFixed(1) : '—' }}
+                <span
+                  v-if="entry.att_change != null && entry.att_change > 0"
+                  class="ml-1 text-xs font-normal text-green-600"
+                  :title="`ATT up ${entry.att_change} from prior week`"
+                  >+{{ entry.att_change.toFixed(1) }}</span
+                >
+                <span
+                  v-else-if="entry.att_change != null && entry.att_change < 0"
+                  class="ml-1 text-xs font-normal text-red-500"
+                  :title="`ATT down ${Math.abs(entry.att_change)} from prior week`"
+                  >{{ entry.att_change.toFixed(1) }}</span
+                >
               </td>
               <td
                 class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
               >
                 {{ entry.def_score != null ? entry.def_score.toFixed(1) : '—' }}
+                <span
+                  v-if="entry.def_change != null && entry.def_change > 0"
+                  class="ml-1 text-xs font-normal text-green-600"
+                  :title="`DEF up ${entry.def_change} from prior week`"
+                  >+{{ entry.def_change.toFixed(1) }}</span
+                >
+                <span
+                  v-else-if="entry.def_change != null && entry.def_change < 0"
+                  class="ml-1 text-xs font-normal text-red-500"
+                  :title="`DEF down ${Math.abs(entry.def_change)} from prior week`"
+                  >{{ entry.def_change.toFixed(1) }}</span
+                >
               </td>
               <td
                 class="px-4 py-3 text-sm text-center font-bold text-brand-600"


### PR DESCRIPTION
## Summary
- Backend: include prior-week ATT/DEF scores from the previous snapshot and emit `att_change`/`def_change` in `/api/qop-rankings`.
- Frontend: render +/- deltas next to ATT and DEF in `QoPStandings.vue`, matching the existing QoP delta styling (green for increase, red for decrease).

## Test plan
- [ ] Load QoP rankings, confirm ATT/DEF deltas display for teams present in both snapshots
- [ ] Teams without a prior snapshot show no delta (no stray `+0.0`)
- [ ] Hover tooltips show direction + magnitude
- [ ] Green/red color matches QoP column behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)