### PR TITLE
feat: filter Recent Form by match type in match preview

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2252,6 +2252,7 @@ async def get_match_preview(
     season_id: int | None = Query(None, description="Season ID for recent form and common opponents"),
     age_group_id: int | None = Query(None, description="Filter by age group"),
     recent_count: int = Query(5, ge=1, le=20, description="Number of recent matches per team"),
+    match_type_id: int | None = Query(None, description="If set, filters recent form to this match type"),
     current_user: dict[str, Any] = Depends(get_current_user_required),
 ):
     """Get match preview data for two teams.
@@ -2266,6 +2267,7 @@ async def get_match_preview(
             season_id=season_id,
             age_group_id=age_group_id,
             recent_count=recent_count,
+            match_type_id=match_type_id,
         )
 
         # Augment preview with QoP ranking data

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -634,6 +634,7 @@ class MatchDAO(BaseDAO):
         season_id: int | None = None,
         age_group_id: int | None = None,
         recent_count: int = 5,
+        match_type_id: int | None = None,
     ) -> dict:
         """Get match preview data: recent form, common opponents, and head-to-head history.
 
@@ -643,6 +644,7 @@ class MatchDAO(BaseDAO):
             season_id: Season for recent form and common opponents (None = all seasons)
             age_group_id: Optional filter to restrict to a specific age group
             recent_count: How many recent matches to return per team
+            match_type_id: If set, restricts recent form to matches of this type
 
         Returns:
             Dict with home_team_recent, away_team_recent, common_opponents, head_to_head
@@ -683,7 +685,7 @@ class MatchDAO(BaseDAO):
                 "updated_at": match.get("updated_at"),
             }
 
-        def build_base_query(team_id: int):
+        def build_base_query(team_id: int, filter_match_type: bool = False):
             q = (
                 self.client.table("matches")
                 .select(select_str)
@@ -694,12 +696,24 @@ class MatchDAO(BaseDAO):
                 q = q.eq("season_id", season_id)
             if age_group_id:
                 q = q.eq("age_group_id", age_group_id)
+            if filter_match_type and match_type_id:
+                q = q.eq("match_type_id", match_type_id)
             return q
 
         try:
-            # --- Recent form for each team ---
-            home_resp = build_base_query(home_team_id).order("match_date", desc=True).limit(recent_count).execute()
-            away_resp = build_base_query(away_team_id).order("match_date", desc=True).limit(recent_count).execute()
+            # --- Recent form for each team (filtered to the same match type) ---
+            home_resp = (
+                build_base_query(home_team_id, filter_match_type=True)
+                .order("match_date", desc=True)
+                .limit(recent_count)
+                .execute()
+            )
+            away_resp = (
+                build_base_query(away_team_id, filter_match_type=True)
+                .order("match_date", desc=True)
+                .limit(recent_count)
+                .execute()
+            )
             home_recent = [flatten(m) for m in (home_resp.data or [])]
             away_recent = [flatten(m) for m in (away_resp.data or [])]
 

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -515,6 +515,7 @@
               :awayTeamName="match.away_team_name"
               :seasonId="match.season_id"
               :ageGroupId="match.age_group_id"
+              :matchTypeId="match.match_type_id"
             />
           </div>
 

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -482,6 +482,8 @@ const props = defineProps({
   ageGroupId: { type: Number, default: null },
   /** How many recent matches to fetch per team */
   recentCount: { type: Number, default: 5 },
+  /** If set, restricts recent form to matches of this type (e.g. League only) */
+  matchTypeId: { type: Number, default: null },
 });
 
 // ─── State ────────────────────────────────────────────────────────────────────
@@ -536,6 +538,7 @@ async function fetchPreview() {
     const params = new URLSearchParams();
     if (props.seasonId) params.set('season_id', props.seasonId);
     if (props.ageGroupId) params.set('age_group_id', props.ageGroupId);
+    if (props.matchTypeId) params.set('match_type_id', props.matchTypeId);
     params.set('recent_count', props.recentCount);
 
     const url = `${getApiBaseUrl()}/api/matches/preview/${props.homeTeamId}/${props.awayTeamId}?${params}`;
@@ -581,7 +584,13 @@ async function fetchPreview() {
 
 // Refetch when key props change
 watch(
-  () => [props.homeTeamId, props.awayTeamId, props.seasonId, props.ageGroupId],
+  () => [
+    props.homeTeamId,
+    props.awayTeamId,
+    props.seasonId,
+    props.ageGroupId,
+    props.matchTypeId,
+  ],
   () => fetchPreview(),
   { immediate: false }
 );


### PR DESCRIPTION
## Summary
- Recent Form tab now filters to matches of the same type as the upcoming match (e.g. League preview → last 5 League matches per team)
- Tournament matches will no longer appear in Recent Form for a League preview (and vice versa)
- Common Opponents and Head-to-Head tabs are unchanged

## Why
A League match preview was showing a Tournament result in the IFA column, which is misleading when sizing up league form.

## Changes
- \`backend/dao/match_dao.py\` — \`get_match_preview\` accepts optional \`match_type_id\`; recent form queries filter by it
- \`backend/app.py\` — \`/api/matches/preview\` endpoint exposes \`match_type_id\` query param
- \`frontend/src/components/MatchPreview.vue\` — new \`matchTypeId\` prop wired into URL and watcher
- \`frontend/src/components/MatchDetailView.vue\` — passes \`match.match_type_id\` to \`<MatchPreview>\`

## Test plan
- [ ] Open a scheduled League match → Recent Form shows only League matches
- [ ] Open a scheduled Tournament match → Recent Form shows only Tournament matches
- [ ] Common Opponents tab still shows all match types (with Tournament label)
- [ ] Head-to-Head tab still spans all seasons/types

🤖 Generated with [Claude Code](https://claude.com/claude-code)