### PR TITLE
feat: add club_notification_channels schema + DAO (Phase 2 of #315)

### DIFF
--- a/backend/dao/club_notifications_dao.py
+++ b/backend/dao/club_notifications_dao.py
@@ -1,0 +1,122 @@
+"""
+Club Notification Channels Data Access Object.
+
+Per-club destinations (Telegram chat_ids, Discord webhook URLs) used by the
+live match notification dispatcher. The ``destination`` value is sensitive
+and is never logged or returned in full from the API layer.
+"""
+
+import structlog
+
+from dao.base_dao import BaseDAO
+
+logger = structlog.get_logger()
+
+TABLE = "club_notification_channels"
+VALID_PLATFORMS = frozenset({"telegram", "discord"})
+
+
+class ClubNotificationsDAO(BaseDAO):
+    """Data access for per-club notification channel config."""
+
+    def list_by_club(self, club_id: int) -> list[dict]:
+        """Return all notification channel rows for a club (any platform, any enabled state)."""
+        try:
+            response = (
+                self.client.table(TABLE)
+                .select("*")
+                .eq("club_id", club_id)
+                .order("platform")
+                .execute()
+            )
+            return response.data or []
+        except Exception:
+            logger.exception("dao_list_club_notifications_failed", club_id=club_id)
+            return []
+
+    def get(self, club_id: int, platform: str) -> dict | None:
+        """Return the channel row for a specific (club, platform), or None."""
+        try:
+            response = (
+                self.client.table(TABLE)
+                .select("*")
+                .eq("club_id", club_id)
+                .eq("platform", platform)
+                .limit(1)
+                .execute()
+            )
+            return response.data[0] if response.data else None
+        except Exception:
+            logger.exception(
+                "dao_get_club_notification_failed",
+                club_id=club_id,
+                platform=platform,
+            )
+            return None
+
+    def upsert(
+        self,
+        club_id: int,
+        platform: str,
+        destination: str,
+        enabled: bool = True,
+    ) -> dict | None:
+        """Create or update a channel for a (club, platform).
+
+        Re-raises on database errors (upsert failures are not expected during
+        normal use; the API layer should translate to HTTP errors).
+        """
+        try:
+            response = (
+                self.client.table(TABLE)
+                .upsert(
+                    {
+                        "club_id": club_id,
+                        "platform": platform,
+                        "destination": destination,
+                        "enabled": enabled,
+                    },
+                    on_conflict="club_id,platform",
+                )
+                .execute()
+            )
+            logger.debug(
+                "dao_upsert_club_notification",
+                club_id=club_id,
+                platform=platform,
+                enabled=enabled,
+            )
+            return response.data[0] if response.data else None
+        except Exception:
+            logger.exception(
+                "dao_upsert_club_notification_failed",
+                club_id=club_id,
+                platform=platform,
+            )
+            raise
+
+    def delete(self, club_id: int, platform: str) -> bool:
+        """Remove a channel. Returns True if a row was deleted."""
+        try:
+            response = (
+                self.client.table(TABLE)
+                .delete()
+                .eq("club_id", club_id)
+                .eq("platform", platform)
+                .execute()
+            )
+            deleted = bool(response.data)
+            logger.debug(
+                "dao_delete_club_notification",
+                club_id=club_id,
+                platform=platform,
+                deleted=deleted,
+            )
+            return deleted
+        except Exception:
+            logger.exception(
+                "dao_delete_club_notification_failed",
+                club_id=club_id,
+                platform=platform,
+            )
+            return False

--- a/backend/tests/unit/test_club_notifications_dao.py
+++ b/backend/tests/unit/test_club_notifications_dao.py
@@ -1,0 +1,170 @@
+"""
+Integration-style tests for ClubNotificationsDAO.
+
+Hits the real local Supabase database (not mocks), per the DAO testing
+convention documented in CLAUDE.md. The service role key bypasses RLS, so
+these tests exercise DAO behavior only; RLS is verified separately at the
+API contract layer (Phase 3).
+"""
+
+import uuid
+
+import pytest
+
+from dao.club_dao import ClubDAO
+from dao.club_notifications_dao import ClubNotificationsDAO
+from dao.match_dao import SupabaseConnection
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.backend,
+    pytest.mark.dao,
+    pytest.mark.database,
+]
+
+
+def _unique_club_name() -> str:
+    return f"NotifyTestClub-{uuid.uuid4().hex[:8]}"
+
+
+class TestClubNotificationsDAO:
+    """CRUD behavior for the notification channels DAO."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.conn = SupabaseConnection()
+        self.dao = ClubNotificationsDAO(self.conn)
+        self.club_dao = ClubDAO(self.conn)
+
+        self.club = self.club_dao.create_club(
+            name=_unique_club_name(),
+            city="Boston, MA",
+        )
+        self.club_id = self.club["id"]
+
+        yield
+
+        # ON DELETE CASCADE on club_id removes any notification rows.
+        try:
+            self.club_dao.delete_club(self.club_id)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------ upsert
+
+    def test_upsert_creates_new_row(self):
+        row = self.dao.upsert(self.club_id, "telegram", "-1001234567890")
+
+        assert row is not None
+        assert row["club_id"] == self.club_id
+        assert row["platform"] == "telegram"
+        assert row["destination"] == "-1001234567890"
+        assert row["enabled"] is True
+        assert row["id"] is not None
+
+    def test_upsert_overwrites_existing_same_platform(self):
+        self.dao.upsert(self.club_id, "discord", "https://discord.com/api/webhooks/1/aaa")
+        updated = self.dao.upsert(
+            self.club_id,
+            "discord",
+            "https://discord.com/api/webhooks/2/bbb",
+            enabled=False,
+        )
+
+        assert updated is not None
+        assert updated["destination"].endswith("/2/bbb")
+        assert updated["enabled"] is False
+
+        rows = self.dao.list_by_club(self.club_id)
+        discord_rows = [r for r in rows if r["platform"] == "discord"]
+        assert len(discord_rows) == 1
+
+    def test_upsert_allows_one_row_per_platform_per_club(self):
+        self.dao.upsert(self.club_id, "telegram", "-100111")
+        self.dao.upsert(self.club_id, "discord", "https://discord.com/api/webhooks/1/a")
+
+        rows = self.dao.list_by_club(self.club_id)
+        platforms = sorted(r["platform"] for r in rows)
+        assert platforms == ["discord", "telegram"]
+
+    # ---------------------------------------------------------------------- get
+
+    def test_get_returns_existing_row(self):
+        self.dao.upsert(self.club_id, "telegram", "-100999")
+        row = self.dao.get(self.club_id, "telegram")
+
+        assert row is not None
+        assert row["destination"] == "-100999"
+        assert row["platform"] == "telegram"
+
+    def test_get_returns_none_when_missing(self):
+        assert self.dao.get(self.club_id, "telegram") is None
+
+    def test_get_scopes_by_platform(self):
+        self.dao.upsert(self.club_id, "telegram", "-100aaa")
+        self.dao.upsert(self.club_id, "discord", "https://discord.com/api/webhooks/1/z")
+
+        tg = self.dao.get(self.club_id, "telegram")
+        dc = self.dao.get(self.club_id, "discord")
+
+        assert tg["destination"] == "-100aaa"
+        assert dc["destination"].endswith("/1/z")
+
+    # --------------------------------------------------------------- list_by_club
+
+    def test_list_by_club_returns_empty_when_no_rows(self):
+        assert self.dao.list_by_club(self.club_id) == []
+
+    def test_list_by_club_does_not_leak_other_clubs(self):
+        other_club = self.club_dao.create_club(name=_unique_club_name(), city="NYC")
+        try:
+            self.dao.upsert(self.club_id, "telegram", "-100ours")
+            self.dao.upsert(other_club["id"], "telegram", "-100theirs")
+
+            rows = self.dao.list_by_club(self.club_id)
+            assert len(rows) == 1
+            assert rows[0]["destination"] == "-100ours"
+        finally:
+            self.club_dao.delete_club(other_club["id"])
+
+    # ------------------------------------------------------------------- delete
+
+    def test_delete_removes_row(self):
+        self.dao.upsert(self.club_id, "telegram", "-100xxx")
+
+        assert self.dao.delete(self.club_id, "telegram") is True
+        assert self.dao.get(self.club_id, "telegram") is None
+
+    def test_delete_nonexistent_returns_false(self):
+        assert self.dao.delete(self.club_id, "telegram") is False
+
+    def test_delete_only_affects_target_platform(self):
+        self.dao.upsert(self.club_id, "telegram", "-100tg")
+        self.dao.upsert(self.club_id, "discord", "https://discord.com/api/webhooks/1/d")
+
+        self.dao.delete(self.club_id, "telegram")
+
+        assert self.dao.get(self.club_id, "telegram") is None
+        assert self.dao.get(self.club_id, "discord") is not None
+
+
+class TestClubTimezoneColumn:
+    """The migration also adds a timezone column to clubs; quick smoke check."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.conn = SupabaseConnection()
+        self.club_dao = ClubDAO(self.conn)
+        self.club = self.club_dao.create_club(name=_unique_club_name(), city="Boston")
+        yield
+        try:
+            self.club_dao.delete_club(self.club["id"])
+        except Exception:
+            pass
+
+    def test_new_club_has_default_timezone(self):
+        # Re-fetch via raw client to see the new column regardless of DAO shape.
+        client = self.conn.get_client()
+        resp = client.table("clubs").select("timezone").eq("id", self.club["id"]).execute()
+        assert resp.data
+        assert resp.data[0]["timezone"] == "America/New_York"

