### PR TITLE
fix: pass full club/league/division context when navigating from table

### DIFF
--- a/backend/dao/standings.py
+++ b/backend/dao/standings.py
@@ -130,6 +130,7 @@ def calculate_standings(matches: list[dict]) -> list[dict]:
             "points": 0,
             "logo_url": None,
             "team_id": None,
+            "club_id": None,
         }
     )
 
@@ -149,13 +150,17 @@ def calculate_standings(matches: list[dict]) -> list[dict]:
         if standings[away_team]["team_id"] is None:
             standings[away_team]["team_id"] = match["away_team"].get("id")
 
-        # Capture club logo_url from joined club data
+        # Capture club logo_url + club_id from joined club data
         home_club = match["home_team"].get("club") or {}
         away_club = match["away_team"].get("club") or {}
         if not standings[home_team]["logo_url"]:
             standings[home_team]["logo_url"] = home_club.get("logo_url")
         if not standings[away_team]["logo_url"]:
             standings[away_team]["logo_url"] = away_club.get("logo_url")
+        if standings[home_team]["club_id"] is None:
+            standings[home_team]["club_id"] = home_club.get("id")
+        if standings[away_team]["club_id"] is None:
+            standings[away_team]["club_id"] = away_club.get("id")
 
         # Update played count
         standings[home_team]["played"] += 1

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -369,6 +369,7 @@
               :initial-age-group-id="matchesFilters.ageGroupId"
               :initial-league-id="matchesFilters.leagueId"
               :initial-division-id="matchesFilters.divisionId"
+              :initial-club-id="matchesFilters.clubId"
               :initial-team-id="matchesFilters.teamId"
               :initial-season-id="matchesFilters.seasonId"
               :initial-match-type-id="matchesFilters.matchTypeId"
@@ -533,6 +534,7 @@ export default {
       ageGroupId: null,
       leagueId: null,
       divisionId: null,
+      clubId: null,
       teamId: null,
       seasonId: null,
       matchTypeId: null,
@@ -710,6 +712,7 @@ export default {
         ageGroupId: filters.ageGroupId || null,
         leagueId: filters.leagueId || null,
         divisionId: filters.divisionId || null,
+        clubId: filters.clubId || null,
         teamId: filters.teamId || null,
         seasonId: filters.seasonId || null,
         matchTypeId: 1, // League

--- a/frontend/src/components/LeagueTable.vue
+++ b/frontend/src/components/LeagueTable.vue
@@ -581,6 +581,7 @@ export default {
       if (!row.team_id) return;
       emit('navigate-to-team', {
         teamId: row.team_id,
+        clubId: row.club_id,
         ageGroupId: selectedAgeGroupId.value,
         leagueId: selectedLeagueId.value,
         divisionId: selectedDivisionId.value,

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -2029,6 +2029,7 @@ export default {
     initialAgeGroupId: { type: Number, default: null },
     initialLeagueId: { type: Number, default: null },
     initialDivisionId: { type: Number, default: null },
+    initialClubId: { type: Number, default: null },
     initialTeamId: { type: Number, default: null },
     initialSeasonId: { type: Number, default: null },
     initialMatchTypeId: { type: Number, default: null },
@@ -3115,33 +3116,37 @@ export default {
         if (props.initialAgeGroupId) {
           selectedAgeGroupId.value = props.initialAgeGroupId;
         }
-
         if (props.initialSeasonId) {
           selectedSeasonId.value = props.initialSeasonId;
         }
-
         if (props.initialMatchTypeId !== null) {
           selectedMatchTypeId.value = props.initialMatchTypeId;
         }
+        if (props.initialLeagueId) {
+          selectedLeagueId.value = props.initialLeagueId;
+        }
+        if (props.initialDivisionId) {
+          selectedDivisionId.value = props.initialDivisionId;
+        }
+        if (props.initialClubId) {
+          selectedClubId.value = props.initialClubId;
+        }
 
-        // If a specific team was clicked, select its club + team directly.
-        // This wins over the league/division-based lookup below.
+        // Resolve team. Prefer explicit team id; fall back to
+        // (club_id, age_group_id, league_id, division_id) lookup.
+        let resolvedTeam = null;
         if (props.initialTeamId) {
-          const team = teams.value.find(
+          resolvedTeam = teams.value.find(
             t => Number(t.id) === Number(props.initialTeamId)
           );
-          if (team) {
-            selectedClubId.value = team.club_id;
-            selectedTeam.value = String(team.id);
-          }
-        } else if (props.initialLeagueId && selectedClubId.value) {
-          // Fallback: find the team that matches the league/division for this age group
-          const matchingTeam = teams.value.find(team => {
-            if (team.club_id !== selectedClubId.value) return false;
+        }
+        if (!resolvedTeam && selectedClubId.value && props.initialLeagueId) {
+          resolvedTeam = teams.value.find(team => {
+            if (Number(team.club_id) !== Number(selectedClubId.value))
+              return false;
             const division =
               team.divisions_by_age_group?.[String(selectedAgeGroupId.value)];
             if (!division) return false;
-            // Match by league_id (and optionally division_id if provided)
             const leagueMatch =
               Number(division.league_id) === Number(props.initialLeagueId);
             const divisionMatch = props.initialDivisionId
@@ -3149,10 +3154,12 @@ export default {
               : true;
             return leagueMatch && divisionMatch;
           });
-
-          if (matchingTeam) {
-            selectedTeam.value = String(matchingTeam.id);
+        }
+        if (resolvedTeam) {
+          if (!selectedClubId.value) {
+            selectedClubId.value = resolvedTeam.club_id;
           }
+          selectedTeam.value = String(resolvedTeam.id);
         }
       }
 


### PR DESCRIPTION
## Summary
Follow-up to #311. The team name is clickable, but admins landed on My Club with an empty team dropdown because only \`selectedClubId\` and \`selectedTeam\` got set — the league / division filters stayed null, and we were relying on \`teams.find()\` to resolve \`club_id\` via a single lookup.

Now we pipe the full filter context from the standings row all the way through to \`MatchesView\`, and apply every filter before resolving the team.

## Changes
- \`backend/dao/standings.py\` — standings rows now include \`club_id\` (from the joined team.club data)
- \`LeagueTable.vue\` — \`navigate-to-team\` event includes \`clubId\`
- \`App.vue\` — \`matchesFilters\` carries \`clubId\` through to \`<MatchesView>\`; new \`:initial-club-id\` prop
- \`MatchesView.vue\` — new \`initialClubId\` prop; on-mount applies age group + season + match type + league + division + club up front, then resolves the team (prefers \`initialTeamId\`, falls back to \`club_id + league_id + division_id\` lookup on the current age group)

## Test plan
- [ ] Click IFA on U14 Homegrown Northeast → Matches → My Club shows IFA (Homegrown - Northeast) preselected in Team dropdown
- [ ] Click a team in a different league (e.g. Academy) → league + division filter both match, team appears
- [ ] Team dropdown options list shows the clicked team when expanded
- [ ] Going back to Table, clicking another team works cleanly

## Notes
Standings response shape change (\`club_id\` added) requires flushing the \`mt:dao:matches:table:*\` Redis cache on deploy, or waiting 24h for TTL. Follow-up: add an automated cache flush hook to the deploy pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)