### PR TITLE
fix: qualify moddatetime() with extensions schema (migration follow-up)

### DIFF
--- a/supabase-local/migrations/20260421000000_add_club_notification_channels.sql
+++ b/supabase-local/migrations/20260421000000_add_club_notification_channels.sql
@@ -42,7 +42,7 @@ DROP TRIGGER IF EXISTS handle_updated_at ON public.club_notification_channels;
 CREATE TRIGGER handle_updated_at
     BEFORE UPDATE ON public.club_notification_channels
     FOR EACH ROW
-    EXECUTE PROCEDURE moddatetime(updated_at);
+    EXECUTE PROCEDURE extensions.moddatetime(updated_at);
 
 -- ----------------------------------------------------------------------------
 -- 4) Row-level security.


### PR DESCRIPTION
## Summary
- Change `EXECUTE PROCEDURE moddatetime(updated_at)` → `EXECUTE PROCEDURE extensions.moddatetime(updated_at)` in the notification channels migration.
- Follow-up to #323 — prod `migrate` failed with `function moddatetime() does not exist (SQLSTATE 42883)` on the trigger CREATE.

## Root cause
Prod's Supabase CLI migration runner uses a restricted session search_path that doesn't include `extensions`. The `moddatetime` extension is installed in schema `extensions` (confirmed by `CREATE EXTENSION ... SCHEMA extensions` earlier in the same file), so the unqualified call can't be resolved at CREATE TRIGGER time. Qualifying it makes resolution deterministic regardless of search_path.

Locally the superuser `psql` connection had a permissive search_path that included `extensions`, which is why this wasn't caught pre-merge.

## Safety
- The migration file uses `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, and `DROP ... IF EXISTS` throughout.
- Whether prod rolled back the failed run or left partial state (table + column + index applied, trigger + RLS not), re-applying after this merge is idempotent.

## Apply instructions (for reviewer)
1. Merge this PR.
2. Re-run on prod: `./scripts/db_tools.sh migrate prod`
3. Verify trigger and policies landed: in Supabase dashboard or via `psql`:
   ```sql
   SELECT trigger_name FROM information_schema.triggers
     WHERE event_object_table = 'club_notification_channels';
   SELECT policyname FROM pg_policies
     WHERE tablename = 'club_notification_channels';
   ```
   Expect `handle_updated_at` and both RLS policies present.

## Test plan
- [x] Diff is a single-line change, trivially reviewable
- [ ] Reviewer re-runs `./scripts/db_tools.sh migrate prod` after merge and confirms trigger + policies applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)