### PR TITLE
fix(ci): install git in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,10 +8,13 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Install system dependencies
+# `git` is required because uv syncs telegram-notify and discord-notify
+# from git+https sources defined in pyproject.toml's [tool.uv.sources].
 RUN apt-get update && apt-get install -y \
     gcc \
     libpq-dev \
     curl \
+    git \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
## Summary
Unblocks CI. Phase 5 (#327) added `telegram-notify` and `discord-notify` as `git+https://` dependencies in `pyproject.toml`'s `[tool.uv.sources]`, but `backend/Dockerfile` doesn't install `git` — so `uv sync --frozen` fails every build with:

```
× Failed to download and build `telegram-notify @ git+https://github.com/silverbeer/telegram-notify@…`
├─▶ Git operation failed
╰─▶ Git executable not found. Ensure that Git is installed and available.
```

## Impact
- Prod is still running image `6d57c90` (Phase 4), so the notifications dispatcher from Phase 5 and the env-var wiring from Phase 6 aren't actually deployed.
- Hitting "Send test" in prod returns the Phase 3 stub message ("Live send is not wired up yet — the notification dispatcher ships in a later phase").
- Failing CI runs: [24780616450](https://github.com/silverbeer/missing-table/actions/runs/24780616450) (#327), [24788519907](https://github.com/silverbeer/missing-table/actions/runs/24788519907) (#328).

## Fix
One line: add `git` to `apt-get install` in `backend/Dockerfile`.

## Test plan
- [ ] CI build-and-push job goes green for this PR
- [ ] Once merged, image-tag auto-update PR opens and lands
- [ ] ArgoCD syncs new image to LKE
- [ ] "Send test" in prod admin UI actually delivers to Telegram/Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)