### PR TITLE
feat: flush Redis DAO cache via ArgoCD PostSync hook

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -720,7 +720,7 @@
         "filename": "helm/missing-table/values.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 93
       }
     ],
     "k3s/worker/QUICKSTART.md": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-27T13:30:08Z"
+  "generated_at": "2026-04-20T22:55:22Z"
 }

--- a/helm/missing-table/templates/cache-flush-hook.yaml
+++ b/helm/missing-table/templates/cache-flush-hook.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.redis.enabled .Values.cacheFlushHook.enabled }}
+# PostSync hook: flush DAO Redis cache after every ArgoCD sync so that
+# response-shape changes in a new release don't get masked by stale cached
+# payloads. See issue #313.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Include commit SHA in the name so ArgoCD creates a fresh Job per deploy
+  # instead of failing on "job already exists".
+  name: {{ include "missing-table.fullname" . }}-cache-flush-{{ .Values.commitSha | default "sync" | trunc 7 }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "missing-table.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cache-flush-hook
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+spec:
+  backoffLimit: {{ .Values.cacheFlushHook.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.cacheFlushHook.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "missing-table.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: cache-flush-hook
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: redis-flush
+        image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+        imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+        env:
+        - name: REDIS_HOST
+          value: {{ include "missing-table.fullname" . }}-redis
+        - name: KEY_PATTERN
+          value: {{ .Values.cacheFlushHook.keyPattern | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo "Flushing Redis keys matching pattern: $KEY_PATTERN"
+          DELETED=$(redis-cli -h "$REDIS_HOST" --scan --pattern "$KEY_PATTERN" \
+            | xargs -r redis-cli -h "$REDIS_HOST" DEL \
+            | awk '{s+=$1} END {print s+0}')
+          echo "Deleted $DELETED key(s)."
+        resources:
+          {{- toYaml .Values.cacheFlushHook.resources | nindent 10 }}
+{{- end }}

--- a/helm/missing-table/values.yaml
+++ b/helm/missing-table/values.yaml
@@ -28,6 +28,26 @@ limitRange:
     cpu: "100m"
     memory: "128Mi"
 
+# PostSync cache flush hook
+# Deletes DAO cache keys after every ArgoCD sync so that response-shape
+# changes in a new release aren't masked by stale cached payloads.
+# Only runs when redis.enabled is true.
+cacheFlushHook:
+  enabled: true
+  # Scan + delete only DAO keys. Non-DAO keys (rate limits, sessions)
+  # are preserved. Use "*" for a full flush.
+  keyPattern: "mt:dao:*"
+  backoffLimit: 2
+  # Auto-clean the Job object 10 minutes after it finishes.
+  ttlSecondsAfterFinished: 600
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
 # Redis configuration
 # For local K3s development, set enabled: true to enable caching
 # See also: backend.env.extra.CACHE_ENABLED to enable the caching layer


### PR DESCRIPTION
## Summary
Closes #313.

Adds an ArgoCD PostSync hook — a short-lived Kubernetes Job that scans Redis for keys matching \`mt:dao:*\` and deletes them after every sync. This prevents response-shape changes in a new release from being masked by stale cached payloads (which bit us on #311 and #312).

## How it works
- Template: \`helm/missing-table/templates/cache-flush-hook.yaml\`
- Job is annotated \`argocd.argoproj.io/hook: PostSync\` — ArgoCD runs it after the main sync completes.
- Job name embeds the short commit SHA so each deploy creates a fresh run (no \"Job already exists\" errors).
- \`hook-delete-policy: HookSucceeded,BeforeHookCreation\` cleans up automatically; \`ttlSecondsAfterFinished: 600\` is a backstop.
- Uses the same Redis image (for \`redis-cli\`) and connects via the in-cluster service DNS.

## Scope of flush
Default pattern is \`mt:dao:*\` — only DAO caches are cleared, so rate-limit counters, auth sessions, and anything else under other prefixes is preserved. Override with \`cacheFlushHook.keyPattern: \"*\"\` if you ever want a full flush.

## Guards
- Only renders when \`redis.enabled\` AND \`cacheFlushHook.enabled\` are both true.
- Default \`cacheFlushHook.enabled: true\` — follows Redis's gating, so disabled in local dev unless Redis is on.
- Verified: \`helm template\` with default values produces zero hook resources; with \`values-prod.yaml\` it produces the Job.

## Test plan
- [ ] Merge, watch ArgoCD sync — PostSync Job appears, runs, exits 0
- [ ] \`kubectl logs job/missing-table-cache-flush-<sha> -n missing-table\` shows \"Deleted N key(s).\"
- [ ] After the hook runs, \`redis-cli --scan --pattern 'mt:dao:*'\` returns nothing
- [ ] Other keys (if any) untouched
- [ ] Subsequent deploy creates a new Job with the next SHA; old one is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)