### PR TITLE
feat: club notification channels UI (Phase 4 of #315)

### DIFF
--- a/frontend/src/__tests__/components/ClubNotificationChannels.spec.js
+++ b/frontend/src/__tests__/components/ClubNotificationChannels.spec.js
@@ -1,0 +1,301 @@
+/**
+ * ClubNotificationChannels.vue Tests
+ *
+ * Covers:
+ * - Render both rows (telegram, discord) from GET response
+ * - Configured state shows hint + reset/test/toggle controls
+ * - Unconfigured state shows input + save with client-side validation
+ * - PUT on save; DELETE on reset; POST on test-send
+ * - Rate limit (429), kill switch (503), Phase 3 stub (501) surface as warnings
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import ClubNotificationChannels from '@/components/notifications/ClubNotificationChannels.vue';
+
+let mockAuthStore;
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => mockAuthStore,
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+}));
+
+const mockResponse = (status, body) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+const mkMount = (initialChannels = []) => {
+  globalThis.fetch = vi
+    .fn()
+    .mockResolvedValue(mockResponse(200, initialChannels));
+  return mount(ClubNotificationChannels, {
+    props: { clubId: 42 },
+  });
+};
+
+describe('ClubNotificationChannels', () => {
+  beforeEach(() => {
+    mockAuthStore = {
+      getAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),
+    };
+    // jsdom doesn't define confirm by default
+    globalThis.confirm = vi.fn(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders both telegram and discord rows', async () => {
+      const wrapper = mkMount([]);
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="row-telegram"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="row-discord"]').exists()).toBe(true);
+    });
+
+    it('shows "Not configured" when the backend returns no channels', async () => {
+      const wrapper = mkMount([]);
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="input-telegram"]').exists()).toBe(
+        true
+      );
+      expect(wrapper.find('[data-testid="save-telegram"]').exists()).toBe(true);
+    });
+
+    it('shows configured state with hint when backend returns a channel', async () => {
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      const status = wrapper.find('[data-testid="status-telegram"]');
+      expect(status.exists()).toBe(true);
+      expect(status.text()).toContain('7890');
+      expect(wrapper.find('[data-testid="reset-telegram"]').exists()).toBe(
+        true
+      );
+      expect(wrapper.find('[data-testid="test-telegram"]').exists()).toBe(true);
+    });
+  });
+
+  describe('save (PUT)', () => {
+    it('rejects invalid telegram input with inline error', async () => {
+      const wrapper = mkMount([]);
+      await flushPromises();
+
+      await wrapper
+        .find('[data-testid="input-telegram"]')
+        .setValue('not-a-chat');
+      await wrapper.find('[data-testid="save-telegram"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="error-telegram"]').exists()).toBe(
+        true
+      );
+      // fetch was called once (the initial GET). No second fetch for PUT.
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects invalid discord input with inline error', async () => {
+      const wrapper = mkMount([]);
+      await flushPromises();
+
+      await wrapper
+        .find('[data-testid="input-discord"]')
+        .setValue('https://example.com/x');
+      await wrapper.find('[data-testid="save-discord"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="error-discord"]').exists()).toBe(true);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('PUTs valid telegram destination and re-fetches', async () => {
+      const wrapper = mkMount([]);
+      await flushPromises();
+
+      // Subsequent fetches: PUT success, then GET updated list
+      globalThis.fetch
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            platform: 'telegram',
+            enabled: true,
+            configured: true,
+            hint: '7890',
+          })
+        )
+        .mockResolvedValueOnce(
+          mockResponse(200, [
+            {
+              platform: 'telegram',
+              enabled: true,
+              configured: true,
+              hint: '7890',
+            },
+          ])
+        );
+
+      await wrapper
+        .find('[data-testid="input-telegram"]')
+        .setValue('-1001234567890');
+      await wrapper.find('[data-testid="save-telegram"]').trigger('click');
+      await flushPromises();
+
+      const calls = globalThis.fetch.mock.calls;
+      const putCall = calls.find(c => c[1]?.method === 'PUT');
+      expect(putCall).toBeDefined();
+      expect(putCall[0]).toContain('/api/clubs/42/notifications/telegram');
+      expect(JSON.parse(putCall[1].body)).toEqual({
+        destination: '-1001234567890',
+        enabled: true,
+      });
+
+      expect(wrapper.find('[data-testid="flash-success"]').exists()).toBe(true);
+    });
+
+    it('accepts a valid discord webhook URL', async () => {
+      const wrapper = mkMount([]);
+      await flushPromises();
+
+      globalThis.fetch
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            platform: 'discord',
+            enabled: true,
+            configured: true,
+            hint: 'n123',
+          })
+        )
+        .mockResolvedValueOnce(mockResponse(200, []));
+
+      await wrapper
+        .find('[data-testid="input-discord"]')
+        .setValue('https://discord.com/api/webhooks/12345/abc-DEF_token123');
+      await wrapper.find('[data-testid="save-discord"]').trigger('click');
+      await flushPromises();
+
+      const putCall = globalThis.fetch.mock.calls.find(
+        c => c[1]?.method === 'PUT'
+      );
+      expect(putCall[0]).toContain('/api/clubs/42/notifications/discord');
+    });
+  });
+
+  describe('reset (DELETE)', () => {
+    it('DELETEs the channel and re-fetches on reset', async () => {
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      globalThis.fetch
+        .mockResolvedValueOnce(mockResponse(204, null))
+        .mockResolvedValueOnce(mockResponse(200, []));
+
+      await wrapper.find('[data-testid="reset-telegram"]').trigger('click');
+      await flushPromises();
+
+      const deleteCall = globalThis.fetch.mock.calls.find(
+        c => c[1]?.method === 'DELETE'
+      );
+      expect(deleteCall).toBeDefined();
+      expect(deleteCall[0]).toContain('/api/clubs/42/notifications/telegram');
+    });
+
+    it('no-ops reset when user declines confirm', async () => {
+      globalThis.confirm = vi.fn(() => false);
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      await wrapper.find('[data-testid="reset-telegram"]').trigger('click');
+      await flushPromises();
+
+      const deleteCall = globalThis.fetch.mock.calls.find(
+        c => c[1]?.method === 'DELETE'
+      );
+      expect(deleteCall).toBeUndefined();
+    });
+  });
+
+  describe('test send (POST)', () => {
+    it('POSTs to /test and shows success flash when sender succeeds', async () => {
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      globalThis.fetch.mockResolvedValueOnce(
+        mockResponse(200, { success: true, error: null })
+      );
+
+      await wrapper.find('[data-testid="test-telegram"]').trigger('click');
+      await flushPromises();
+
+      const postCall = globalThis.fetch.mock.calls.find(
+        c => c[1]?.method === 'POST'
+      );
+      expect(postCall[0]).toContain(
+        '/api/clubs/42/notifications/telegram/test'
+      );
+      expect(wrapper.find('[data-testid="flash-success"]').exists()).toBe(true);
+    });
+
+    it('surfaces 429 as rate-limit warning flash', async () => {
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      globalThis.fetch.mockResolvedValueOnce(
+        mockResponse(429, { detail: 'rate limit' })
+      );
+
+      await wrapper.find('[data-testid="test-telegram"]').trigger('click');
+      await flushPromises();
+
+      const flash = wrapper.find('[data-testid="flash-warning"]');
+      expect(flash.exists()).toBe(true);
+      expect(flash.text()).toMatch(/rate limit/i);
+    });
+
+    it('surfaces 503 as kill-switch warning flash', async () => {
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      globalThis.fetch.mockResolvedValueOnce(mockResponse(503, {}));
+
+      await wrapper.find('[data-testid="test-telegram"]').trigger('click');
+      await flushPromises();
+
+      const flash = wrapper.find('[data-testid="flash-warning"]');
+      expect(flash.exists()).toBe(true);
+      expect(flash.text()).toMatch(/disabled/i);
+    });
+
+    it('surfaces 501 from Phase 3 stub as warning flash', async () => {
+      const wrapper = mkMount([
+        { platform: 'telegram', enabled: true, configured: true, hint: '7890' },
+      ]);
+      await flushPromises();
+
+      globalThis.fetch.mockResolvedValueOnce(mockResponse(501, {}));
+
+      await wrapper.find('[data-testid="test-telegram"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="flash-warning"]').exists()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/components/AdminPanel.vue
+++ b/frontend/src/components/AdminPanel.vue
@@ -68,6 +68,15 @@
           <AdminChannelRequests />
         </div>
 
+        <!-- Live Match Notifications (per-club Telegram/Discord) -->
+        <div
+          v-if="currentSection === 'club-notifications'"
+          class="p-6"
+          data-testid="admin-section-club-notifications"
+        >
+          <AdminClubNotifications />
+        </div>
+
         <!-- Age Groups Management -->
         <div
           v-if="currentSection === 'age-groups'"
@@ -212,6 +221,7 @@ import AdminMatches from './admin/AdminMatches.vue';
 import AdminGoals from './admin/AdminGoals.vue';
 import AdminInvites from './admin/AdminInvites.vue';
 import AdminChannelRequests from './admin/AdminChannelRequests.vue';
+import AdminClubNotifications from './admin/AdminClubNotifications.vue';
 import AdminInviteRequests from './admin/AdminInviteRequests.vue';
 import AdminPlayoffs from './admin/AdminPlayoffs.vue';
 import AdminCache from './admin/AdminCache.vue';
@@ -232,6 +242,7 @@ export default {
     AdminGoals,
     AdminInvites,
     AdminChannelRequests,
+    AdminClubNotifications,
     AdminInviteRequests,
     AdminPlayoffs,
     AdminCache,
@@ -246,6 +257,11 @@ export default {
     const allAdminSections = [
       { id: 'invite-requests', name: 'Requests', adminOnly: true },
       { id: 'channel-requests', name: 'Channel Requests', adminOnly: false },
+      {
+        id: 'club-notifications',
+        name: 'Live Match Notifications',
+        adminOnly: false,
+      },
       { id: 'age-groups', name: 'Age Groups', adminOnly: true },
       { id: 'seasons', name: 'Seasons', adminOnly: true },
       { id: 'leagues', name: 'Leagues', adminOnly: true },

--- a/frontend/src/components/admin/AdminClubNotifications.vue
+++ b/frontend/src/components/admin/AdminClubNotifications.vue
@@ -1,0 +1,79 @@
+<template>
+  <div data-testid="admin-club-notifications">
+    <div class="flex justify-between items-center mb-6">
+      <h2 class="text-xl font-bold text-gray-900">Club Notifications</h2>
+      <!-- Admins pick a club; club_managers are auto-scoped to their own -->
+      <div v-if="isAdmin" class="flex items-center gap-3">
+        <label class="text-sm text-gray-600" for="club-picker">Club:</label>
+        <select
+          id="club-picker"
+          v-model.number="selectedClubId"
+          data-testid="admin-notifications-club-picker"
+          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option :value="null" disabled>Select a club…</option>
+          <option v-for="c in clubs" :key="c.id" :value="c.id">
+            {{ c.name }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <div v-if="loadingClubs" class="text-sm text-gray-500">Loading clubs…</div>
+
+    <div
+      v-else-if="!isAdmin && !selectedClubId"
+      class="bg-yellow-50 border border-yellow-200 rounded-md p-4 text-sm text-yellow-800"
+      data-testid="no-club-assigned"
+    >
+      No club is assigned to your account. Contact an administrator to have one
+      assigned before configuring notifications.
+    </div>
+
+    <div v-else-if="selectedClubId">
+      <ClubNotificationChannels :club-id="selectedClubId" />
+    </div>
+
+    <div v-else class="text-sm text-gray-500" data-testid="no-club-selected">
+      Select a club to configure its notification channels.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import { getApiBaseUrl } from '@/config/api';
+import ClubNotificationChannels from '@/components/notifications/ClubNotificationChannels.vue';
+
+const authStore = useAuthStore();
+
+const isAdmin = computed(() => authStore.isAdmin.value);
+const ownClubId = computed(() => authStore.state.profile?.club_id ?? null);
+
+const clubs = ref([]);
+const loadingClubs = ref(false);
+const selectedClubId = ref(null);
+
+const fetchClubs = async () => {
+  loadingClubs.value = true;
+  try {
+    const resp = await fetch(`${getApiBaseUrl()}/api/clubs`, {
+      headers: authStore.getAuthHeaders(),
+    });
+    if (resp.ok) {
+      clubs.value = await resp.json();
+    }
+  } finally {
+    loadingClubs.value = false;
+  }
+};
+
+onMounted(async () => {
+  if (isAdmin.value) {
+    await fetchClubs();
+  } else {
+    selectedClubId.value = ownClubId.value;
+  }
+});
+</script>

--- a/frontend/src/components/notifications/ClubNotificationChannels.vue
+++ b/frontend/src/components/notifications/ClubNotificationChannels.vue
@@ -1,0 +1,533 @@
+<template>
+  <div class="club-notifications" data-testid="club-notifications">
+    <div class="header">
+      <h3 class="title">Live Match Notifications</h3>
+      <p class="subtitle">
+        When live match events happen, Missing Table can post updates to your
+        club's Telegram group and/or Discord channel. Configure each platform
+        below. Destinations are write-only: once saved, you can test or reset
+        them, but the full value is never displayed again.
+      </p>
+    </div>
+
+    <!-- Inline flash message -->
+    <div
+      v-if="flash"
+      :class="['flash', flash.kind]"
+      :data-testid="`flash-${flash.kind}`"
+    >
+      {{ flash.text }}
+    </div>
+
+    <div v-if="loading" class="loading" data-testid="loading">
+      Loading channels…
+    </div>
+
+    <div v-else-if="loadError" class="flash error">
+      {{ loadError }}
+      <button class="link" @click="fetchChannels">Retry</button>
+    </div>
+
+    <div v-else class="rows">
+      <div
+        v-for="platform in platforms"
+        :key="platform.id"
+        class="row"
+        :data-testid="`row-${platform.id}`"
+      >
+        <div class="row-header">
+          <span class="platform-name">
+            <span class="icon" aria-hidden="true">{{ platform.icon }}</span>
+            {{ platform.label }}
+          </span>
+          <span
+            v-if="configured(platform.id)"
+            class="status configured"
+            :data-testid="`status-${platform.id}`"
+          >
+            ✓ Configured (ends …{{ hintFor(platform.id) }})
+          </span>
+          <span v-else class="status unconfigured">Not configured</span>
+        </div>
+
+        <!-- Configured: show toggle + test + reset -->
+        <div v-if="configured(platform.id)" class="row-actions">
+          <label class="toggle">
+            <input
+              type="checkbox"
+              :checked="enabledFor(platform.id)"
+              :disabled="busy[platform.id]"
+              :data-testid="`toggle-${platform.id}`"
+              @change="toggleEnabled(platform.id, $event.target.checked)"
+            />
+            <span>Enabled</span>
+          </label>
+
+          <button
+            class="btn secondary"
+            :disabled="busy[platform.id] || !enabledFor(platform.id)"
+            :data-testid="`test-${platform.id}`"
+            @click="testSend(platform.id)"
+          >
+            Send test
+          </button>
+
+          <button
+            class="btn danger"
+            :disabled="busy[platform.id]"
+            :data-testid="`reset-${platform.id}`"
+            @click="reset(platform.id)"
+          >
+            Reset
+          </button>
+        </div>
+
+        <!-- Not configured: input + save -->
+        <div v-else class="row-input">
+          <input
+            v-model="draft[platform.id]"
+            :placeholder="platform.placeholder"
+            :data-testid="`input-${platform.id}`"
+            class="input"
+            :disabled="busy[platform.id]"
+            @input="clearValidationError(platform.id)"
+          />
+          <button
+            class="btn primary"
+            :disabled="!canSave(platform.id) || busy[platform.id]"
+            :data-testid="`save-${platform.id}`"
+            @click="save(platform.id)"
+          >
+            {{ busy[platform.id] ? 'Saving…' : 'Save' }}
+          </button>
+        </div>
+
+        <!-- Per-row validation error -->
+        <div
+          v-if="validationError[platform.id]"
+          class="field-error"
+          :data-testid="`error-${platform.id}`"
+        >
+          {{ validationError[platform.id] }}
+        </div>
+
+        <p class="hint-text">{{ platform.hint }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref, watch } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import { getApiBaseUrl } from '@/config/api';
+
+const props = defineProps({
+  clubId: {
+    type: Number,
+    required: true,
+  },
+});
+
+const authStore = useAuthStore();
+
+// Mirrors backend validation in backend/api/club_notifications.py
+const TELEGRAM_RE = /^(@\w+|-?\d+)$/;
+const DISCORD_RE = /^https:\/\/discord(app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/;
+
+const platforms = [
+  {
+    id: 'telegram',
+    label: 'Telegram',
+    icon: '✈️',
+    placeholder: 'e.g. -1001234567890 or @channelname',
+    hint: 'Paste the chat_id for a group the Missing Table bot has been added to, or an @channel username.',
+    validator: v => {
+      if (!v) return 'Required';
+      if (!TELEGRAM_RE.test(v))
+        return 'Must be a numeric chat_id (e.g. -1001234567890) or @channelname';
+      return null;
+    },
+  },
+  {
+    id: 'discord',
+    label: 'Discord',
+    icon: '💬',
+    placeholder: 'https://discord.com/api/webhooks/…/…',
+    hint: 'Create a webhook on your Discord channel (Channel Settings → Integrations → Webhooks) and paste the full URL.',
+    validator: v => {
+      if (!v) return 'Required';
+      if (!DISCORD_RE.test(v))
+        return 'Must be a Discord webhook URL (discord.com/api/webhooks/{id}/{token})';
+      return null;
+    },
+  },
+];
+
+const channels = ref([]); // from GET
+const draft = reactive({ telegram: '', discord: '' });
+const busy = reactive({ telegram: false, discord: false });
+const validationError = reactive({ telegram: null, discord: null });
+const loading = ref(false);
+const loadError = ref(null);
+const flash = ref(null); // { kind: 'success'|'error'|'warning', text }
+
+let flashTimer = null;
+const showFlash = (kind, text, ttlMs = 5000) => {
+  flash.value = { kind, text };
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => (flash.value = null), ttlMs);
+};
+
+const urlBase = () =>
+  `${getApiBaseUrl()}/api/clubs/${props.clubId}/notifications`;
+const authHeaders = () => authStore.getAuthHeaders();
+
+const configured = platformId =>
+  channels.value.some(c => c.platform === platformId && c.configured);
+
+const hintFor = platformId => {
+  const row = channels.value.find(c => c.platform === platformId);
+  return row?.hint ?? '';
+};
+
+const enabledFor = platformId => {
+  const row = channels.value.find(c => c.platform === platformId);
+  return !!row?.enabled;
+};
+
+const canSave = platformId => {
+  const value = (draft[platformId] || '').trim();
+  const platform = platforms.find(p => p.id === platformId);
+  const err = platform.validator(value);
+  if (err && draft[platformId]) {
+    // Validation happens only once the user has typed something.
+    validationError[platformId] = err;
+  } else {
+    validationError[platformId] = null;
+  }
+  return !err;
+};
+
+const clearValidationError = platformId => {
+  validationError[platformId] = null;
+};
+
+const fetchChannels = async () => {
+  loading.value = true;
+  loadError.value = null;
+  try {
+    const resp = await fetch(urlBase(), { headers: authHeaders() });
+    if (!resp.ok)
+      throw new Error(`Failed to load channels (HTTP ${resp.status})`);
+    channels.value = await resp.json();
+  } catch (err) {
+    loadError.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+
+const save = async platformId => {
+  const value = (draft[platformId] || '').trim();
+  const platform = platforms.find(p => p.id === platformId);
+  const err = platform.validator(value);
+  if (err) {
+    validationError[platformId] = err;
+    return;
+  }
+
+  busy[platformId] = true;
+  try {
+    const resp = await fetch(`${urlBase()}/${platformId}`, {
+      method: 'PUT',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ destination: value, enabled: true }),
+    });
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      throw new Error(body.detail || `Save failed (HTTP ${resp.status})`);
+    }
+    draft[platformId] = '';
+    showFlash('success', `${platform.label} channel saved.`);
+    await fetchChannels();
+  } catch (err) {
+    showFlash('error', err.message);
+  } finally {
+    busy[platformId] = false;
+  }
+};
+
+const toggleEnabled = async (platformId, nextEnabled) => {
+  // Enabling/disabling requires the destination again. We don't have it, so
+  // we PUT with a placeholder — but the API requires the real value. Instead,
+  // we explicitly disable by calling DELETE, and require the user to re-save
+  // to re-enable. Simpler contract; no storing destinations in the client.
+  if (nextEnabled) {
+    // Revert the toggle visually by refreshing state.
+    await fetchChannels();
+    showFlash(
+      'warning',
+      'Re-saving required. Use Reset, then Save with the destination again to re-enable.'
+    );
+    return;
+  }
+  busy[platformId] = true;
+  try {
+    const resp = await fetch(`${urlBase()}/${platformId}`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    if (!resp.ok) throw new Error(`Disable failed (HTTP ${resp.status})`);
+    showFlash('success', 'Channel disabled.');
+    await fetchChannels();
+  } catch (err) {
+    showFlash('error', err.message);
+    await fetchChannels();
+  } finally {
+    busy[platformId] = false;
+  }
+};
+
+const reset = async platformId => {
+  if (
+    !confirm(
+      `Remove the ${platformId} notification channel for this club? The destination will have to be re-entered.`
+    )
+  )
+    return;
+  busy[platformId] = true;
+  try {
+    const resp = await fetch(`${urlBase()}/${platformId}`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    if (!resp.ok) throw new Error(`Reset failed (HTTP ${resp.status})`);
+    showFlash('success', 'Channel cleared.');
+    await fetchChannels();
+  } catch (err) {
+    showFlash('error', err.message);
+  } finally {
+    busy[platformId] = false;
+  }
+};
+
+const testSend = async platformId => {
+  busy[platformId] = true;
+  try {
+    const resp = await fetch(`${urlBase()}/${platformId}/test`, {
+      method: 'POST',
+      headers: authHeaders(),
+    });
+    if (resp.status === 429) {
+      showFlash('warning', 'Rate limit: max 5 test sends per minute per club.');
+      return;
+    }
+    if (resp.status === 503) {
+      showFlash(
+        'warning',
+        'Notifications are globally disabled by an administrator.'
+      );
+      return;
+    }
+    if (resp.status === 501) {
+      showFlash(
+        'warning',
+        'Live send is not wired up yet — the notification dispatcher ships in a later phase.'
+      );
+      return;
+    }
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      throw new Error(body.detail || `Test failed (HTTP ${resp.status})`);
+    }
+    const body = await resp.json();
+    if (body.success) {
+      showFlash('success', `Test message sent to ${platformId}.`);
+    } else {
+      showFlash('error', `Send failed: ${body.error || 'unknown error'}`);
+    }
+  } catch (err) {
+    showFlash('error', err.message);
+  } finally {
+    busy[platformId] = false;
+  }
+};
+
+watch(
+  () => props.clubId,
+  () => fetchChannels()
+);
+
+onMounted(fetchChannels);
+</script>
+
+<style scoped>
+.club-notifications {
+  max-width: 720px;
+}
+.header {
+  margin-bottom: 1rem;
+}
+.title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #111827;
+}
+.subtitle {
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+.loading {
+  padding: 1rem;
+  color: #6b7280;
+  text-align: center;
+}
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.row {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: #fff;
+}
+.row-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.platform-name {
+  font-weight: 500;
+  color: #111827;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+.icon {
+  font-size: 1rem;
+}
+.status {
+  font-size: 0.8125rem;
+}
+.status.configured {
+  color: #059669;
+  font-weight: 500;
+}
+.status.unconfigured {
+  color: #9ca3af;
+}
+.row-actions {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.row-input {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}
+.input:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: -1px;
+  border-color: #3b82f6;
+}
+.btn {
+  padding: 0.5rem 0.875rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn.primary {
+  background: #2563eb;
+  color: #fff;
+}
+.btn.primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+.btn.secondary {
+  background: #f3f4f6;
+  color: #111827;
+  border-color: #d1d5db;
+}
+.btn.secondary:hover:not(:disabled) {
+  background: #e5e7eb;
+}
+.btn.danger {
+  background: #fff;
+  color: #b91c1c;
+  border-color: #fecaca;
+}
+.btn.danger:hover:not(:disabled) {
+  background: #fee2e2;
+}
+.toggle {
+  display: inline-flex;
+  gap: 0.375rem;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #374151;
+}
+.hint-text {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+.field-error {
+  color: #b91c1c;
+  font-size: 0.8125rem;
+  margin-top: 0.375rem;
+}
+.flash {
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+}
+.flash.success {
+  background: #ecfdf5;
+  color: #065f46;
+  border-color: #a7f3d0;
+}
+.flash.error {
+  background: #fef2f2;
+  color: #991b1b;
+  border-color: #fecaca;
+}
+.flash.warning {
+  background: #fffbeb;
+  color: #92400e;
+  border-color: #fde68a;
+}
+.link {
+  margin-left: 0.5rem;
+  color: #2563eb;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  text-decoration: underline;
+  padding: 0;
+}
+</style>

--- a/frontend/src/components/profiles/ClubManagerProfile.vue
+++ b/frontend/src/components/profiles/ClubManagerProfile.vue
@@ -170,6 +170,11 @@
         to get assigned.
       </p>
     </div>
+    <!-- Live Match Notification Channels (Telegram / Discord per club) -->
+    <div v-if="club?.id" class="notifications-section">
+      <ClubNotificationChannels :club-id="club.id" />
+    </div>
+
     <LiveUpdatesSection />
   </div>
 </template>
@@ -180,10 +185,15 @@ import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../../config/api';
 import LiveUpdatesTeaser from './LiveUpdatesTeaser.vue';
 import LiveUpdatesSection from './LiveUpdatesSection.vue';
+import ClubNotificationChannels from '@/components/notifications/ClubNotificationChannels.vue';
 
 export default {
   name: 'ClubManagerProfile',
-  components: { LiveUpdatesTeaser, LiveUpdatesSection },
+  components: {
+    LiveUpdatesTeaser,
+    LiveUpdatesSection,
+    ClubNotificationChannels,
+  },
   emits: ['switch-tab'],
   setup(props, { emit }) {
     const authStore = useAuthStore();


### PR DESCRIPTION
## Summary
Vue 3 UI for managing per-club Telegram / Discord live-match notification destinations. Consumes the endpoints shipped in Phase 3 (#318).

Part of epic #315. Closes #319.

## What's new

**`ClubNotificationChannels.vue`** (`frontend/src/components/notifications/`)
The focused editor. Two rows (telegram, discord) with state-aware controls:
- **Unconfigured**: input + Save, with inline client-side validation mirroring the backend regexes
- **Configured**: `✓ Configured (ends …xxxx)` + Enabled toggle + Send test + Reset
- Destination is write-only. After save, only last 4 chars of the destination are ever rendered (`hint` from the API)
- Flash messages for success / error / rate-limit (429) / kill-switch (503) / Phase 3 stub (501)

**`AdminClubNotifications.vue`** (`frontend/src/components/admin/`)
Admin-panel wrapper:
- Admin: club picker dropdown (populated via `GET /api/clubs`)
- Club manager: auto-scoped to their own `user_club_id`

**Wiring**
- `AdminPanel.vue`: new "Live Match Notifications" tab with `adminOnly: false` so club_managers see it too
- `ClubManagerProfile.vue`: embeds the editor directly on the profile dashboard so club managers don't need to jump into admin

## Validation mirrors backend

```
telegram: ^(@\w+|-?\d+)$
discord:  ^https://discord(app)?\.com/api/webhooks/\d+/[\w-]+$
```

## Manual QA (live browser against running backend)

Logged in as admin (`tom`), selected IFA club:

| Action | Network | UI result |
|---|---|---|
| Load section | `GET /api/clubs/1/notifications` → 200 `[]` | Two "Not configured" rows render |
| Enter invalid telegram (`not-a-chat-id`) | *(no network)* | Inline error "Must be a numeric chat_id…", Save disabled |
| Enter valid telegram (`-1001234567890`) + Save | `PUT ... 200`, `GET ... 200` | Row flips to "✓ Configured (ends …7890)" + toggle/test/reset |
| Send test | `POST .../test 501` | Phase 3 stub surfaces as warning flash ("wired up in a later phase") |
| Reset (confirm) | `DELETE ... 204`, `GET ... 200` | Row returns to "Not configured" |
| Channel Requests tab (regression check) | *(pre-existing 500 from unrelated code)* | No new error — feature doesn't leak into sibling tabs |

## Test plan

- [x] `npm run lint` — clean (ESLint auto-formatted on commit via husky)
- [x] `npx vitest run ClubNotificationChannels.spec.js` — 13/13 pass
- [x] `npm run test:run` full suite — 195/195 pass
- [x] Browser QA above (see screenshots in the comment below)
- [ ] Reviewer: verify Club Manager path by logging in as one of the `club_manager` test users

## Scope

- **In scope**: UI, validation, state transitions, test-send button. No backend changes.
- **Out of scope**: Actual Telegram/Discord sending — that's Phase 5 (#320). Until then, Send test surfaces 501 from the Phase 3 stub as a friendly warning.

## Next phase
#320 (Phase 5) — notification dispatcher + formatters + wiring into live match endpoints. Once that lands, Send test will actually deliver a message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)