### PR TITLE
feat: wire TELEGRAM_BOT_TOKEN through helm (Phase 6 of #315)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -667,14 +667,14 @@
         "filename": "helm/missing-table/values-dev.yaml.example",
         "hashed_secret": "1bfee5bbc6ccbb231a3b5e484fcc9e50114c119b",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 34
       },
       {
         "type": "Secret Keyword",
         "filename": "helm/missing-table/values-dev.yaml.example",
         "hashed_secret": "c5186bab2257c3a0e6144201bc3c57c7fc3c1871",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 112
       }
     ],
     "helm/missing-table/values-prod-deprecated.yaml.example": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T22:55:22Z"
+  "generated_at": "2026-04-22T13:25:28Z"
 }

--- a/helm/missing-table/templates/backend.yaml
+++ b/helm/missing-table/templates/backend.yaml
@@ -79,6 +79,20 @@ spec:
               name: {{ include "missing-table.fullname" . }}-secrets
               key: resend-api-key
               optional: true
+        # Telegram bot token for live-match notifications.
+        # Optional: pod starts even if the key is absent; the dispatcher logs
+        # a NotificationConfigError and skips telegram sends until the key
+        # is populated (by ESO in prod, by values.secrets.telegramBotToken
+        # locally/dev).
+        - name: TELEGRAM_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "missing-table.fullname" . }}-secrets
+              key: telegram-bot-token
+              optional: true
+        # Global kill switch for live-match notifications. Defaults to true.
+        - name: NOTIFICATIONS_ENABLED
+          value: {{ .Values.notifications.enabled | default true | quote }}
         # Non-sensitive configuration
         - name: APP_BASE_URL
           value: {{ .Values.backend.env.appBaseUrl | default "https://missingtable.com" | quote }}

--- a/helm/missing-table/templates/secrets.yaml
+++ b/helm/missing-table/templates/secrets.yaml
@@ -26,6 +26,14 @@ stringData:
   resend-api-key: {{ .Values.secrets.resendApiKey | quote }}
   {{- end }}
 
+  # Telegram bot token - for live-match notifications (Phase 6 of #315)
+  # In prod this key is populated by External Secrets Operator from AWS
+  # Secrets Manager, so values-prod.yaml has no secrets block and this
+  # conditional is harmless there.
+  {{- if .Values.secrets.telegramBotToken }}
+  telegram-bot-token: {{ .Values.secrets.telegramBotToken | quote }}
+  {{- end }}
+
   # RabbitMQ connection (for match-scraper CronJob)
   {{- if .Values.rabbitmq }}
   rabbitmq-url: {{ printf "amqp://%s:%s@%s:%d//" .Values.rabbitmq.username .Values.rabbitmq.password .Values.rabbitmq.host (.Values.rabbitmq.port | int) | quote }} # pragma: allowlist secret

--- a/helm/missing-table/values-dev.yaml.example
+++ b/helm/missing-table/values-dev.yaml.example
@@ -24,6 +24,10 @@ secrets:
   # Application secrets
   serviceAccountSecret: "your-service-account-secret-here"
 
+  # Telegram bot token — for live-match notifications. Leave empty/commented
+  # to disable telegram sends (discord is independent, per-club webhook).
+  # telegramBotToken: "your-telegram-bot-token-here"
+
   # Grafana Cloud OTLP credentials (for frontend telemetry)
   # Get these from: Grafana Cloud -> Connections -> OTLP
   grafanaInstanceId: "your-grafana-instance-id"

--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -26,6 +26,13 @@ backend:
     extra:
       CACHE_ENABLED: "true"
 
+# Live-match notifications (explicit override — defaults to true in values.yaml)
+# The TELEGRAM_BOT_TOKEN key inside the ESO-managed missing-table-secrets must
+# exist in AWS Secrets Manager BEFORE any real telegram sends will succeed.
+# Until then, the dispatcher logs NotificationConfigError and skips telegram.
+notifications:
+  enabled: true
+
 # Redis for caching (deployed by this Helm chart)
 redis:
   enabled: true

--- a/helm/missing-table/values.yaml
+++ b/helm/missing-table/values.yaml
@@ -83,12 +83,12 @@ redis:
 # Backend configuration
 backend:
   replicaCount: 1
-  
+
   image:
     repository: missing-table-backend
     tag: ""  # Defaults to chart appVersion
     pullPolicy: Always
-  
+
   env:
     databaseUrl: "postgresql://postgres:postgres@host.rancher-desktop.internal:54322/postgres"
     environment: "development"
