### PR TITLE
feat: clickable team name on League Table jumps to Matches

### DIFF
--- a/backend/dao/standings.py
+++ b/backend/dao/standings.py
@@ -129,6 +129,7 @@ def calculate_standings(matches: list[dict]) -> list[dict]:
             "goal_difference": 0,
             "points": 0,
             "logo_url": None,
+            "team_id": None,
         }
     )
 
@@ -141,6 +142,12 @@ def calculate_standings(matches: list[dict]) -> list[dict]:
         # Skip matches without scores
         if home_score is None or away_score is None:
             continue
+
+        # Capture team_id from joined team data
+        if standings[home_team]["team_id"] is None:
+            standings[home_team]["team_id"] = match["home_team"].get("id")
+        if standings[away_team]["team_id"] is None:
+            standings[away_team]["team_id"] = match["away_team"].get("id")
 
         # Capture club logo_url from joined club data
         home_club = match["home_team"].get("club") or {}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -359,6 +359,7 @@
               :initial-league-id="tableFilters.leagueId"
               :initial-division-id="tableFilters.divisionId"
               :filter-key="tableFilters.key"
+              @navigate-to-team="handleNavigateToTeam"
             />
           </div>
 
@@ -368,6 +369,9 @@
               :initial-age-group-id="matchesFilters.ageGroupId"
               :initial-league-id="matchesFilters.leagueId"
               :initial-division-id="matchesFilters.divisionId"
+              :initial-team-id="matchesFilters.teamId"
+              :initial-season-id="matchesFilters.seasonId"
+              :initial-match-type-id="matchesFilters.matchTypeId"
               :filter-key="matchesFilters.key"
             />
           </div>
@@ -529,6 +533,9 @@ export default {
       ageGroupId: null,
       leagueId: null,
       divisionId: null,
+      teamId: null,
+      seasonId: null,
+      matchTypeId: null,
       key: 0, // Used to force re-render when filters change
     });
     const showLoginModal = ref(false);
@@ -689,9 +696,25 @@ export default {
           ageGroupId: filters.ageGroupId || null,
           leagueId: filters.leagueId || null,
           divisionId: filters.divisionId || null,
+          teamId: filters.teamId || null,
+          seasonId: filters.seasonId || null,
+          matchTypeId: filters.matchTypeId || null,
           key: matchesFilters.value.key + 1, // Force re-render
         };
       }
