### PR TITLE
feat: club notification channels API (Phase 3 of #315)

### DIFF
--- a/backend/api/club_notifications.py
+++ b/backend/api/club_notifications.py
@@ -1,0 +1,310 @@
+"""
+Club notification channels API.
+
+Per-club Telegram / Discord destinations for live-match notifications.
+- GET    /api/clubs/{club_id}/notifications
+- PUT    /api/clubs/{club_id}/notifications/{platform}
+- DELETE /api/clubs/{club_id}/notifications/{platform}
+- POST   /api/clubs/{club_id}/notifications/{platform}/test
+
+Permissions: admin OR (club_manager AND user_club_id == club_id).
+The `destination` value is never returned in full — callers only see the last
+four characters of a configured destination as `hint`. The full value stays
+write-only from the API's perspective.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from typing import Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from auth import get_current_user_required
+from dao.club_notifications_dao import VALID_PLATFORMS, ClubNotificationsDAO
+from dao.match_dao import SupabaseConnection
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/clubs", tags=["club-notifications"])
+
+
+# ---------------------------------------------------------------------------
+# Connection / DAO (lazy singleton)
+# ---------------------------------------------------------------------------
+
+_connection: SupabaseConnection | None = None
+
+
+def _dao() -> ClubNotificationsDAO:
+    global _connection
+    if _connection is None:
+        _connection = SupabaseConnection()
+    return ClubNotificationsDAO(_connection)
+
+
+# ---------------------------------------------------------------------------
+# Kill switch
+# ---------------------------------------------------------------------------
+
+
+def is_notifications_enabled() -> bool:
+    """False only when NOTIFICATIONS_ENABLED is explicitly off."""
+    return os.getenv("NOTIFICATIONS_ENABLED", "true").lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Redis-backed rate limiter (fail-open)
+# ---------------------------------------------------------------------------
+
+_redis_client = None
+
+
+def _get_redis():
+    """Lazy Redis client. Returns None if Redis isn't reachable."""
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+    try:
+        import redis
+
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        client = redis.from_url(url, decode_responses=True, socket_timeout=1.0)
+        client.ping()
+        _redis_client = client
+        return _redis_client
+    except Exception as exc:
+        logger.warning("notifications_redis_unavailable", error=str(exc))
+        return None
+
+
+def check_rate_limit(key: str, max_per_minute: int) -> bool:
+    """Fixed-window counter. Returns True if the request is allowed.
+
+    Fail-open: any Redis failure returns True so the limiter never takes the
+    service down. The limiter is best-effort defense-in-depth, not a hard
+    quota.
+    """
+    client = _get_redis()
+    if client is None:
+        return True
+
+    bucket = int(time.time() // 60)
+    full_key = f"{key}:{bucket}"
+    try:
+        count = client.incr(full_key)
+        if count == 1:
+            client.expire(full_key, 65)
+        return count <= max_per_minute
+    except Exception as exc:
+        logger.warning("rate_limit_check_failed", key=key, error=str(exc))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Permission guard
+# ---------------------------------------------------------------------------
+
+
+def ensure_club_access(current_user: dict, club_id: int) -> None:
+    """Raise 403 unless the caller is admin or a club_manager for this club."""
+    role = current_user.get("role")
+    if role == "admin":
+        return
+    if role == "club_manager" and current_user.get("club_id") == club_id:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Requires admin or club_manager for this club",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+_TELEGRAM_RE = re.compile(r"^(@\w+|-?\d+)$")
+_DISCORD_RE = re.compile(r"^https://discord(app)?\.com/api/webhooks/\d+/[\w-]+$")
+
+
+def _validate_destination(platform: str, destination: str) -> None:
+    if platform == "telegram":
+        if not _TELEGRAM_RE.match(destination):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Telegram destination must be a numeric chat_id (e.g. -1001234567890) or @channel",
+            )
+    elif platform == "discord":
+        if not _DISCORD_RE.match(destination):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Discord destination must be a webhook URL",
+            )
+
+
+def _validate_platform(platform: str) -> None:
+    if platform not in VALID_PLATFORMS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"platform must be one of {sorted(VALID_PLATFORMS)}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Response / request models
+# ---------------------------------------------------------------------------
+
+
+class ChannelResponse(BaseModel):
+    platform: Literal["telegram", "discord"]
+    enabled: bool
+    configured: bool
+    hint: str | None = Field(None, description="Last 4 chars of destination; full value never exposed")
+
+
+class ChannelUpsert(BaseModel):
+    destination: str = Field(..., min_length=1, max_length=500)
+    enabled: bool = True
+
+
+class TestSendResponse(BaseModel):
+    success: bool
+    error: str | None = None
+
+
+def _to_response(row: dict) -> ChannelResponse:
+    destination = row.get("destination") or ""
+    hint = destination[-4:] if destination else None
+    return ChannelResponse(
+        platform=row["platform"],
+        enabled=bool(row["enabled"]),
+        configured=True,
+        hint=hint,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test-send stub (Phase 5 replaces this with real Telegram / Discord calls)
+# ---------------------------------------------------------------------------
+
+
+def _send_test_message(platform: str, destination: str) -> None:
+    """Send a test notification. Replaced in Phase 5."""
+    raise NotImplementedError("Notification sending lands in Phase 5 (#320)")
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{club_id}/notifications",
+    response_model=list[ChannelResponse],
+)
+def list_channels(
+    club_id: int,
+    current_user: dict = Depends(get_current_user_required),
+) -> list[ChannelResponse]:
+    ensure_club_access(current_user, club_id)
+    rows = _dao().list_by_club(club_id)
+    return [_to_response(row) for row in rows]
+
+
+@router.put(
+    "/{club_id}/notifications/{platform}",
+    response_model=ChannelResponse,
+)
+def upsert_channel(
+    club_id: int,
+    platform: str,
+    body: ChannelUpsert,
+    current_user: dict = Depends(get_current_user_required),
+) -> ChannelResponse:
+    ensure_club_access(current_user, club_id)
+    _validate_platform(platform)
+    _validate_destination(platform, body.destination)
+
+    row = _dao().upsert(club_id, platform, body.destination, body.enabled)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save notification channel",
+        )
+    return _to_response(row)
+
+
+@router.delete(
+    "/{club_id}/notifications/{platform}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_channel(
+    club_id: int,
+    platform: str,
+    current_user: dict = Depends(get_current_user_required),
+):
+    ensure_club_access(current_user, club_id)
+    _validate_platform(platform)
+    _dao().delete(club_id, platform)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{club_id}/notifications/{platform}/test",
+    response_model=TestSendResponse,
+)
+def test_send_channel(
+    club_id: int,
+    platform: str,
+    current_user: dict = Depends(get_current_user_required),
+) -> TestSendResponse:
+    ensure_club_access(current_user, club_id)
+    _validate_platform(platform)
+
+    if not is_notifications_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Notifications are disabled globally (NOTIFICATIONS_ENABLED=false)",
+        )
+
+    if not check_rate_limit(f"ratelimit:notify-test:{club_id}", max_per_minute=5):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded: 5 test sends per minute per club",
+        )
+
+    row = _dao().get(club_id, platform)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No {platform} channel configured for club {club_id}",
+        )
+
+    try:
+        _send_test_message(platform, row["destination"])
+    except NotImplementedError as exc:
+        # Phase 3 only — Phase 5 replaces the stub with real sending.
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=str(exc),
+        ) from None
+    except Exception as exc:
+        logger.exception(
+            "test_send_failed",
+            club_id=club_id,
+            platform=platform,
+            error_type=type(exc).__name__,
+        )
+        return TestSendResponse(success=False, error=type(exc).__name__)
+
+    return TestSendResponse(success=True, error=None)

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from api.channel_requests import router as channel_requests_router
+from api.club_notifications import router as club_notifications_router
 from api.invite_requests import router as invite_requests_router
 from api.invites import router as invites_router
 from auth import (
@@ -253,6 +254,7 @@ def get_client_ip(request: Request) -> str:
 app.include_router(invites_router)
 app.include_router(invite_requests_router)
 app.include_router(channel_requests_router)
+app.include_router(club_notifications_router)
 
 # Version endpoint
 import contextlib

--- a/backend/tests/integration/api/test_club_notifications_api.py
+++ b/backend/tests/integration/api/test_club_notifications_api.py
@@ -1,0 +1,390 @@
+"""
+API contract / integration tests for club notification channel endpoints.
+
+Uses FastAPI TestClient with `app.dependency_overrides` to impersonate each
+role, and the real local Supabase for DAO-layer state. Covers permissions,
+masking, validation, the NOTIFICATIONS_ENABLED kill switch, and the
+Redis-backed rate limiter on test-send.
+
+The tests mock `_send_test_message` so they don't require Phase 5 sending
+code. They also patch `check_rate_limit` where determinism matters, since
+the real limiter uses wall-clock minute buckets.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import club_notifications as api_module
+from app import app
+from auth import get_current_user_required
+from dao.club_dao import ClubDAO
+from dao.club_notifications_dao import ClubNotificationsDAO
+from dao.match_dao import SupabaseConnection
+
+pytestmark = [pytest.mark.integration, pytest.mark.api]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unique_name() -> str:
+    return f"NotifyApi-{uuid.uuid4().hex[:8]}"
+
+
+def _fake_user(role: str, club_id: int | None = None, user_id: str = "u-1"):
+    return {
+        "user_id": user_id,
+        "username": f"{role}_user",
+        "role": role,
+        "email": f"{role}@example.com",
+        "team_id": None,
+        "club_id": club_id,
+        "display_name": f"{role.title()} User",
+    }
+
+
+@contextmanager
+def as_user(user: dict):
+    app.dependency_overrides[get_current_user_required] = lambda: user
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_current_user_required, None)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn():
+    return SupabaseConnection()
+
+
+@pytest.fixture
+def club_dao(conn):
+    return ClubDAO(conn)
+
+
+@pytest.fixture
+def notif_dao(conn):
+    return ClubNotificationsDAO(conn)
+
+
+@pytest.fixture
+def club(club_dao):
+    c = club_dao.create_club(name=_unique_name(), city="Boston")
+    yield c
+    try:
+        club_dao.delete_club(c["id"])
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def other_club(club_dao):
+    c = club_dao.create_club(name=_unique_name(), city="NYC")
+    yield c
+    try:
+        club_dao.delete_club(c["id"])
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# GET /api/clubs/{club_id}/notifications
+# ---------------------------------------------------------------------------
+
+
+class TestListChannels:
+    def test_empty_list_for_unconfigured_club(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.get(f"/api/clubs/{club['id']}/notifications")
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_returns_configured_channels_with_masked_destination(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-1001234567890")
+        with as_user(_fake_user("admin")) as c:
+            r = c.get(f"/api/clubs/{club['id']}/notifications")
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data) == 1
+        assert data[0]["platform"] == "telegram"
+        assert data[0]["configured"] is True
+        assert data[0]["enabled"] is True
+        assert data[0]["hint"] == "7890"  # last 4 of destination
+        assert "destination" not in data[0]  # full value never exposed
+
+    def test_club_manager_sees_own_club(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "discord", "https://discord.com/api/webhooks/9/xyz9")
+        with as_user(_fake_user("club_manager", club_id=club["id"])) as c:
+            r = c.get(f"/api/clubs/{club['id']}/notifications")
+        assert r.status_code == 200
+        assert r.json()[0]["hint"] == "xyz9"
+
+    def test_club_manager_denied_other_club(self, club, other_club, notif_dao):
+        notif_dao.upsert(other_club["id"], "telegram", "-100aaa")
+        with as_user(_fake_user("club_manager", club_id=club["id"])) as c:
+            r = c.get(f"/api/clubs/{other_club['id']}/notifications")
+        assert r.status_code == 403
+
+    def test_regular_user_denied(self, club):
+        with as_user(_fake_user("user")) as c:
+            r = c.get(f"/api/clubs/{club['id']}/notifications")
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/clubs/{club_id}/notifications/{platform}
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertChannel:
+    def test_admin_creates_telegram(self, club, notif_dao):
+        with as_user(_fake_user("admin")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/telegram",
+                json={"destination": "-1001112223334", "enabled": True},
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["platform"] == "telegram"
+        assert body["enabled"] is True
+        assert body["hint"] == "3334"
+        # DB side: destination stored in full
+        stored = notif_dao.get(club["id"], "telegram")
+        assert stored["destination"] == "-1001112223334"
+
+    def test_admin_creates_discord_webhook(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/discord",
+                json={
+                    "destination": "https://discord.com/api/webhooks/12345/abc-DEF_token123",
+                    "enabled": True,
+                },
+            )
+        assert r.status_code == 200
+        assert r.json()["hint"] == "n123"
+
+    def test_admin_overwrites_existing_channel(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-1000000000001")
+        with as_user(_fake_user("admin")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/telegram",
+                json={"destination": "-1000000000002", "enabled": False},
+            )
+        assert r.status_code == 200
+        assert r.json()["enabled"] is False
+        assert notif_dao.get(club["id"], "telegram")["destination"] == "-1000000000002"
+
+    def test_club_manager_creates_for_own_club(self, club):
+        with as_user(_fake_user("club_manager", club_id=club["id"])) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/telegram",
+                json={"destination": "-1009999", "enabled": True},
+            )
+        assert r.status_code == 200
+
+    def test_club_manager_denied_other_club(self, other_club, club):
+        with as_user(_fake_user("club_manager", club_id=club["id"])) as c:
+            r = c.put(
+                f"/api/clubs/{other_club['id']}/notifications/telegram",
+                json={"destination": "-100abc", "enabled": True},
+            )
+        assert r.status_code == 403
+
+    def test_regular_user_denied(self, club):
+        with as_user(_fake_user("user")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/telegram",
+                json={"destination": "-100abc", "enabled": True},
+            )
+        assert r.status_code == 403
+
+    def test_invalid_telegram_destination_rejected(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/telegram",
+                json={"destination": "not-a-chat-id", "enabled": True},
+            )
+        assert r.status_code == 422
+
+    def test_invalid_discord_destination_rejected(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/discord",
+                json={"destination": "https://example.com/hook", "enabled": True},
+            )
+        assert r.status_code == 422
+
+    def test_unknown_platform_rejected(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.put(
+                f"/api/clubs/{club['id']}/notifications/sms",
+                json={"destination": "555-1212", "enabled": True},
+            )
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/clubs/{club_id}/notifications/{platform}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteChannel:
+    def test_admin_deletes(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-100xxxx")
+        with as_user(_fake_user("admin")) as c:
+            r = c.delete(f"/api/clubs/{club['id']}/notifications/telegram")
+        assert r.status_code == 204
+        assert notif_dao.get(club["id"], "telegram") is None
+
+    def test_delete_nonexistent_still_204(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.delete(f"/api/clubs/{club['id']}/notifications/telegram")
+        assert r.status_code == 204
+
+    def test_club_manager_denied_other_club(self, club, other_club):
+        with as_user(_fake_user("club_manager", club_id=club["id"])) as c:
+            r = c.delete(f"/api/clubs/{other_club['id']}/notifications/telegram")
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /api/clubs/{club_id}/notifications/{platform}/test
+# ---------------------------------------------------------------------------
+
+
+class TestTestSend:
+    def test_returns_501_when_sender_not_implemented(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-100sendtest1")
+        with as_user(_fake_user("admin")) as c:
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+        assert r.status_code == 501  # Phase 3 stub raises NotImplementedError
+
+    def test_success_when_sender_mocked(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-100sendtest2")
+        with (
+            patch.object(api_module, "_send_test_message", return_value=None),
+            as_user(_fake_user("admin")) as c,
+        ):
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+        assert r.status_code == 200
+        assert r.json() == {"success": True, "error": None}
+
+    def test_404_when_no_channel_configured(self, club):
+        with as_user(_fake_user("admin")) as c:
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+        assert r.status_code == 404
+
+    def test_503_when_notifications_disabled(self, club, notif_dao, monkeypatch):
+        notif_dao.upsert(club["id"], "telegram", "-100off")
+        monkeypatch.setenv("NOTIFICATIONS_ENABLED", "false")
+        with as_user(_fake_user("admin")) as c:
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+        assert r.status_code == 503
+
+    def test_429_when_rate_limit_exceeded(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-100ratelimited")
+        with (
+            patch.object(api_module, "check_rate_limit", return_value=False),
+            patch.object(api_module, "_send_test_message", return_value=None),
+            as_user(_fake_user("admin")) as c,
+        ):
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+        assert r.status_code == 429
+
+    def test_reports_sender_exception_without_leaking_destination(
+        self, club, notif_dao, caplog
+    ):
+        notif_dao.upsert(club["id"], "telegram", "-100shouldNotAppearInLogs")
+
+        def _boom(platform, destination):
+            raise RuntimeError("upstream down")
+
+        with (
+            patch.object(api_module, "_send_test_message", side_effect=_boom),
+            as_user(_fake_user("admin")) as c,
+        ):
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["success"] is False
+        assert body["error"] == "RuntimeError"
+        # Destination value must not leak into logs
+        assert "shouldNotAppearInLogs" not in caplog.text
+
+    def test_club_manager_can_test_own_club(self, club, notif_dao):
+        notif_dao.upsert(club["id"], "telegram", "-100mgr")
+        with (
+            patch.object(api_module, "_send_test_message", return_value=None),
+            as_user(_fake_user("club_manager", club_id=club["id"])) as c,
+        ):
+            r = c.post(f"/api/clubs/{club['id']}/notifications/telegram/test")
+        assert r.status_code == 200
+
+    def test_club_manager_denied_other_club(self, other_club, club, notif_dao):
+        notif_dao.upsert(other_club["id"], "telegram", "-100xxx")
+        with as_user(_fake_user("club_manager", club_id=club["id"])) as c:
+            r = c.post(f"/api/clubs/{other_club['id']}/notifications/telegram/test")
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiterHelper:
+    def test_fail_open_when_redis_unreachable(self, monkeypatch):
+        """If Redis isn't there, we never block requests."""
+        monkeypatch.setattr(api_module, "_redis_client", None)
+        monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:1")  # wrong port
+        # Reset the module-level client so _get_redis() retries
+        api_module._redis_client = None
+        assert api_module.check_rate_limit("t", max_per_minute=1) is True
+
+    def test_counts_requests_within_a_minute(self):
+        """Real Redis exercise: six calls, first 5 allowed, 6th blocked."""
+        # Skip gracefully if Redis isn't available locally.
+        if api_module._get_redis() is None:
+            pytest.skip("Redis not available")
+
+        key = f"ratelimit-test-{uuid.uuid4().hex[:8]}"
+        results = [api_module.check_rate_limit(key, max_per_minute=5) for _ in range(6)]
+        assert results[:5] == [True] * 5
+        assert results[5] is False
+
+
+# ---------------------------------------------------------------------------
+# Kill switch helper
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    def test_default_true(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATIONS_ENABLED", raising=False)
+        assert api_module.is_notifications_enabled() is True
+
+    @pytest.mark.parametrize("val", ["false", "0", "no", "off", "FALSE", "Off"])
+    def test_falsy_values_disable(self, monkeypatch, val):
+        monkeypatch.setenv("NOTIFICATIONS_ENABLED", val)
+        assert api_module.is_notifications_enabled() is False
+
+    @pytest.mark.parametrize("val", ["true", "1", "yes", "on", "TRUE"])
+    def test_truthy_values_enable(self, monkeypatch, val):
+        monkeypatch.setenv("NOTIFICATIONS_ENABLED", val)
+        assert api_module.is_notifications_enabled() is True


### PR DESCRIPTION
## Summary
REST API for managing per-club Telegram / Discord notification destinations. Backed by the `club_notification_channels` table shipped in Phase 2 (#317).

Four endpoints under `/api/clubs/{club_id}/notifications`:
- `GET /` — list configured channels; `destination` is never returned in full, only last 4 chars as `hint`
- `PUT /{platform}` — upsert a channel (validates destination format per platform)
- `DELETE /{platform}` — remove a channel (204)
- `POST /{platform}/test` — send a test message (501 until Phase 5 replaces the sender stub)

Part of #315. Closes #318.

## Permissions
`ensure_club_access()` helper enforces: admin (any club) OR club_manager (their own club only). All other roles get 403. Modeled after existing `require_team_manager_or_admin` pattern in `auth.py`.

## Test-send safety
- **Global kill switch**: `NOTIFICATIONS_ENABLED` env var (default `true`); `503` when off
- **Rate limit**: Redis-backed, 5/minute/club, fixed-window counter. Fail-open — any Redis error passes the request through (the limiter is best-effort defense-in-depth, not a hard quota)
- **501** until Phase 5: the `_send_test_message` stub raises `NotImplementedError`. Tests mock it

## Design notes
- **Stub for test-send**: the actual Telegram/Discord send logic lands in Phase 5 (#320) when we add the `telegram-notify` and `discord-notify` deps + dispatcher. `_send_test_message` is a module-level function specifically so Phase 5 can replace it with real sending without touching the endpoint code
- **Destination redaction**: `dao.club_notifications_dao.ClubNotificationsDAO` already avoids logging `destination`. The API layer further masks it on GET (last 4 chars) and never echoes it on PUT response
- **Test location**: tests live at `backend/tests/integration/api/` rather than `backend/tests/contract/` (where the issue originally suggested). The contract test harness requires a live backend server (`verify_server_running` session fixture). Using FastAPI TestClient + `dependency_overrides` in `integration/api/` keeps the tests standalone and CI-friendly — same pattern as `test_clubs_filtering.py`

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest tests/unit/test_club_notifications_dao.py tests/integration/api/test_club_notifications_api.py` — 51/51 passing
- [x] 39 API tests cover:
  - masking / hint format
  - each role's access (admin, club_manager own/other, regular user)
  - platform validation (telegram chat_id + @channel, discord webhook URL)
  - 422 on unknown platform
  - 404/501/503/429 branches on test-send
  - log redaction (destination never appears in captured logs)
  - `NOTIFICATIONS_ENABLED` parsing (truthy/falsy values)
  - Rate limiter fail-open when Redis unavailable
  - Rate limiter blocks 6th request in a minute (with real Redis)

## One dev-env note (not in this PR)
Both local Supabase stacks (`54322` and `54332`) had stale `clubs_id_seq` sequences vs. max(id). I bumped each to 10000 so integration tests don't collide with legacy rows. Worth a `supabase migration repair` sweep at some point — out of scope here.

## Next phase
#319 (Phase 4) — Vue admin + club manager UI wiring these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)