--- a/scripts/backup_database.py
+++ b/scripts/backup_database.py
@@ -154,6 +154,9 @@ def create_backup(backup_dir: Path | None = None):
         # Clubs (before teams - teams have club_id foreign key)
         'clubs',
 
+        # Per-club notification channels (Telegram/Discord) for live match updates
+        'club_notification_channels',
+
         # Teams and mappings
         'teams',
         'team_mappings',

--- a/supabase-local/migrations/20260421000000_add_club_notification_channels.sql
+++ b/supabase-local/migrations/20260421000000_add_club_notification_channels.sql
@@ -1,0 +1,79 @@
+-- Migration: Add club_notification_channels + clubs.timezone
+-- Description: Per-club Telegram / Discord channels for live match notifications.
+-- Date: 2026-04-21
+-- Related: Phase 2 of #315 (live match notifications feature)
+
+-- Ensure moddatetime extension is available for the updated_at trigger.
+CREATE EXTENSION IF NOT EXISTS moddatetime SCHEMA extensions;
+
+-- ----------------------------------------------------------------------------
+-- 1) clubs.timezone — used when rendering match times in notifications.
+--    Home club's timezone is used regardless of the destination channel.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.clubs
+    ADD COLUMN IF NOT EXISTS timezone text NOT NULL DEFAULT 'America/New_York';
+
+COMMENT ON COLUMN public.clubs.timezone IS 'IANA timezone name used when formatting match times in notifications (e.g. America/New_York).';
+
+-- ----------------------------------------------------------------------------
+-- 2) club_notification_channels — one row per (club, platform).
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.club_notification_channels (
+    id serial PRIMARY KEY,
+    club_id integer NOT NULL REFERENCES public.clubs(id) ON DELETE CASCADE,
+    platform text NOT NULL CHECK (platform IN ('telegram', 'discord')),
+    destination text NOT NULL,
+    enabled boolean NOT NULL DEFAULT true,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT club_notification_channels_club_platform_unique UNIQUE (club_id, platform)
+);
+
+COMMENT ON TABLE public.club_notification_channels IS 'Per-club Telegram chat_ids and Discord webhook URLs for live match notifications.';
+COMMENT ON COLUMN public.club_notification_channels.destination IS 'Sensitive: Telegram chat_id or Discord webhook URL. Never logged. Never returned to the frontend in full.';
+
+CREATE INDEX IF NOT EXISTS idx_club_notification_channels_club_enabled
+    ON public.club_notification_channels (club_id, enabled);
+
+-- ----------------------------------------------------------------------------
+-- 3) updated_at trigger (mirrors backend/sql/021_add_updated_at_trigger.sql).
+-- ----------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS handle_updated_at ON public.club_notification_channels;
+CREATE TRIGGER handle_updated_at
+    BEFORE UPDATE ON public.club_notification_channels
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime(updated_at);
+
+-- ----------------------------------------------------------------------------
+-- 4) Row-level security.
+--    - admin: full access on any row
+--    - club_manager: full access on rows where club_id = their own club
+--    - everyone else: no access
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.club_notification_channels ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS club_notification_channels_admin_all ON public.club_notification_channels;
+CREATE POLICY club_notification_channels_admin_all
+    ON public.club_notification_channels
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());
+
+DROP POLICY IF EXISTS club_notification_channels_club_manager_own_club ON public.club_notification_channels;
+CREATE POLICY club_notification_channels_club_manager_own_club
+    ON public.club_notification_channels
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.user_profiles
+            WHERE user_profiles.id = auth.uid()
+              AND user_profiles.role::text = 'club_manager'
+              AND user_profiles.club_id = club_notification_channels.club_id
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.user_profiles
+            WHERE user_profiles.id = auth.uid()
+              AND user_profiles.role::text = 'club_manager'
+              AND user_profiles.club_id = club_notification_channels.club_id
+        )
+    );