@@ -132,6 +132,15 @@ backend:
     loadBalancer:
       enabled: false  # Disabled in favor of Ingress for external access
       port: 8000
+
+# Live-match notifications (Telegram / Discord per club).
+# TELEGRAM_BOT_TOKEN is read from the `missing-table-secrets` k8s Secret
+# (populated by External Secrets Operator in prod, or by values.secrets.telegramBotToken
+# locally). The env var is marked optional, so the pod starts even without
+# the key — the dispatcher logs a NotificationConfigError and skips telegram
+# sends until the key is populated.
+notifications:
+  enabled: true
 
 # Frontend configuration
 frontend:


### PR DESCRIPTION
## Summary
Wires the `TELEGRAM_BOT_TOKEN` and `NOTIFICATIONS_ENABLED` env vars the Phase 5 dispatcher needs, via the existing ESO-backed `missing-table-secrets` k8s Secret.

Part of epic #315. Closes #321.

## ⚠️ Do NOT merge until the AWS Secrets Manager entry is created

This PR is additive and safe to merge from a code-standpoint, but the feature will only deliver telegram messages once **all three** of these are in place:

1. A real bot token exists in **AWS Secrets Manager** at `missing-table/prod/telegram-bot-token` (or whatever path your ESO `SecretStore` / ExternalSecret points at)
2. The **ESO `ExternalSecret` manifest** (in `missingtable-platform-bootstrap`) is updated to add a `telegram-bot-token` key to the `missing-table-secrets` Kubernetes Secret
3. At least one club configures a Telegram destination in the admin UI

Discord is independent — webhook URLs are stored per-club in Postgres and need none of the above.

## Changes

| File | Change |
|---|---|
| `templates/backend.yaml` | Add `TELEGRAM_BOT_TOKEN` env (secretKeyRef to `missing-table-secrets`/`telegram-bot-token`, `optional: true`) + `NOTIFICATIONS_ENABLED` env (from helm value) |
| `templates/secrets.yaml` | Conditional `telegram-bot-token` entry for the local/dev values-based Secret (no-op in prod since `.Values.secrets` is unset there) |
| `values.yaml` | `notifications.enabled: true` default |
| `values-prod.yaml` | Explicit `notifications.enabled: true` + comment explaining the ESO dependency |
| `values-dev.yaml.example` | Commented-out `telegramBotToken` slot |
| `.secrets.baseline` | Line-number shifts from the added lines (existing entries, no new secret flags) |

## Why `optional: true`

Without this flag, the backend pod would fail to start if the `telegram-bot-token` key doesn't exist in the Secret — a chicken-and-egg problem during the staged rollout. With `optional: true`, the pod starts cleanly; the dispatcher catches the missing-token case via `NotificationConfigError` and logs `notifications.skipped` for telegram destinations while continuing to deliver to discord destinations.

## Verification

```bash
helm template ./helm/missing-table -f ./helm/missing-table/values-prod.yaml | grep -A5 TELEGRAM
```

Produces:
```yaml
- name: TELEGRAM_BOT_TOKEN
  valueFrom:
    secretKeyRef:
      name: missing-table-secrets
      key: telegram-bot-token
      optional: true
- name: NOTIFICATIONS_ENABLED
  value: "true"
```

## Rollout sequence (for @silverbeer)

1. **Create the AWS Secrets Manager entry** with the real bot token. The path depends on your ESO `SecretStore` convention — match the existing entries in the same secret (e.g. `missing-table/prod/telegram-bot-token`). Tell me the final path/name if you want me to reference it in docs.
2. **Update the `ExternalSecret` in `missingtable-platform-bootstrap`** to add `telegram-bot-token` to the target `missing-table-secrets` Kubernetes Secret, pointing at the AWS path from step 1. That's a separate PR in that repo.
3. **Merge this PR.** ArgoCD syncs automatically; the backend pods roll with the new env var sourced from the ESO-populated key.
4. **Verify** in the pod:
   ```
   kubectl -n missing-table exec deploy/missing-table-backend -- env | grep -E "TELEGRAM_BOT_TOKEN|NOTIFICATIONS_ENABLED" | sed 's/TOKEN=.*/TOKEN=***/'
   ```
5. **Smoke test** from the admin UI — configure a destination on a test club + hit Send test. Phase 7 (#322) covers the full end-to-end smoke.

## What's NOT in this PR
- No changes to the ESO manifest (lives in `missingtable-platform-bootstrap`)
- No changes to celery-worker — the dispatcher runs in the backend FastAPI process via BackgroundTasks, not a celery task
- No AWS Secrets Manager creation — I'll do that with you once you share the bot token securely (don't paste it in a PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)