+    };
+
+    const handleNavigateToTeam = filters => {
+      currentTab.value = 'scores';
+      matchesFilters.value = {
+        ageGroupId: filters.ageGroupId || null,
+        leagueId: filters.leagueId || null,
+        divisionId: filters.divisionId || null,
+        teamId: filters.teamId || null,
+        seasonId: filters.seasonId || null,
+        matchTypeId: 1, // League
+        key: matchesFilters.value.key + 1,
+      };
     };
 
     const submitInviteRequest = async () => {
@@ -868,6 +891,7 @@ export default {
       handleLoginSuccess,
       handleLogout,
       handleSwitchTab,
+      handleNavigateToTeam,
       submitInviteRequest,
       // Live match
       liveMatches,

--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -264,7 +264,16 @@
                   :name="team.team"
                   size="xs"
                 />
-                <span>{{ getTeamDisplayName(team.team) }}</span>
+                <button
+                  v-if="team.team_id"
+                  type="button"
+                  @click="handleTeamClick(team)"
+                  data-testid="standings-team-link"
+                  class="text-left text-brand-600 hover:text-brand-700 hover:underline focus:outline-none focus:underline"
+                >
+                  {{ getTeamDisplayName(team.team) }}
+                </button>
+                <span v-else>{{ getTeamDisplayName(team.team) }}</span>
               </div>
             </td>
             <td
@@ -383,7 +392,8 @@ export default {
       default: 0,
     },
   },
-  setup(props) {
+  emits: ['navigate-to-team'],
+  setup(props, { emit }) {
     const authStore = useAuthStore();
     const tableData = ref([]);
     const teams = ref([]); // Store all teams for name→id mapping
@@ -565,6 +575,17 @@ export default {
     // Teams are scoped by league in the new clubs architecture
     const getTeamDisplayName = teamName => {
       return teamName;
+    };
+
+    const handleTeamClick = row => {
+      if (!row.team_id) return;
+      emit('navigate-to-team', {
+        teamId: row.team_id,
+        ageGroupId: selectedAgeGroupId.value,
+        leagueId: selectedLeagueId.value,
+        divisionId: selectedDivisionId.value,
+        seasonId: selectedSeasonId.value,
+      });
     };
 
     const fetchTableData = async () => {
@@ -755,6 +776,7 @@ export default {
       selectedSeasonId,
       formatSeasonDates,
       getTeamDisplayName,
+      handleTeamClick,
       error,
       loading,
       bracketExists,

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -2029,6 +2029,9 @@ export default {
     initialAgeGroupId: { type: Number, default: null },
     initialLeagueId: { type: Number, default: null },
     initialDivisionId: { type: Number, default: null },
+    initialTeamId: { type: Number, default: null },
+    initialSeasonId: { type: Number, default: null },
+    initialMatchTypeId: { type: Number, default: null },
     filterKey: { type: Number, default: 0 },
   },
   setup(props) {
@@ -3103,7 +3106,8 @@ export default {
         selectedClubId.value = authStore.userClubId.value;
       }
 
-      // Apply initial filters from props if provided (navigation from FanProfile)
+      // Apply initial filters from props if provided (navigation from FanProfile
+      // or from clicking a team on the League Table)
       if (props.filterKey > 0) {
         // Switch to My Club tab when filters are specified
         selectedViewTab.value = 'myclub';
@@ -3112,9 +3116,26 @@ export default {
           selectedAgeGroupId.value = props.initialAgeGroupId;
         }
 
-        // If league/division is specified, try to auto-select the matching team
-        if (props.initialLeagueId && selectedClubId.value) {
-          // Find the team that matches the league/division for this age group
+        if (props.initialSeasonId) {
+          selectedSeasonId.value = props.initialSeasonId;
+        }
+
+        if (props.initialMatchTypeId !== null) {
+          selectedMatchTypeId.value = props.initialMatchTypeId;
+        }
+
+        // If a specific team was clicked, select its club + team directly.
+        // This wins over the league/division-based lookup below.
+        if (props.initialTeamId) {
+          const team = teams.value.find(
+            t => Number(t.id) === Number(props.initialTeamId)
+          );
+          if (team) {
+            selectedClubId.value = team.club_id;
+            selectedTeam.value = String(team.id);
+          }
+        } else if (props.initialLeagueId && selectedClubId.value) {
+          // Fallback: find the team that matches the league/division for this age group
           const matchingTeam = teams.value.find(team => {
             if (team.club_id !== selectedClubId.value) return false;
             const division =


### PR DESCRIPTION
## Summary
- Click a team on the League Table → lands on Matches → My Club with the club + team pre-selected
- Age Group, Season, and Division come from the current table context
- Match Type is set to League

## Changes
- \`backend/dao/standings.py\` — standings rows now include \`team_id\` (captured from the joined team data)
- \`frontend/src/components/LeagueTable.vue\` — team name is a button when \`team_id\` is present; emits \`navigate-to-team\` with the full filter context
- \`frontend/src/App.vue\` — new \`handleNavigateToTeam\` pipes filters into \`matchesFilters\` and switches to the Matches tab; passes 3 new props (\`initialTeamId\`, \`initialSeasonId\`, \`initialMatchTypeId\`) to \`<MatchesView>\`
- \`frontend/src/components/MatchesView.vue\` — when \`initialTeamId\` is set, resolves club + team directly from \`teams.value\` (bypassing the older league/division lookup) and switches to the My Club subtab

## Test plan
- [ ] On Table tab, select U14 / Homegrown / Northeast / 2025-2026
- [ ] Click \"IFA\" → lands on Matches → My Club with IFA (Homegrown - Northeast) selected, U14 / 2025-2026 / League active
- [ ] Try the same with Academy league and a different age group — context should carry through
- [ ] Click a team name, go back to Table, click a different team — second team should load cleanly
- [ ] Non-team-id rows (shouldn't happen normally) still render as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)