### PR DESCRIPTION
## Summary
- Adds `club_notification_channels` table (per-club Telegram/Discord destinations) with RLS scoped to admin + own-club club_manager.
- Adds `clubs.timezone` (default `America/New_York`) so notification messages can render match times in the home club's local time.
- New `ClubNotificationsDAO` with `list_by_club` / `get` / `upsert` / `delete`. The `destination` column is treated as sensitive — never logged.
- `scripts/backup_database.py` includes the new table (per CLAUDE.md memory).
- 12 integration-style DAO tests pass against the local Supabase.

Part of epic #315. Closes #317.

## Design notes
- **RLS**: two permissive policies — `admin_all` (via `public.is_admin()`) and `club_manager_own_club` (checks `user_profiles.role = 'club_manager'` AND `club_id` match). Everyone else is denied.
- **Cascade**: `ON DELETE CASCADE` from `clubs(id)` — deleting a club removes its notification config automatically.
- **Unique**: `(club_id, platform)` so upsert can merge on conflict.
- **Trigger**: `moddatetime` on `updated_at`, matching the pattern from `backend/sql/021_add_updated_at_trigger.sql`.
- **Idempotent**: all DDL uses `IF NOT EXISTS` / `DROP ... IF EXISTS` so re-applying is safe.

## Migration application note
Local Supabase migration tracking in this env is already out of sync with the DB (pre-existing — the 20260418 qop_snapshots migration is in the DB but not in `supabase_migrations.schema_migrations`). The migration was applied directly via `psql` on the two local stacks (ports 54322 and 54332). In prod, `./scripts/db_tools.sh migrate prod` will apply it through the normal path.

## Test plan
- [x] `uv run ruff check .` clean on `dao/` + new test file
- [x] `uv run pytest tests/unit/test_club_notifications_dao.py` — 12 passed
- [x] Verified RLS policies, CHECK constraint, FK cascade, UNIQUE, index, and trigger all present via `\d+ public.club_notification_channels`
- [x] Verified `clubs.timezone` default = `'America/New_York'`
- [ ] Reviewer: confirm migration strategy is OK (direct psql for this env, normal flow in prod)

## Next phases
- #318 (Phase 3): API endpoints + rate limiter + kill switch
- #319 (Phase 4): Admin + club manager UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)