### PR TITLE
feat(QoP): navigate between weekly snapshots in UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6435,10 +6435,23 @@ async def ingest_qop_rankings(
 async def get_qop_rankings(
     division_id: int = Query(..., description="Division ID"),
     age_group_id: int = Query(..., description="Age group ID"),
+    snapshot_id: int | None = Query(
+        None,
+        description="Optional snapshot ID — omit to get the latest snapshot. "
+        "Response includes prev_snapshot_id/next_snapshot_id for navigation.",
+    ),
 ):
-    """Get the latest QoP rankings for a division/age_group with week-over-week rank delta."""
+    """Get QoP rankings for a division/age_group with week-over-week deltas.
+
+    When `snapshot_id` is omitted, returns the latest snapshot. When provided,
+    returns that specific snapshot. In both cases the response carries
+    `prev_snapshot_id` / `next_snapshot_id` (null at boundaries) so the client
+    can step through history.
+    """
     try:
-        result = QoPRankingsDAO.get_latest_with_delta(match_dao.client, division_id, age_group_id)
+        result = QoPRankingsDAO.get_with_delta(
+            match_dao.client, division_id, age_group_id, snapshot_id
+        )
         return result
     except Exception as e:
         logger.error(f"Error retrieving QoP rankings: {e!s}", exc_info=True)

--- a/backend/dao/qop_rankings_dao.py
+++ b/backend/dao/qop_rankings_dao.py
@@ -302,17 +302,36 @@ class QoPRankingsDAO:
     def get_latest_with_delta(
         client, division_id: int, age_group_id: int
     ) -> dict:
-        """
-        Fetch the two most recent snapshots and compute per-team rank delta.
+        """Back-compat wrapper around `get_with_delta` for callers that always
+        want the newest snapshot (match preview, /api/table enrichment)."""
+        return QoPRankingsDAO.get_with_delta(client, division_id, age_group_id)
 
-        Response shape is preserved from the legacy API for frontend compat —
-        the `week_of` / `prior_week_of` keys are now semantically *detection
-        dates* rather than ISO-week Mondays, but callers don't need to change.
+    @staticmethod
+    def get_with_delta(
+        client,
+        division_id: int,
+        age_group_id: int,
+        snapshot_id: int | None = None,
+    ) -> dict:
+        """
+        Fetch one snapshot (the latest, or the one pinned by `snapshot_id`)
+        plus the one immediately older, and compute per-team rank/score deltas.
+
+        Also returns `prev_snapshot_id` / `next_snapshot_id` so the caller can
+        step backward/forward through history. Both are `None` at the ends —
+        that's the signal the UI uses to hide the prev/next buttons.
+
+        Response shape is a superset of the legacy `get_latest_with_delta`
+        response — `week_of` / `prior_week_of` are detection dates, not ISO
+        weeks, and are preserved purely for frontend compat.
         """
         empty = {
             "has_data": False,
             "week_of": None,
             "prior_week_of": None,
+            "snapshot_id": None,
+            "prev_snapshot_id": None,
+            "next_snapshot_id": None,
             "rankings": [],
         }
 
@@ -323,14 +342,32 @@ class QoPRankingsDAO:
                 .eq("division_id", division_id)
                 .eq("age_group_id", age_group_id)
                 .order("detected_at", desc=True)
-                .limit(2)
                 .execute()
             )
-            if not snap_resp.data:
+            snapshots = snap_resp.data or []
+            if not snapshots:
                 return empty
 
-            current = snap_resp.data[0]
-            prior = snap_resp.data[1] if len(snap_resp.data) > 1 else None
+            current_index = 0
+            if snapshot_id is not None:
+                current_index = next(
+                    (i for i, s in enumerate(snapshots) if s["id"] == snapshot_id),
+                    -1,
+                )
+                if current_index == -1:
+                    return empty
+
+            current = snapshots[current_index]
+            # DESC order: older snapshots have higher indices.
+            prior = (
+                snapshots[current_index + 1]
+                if current_index + 1 < len(snapshots)
+                else None
+            )
+            next_snapshot_id = (
+                snapshots[current_index - 1]["id"] if current_index > 0 else None
+            )
+            prev_snapshot_id = prior["id"] if prior is not None else None
 
             current_rows_resp = (
                 client.table("qop_rankings")
@@ -407,13 +444,17 @@ class QoPRankingsDAO:
                 "has_data": True,
                 "week_of": current["detected_at"],
                 "prior_week_of": prior["detected_at"] if prior else None,
+                "snapshot_id": current["id"],
+                "prev_snapshot_id": prev_snapshot_id,
+                "next_snapshot_id": next_snapshot_id,
                 "rankings": rankings,
             }
 
         except Exception:
             logger.exception(
-                "qop_rankings_get_latest_error",
+                "qop_rankings_get_with_delta_error",
                 division_id=division_id,
                 age_group_id=age_group_id,
+                snapshot_id=snapshot_id,
             )
             return empty

--- a/backend/tests/unit/test_qop_rankings.py
+++ b/backend/tests/unit/test_qop_rankings.py
@@ -10,6 +10,9 @@ Tests:
 - get_latest_with_delta: no data → has_data=False
 - get_latest_with_delta: two snapshots → rank_change computed
 - get_latest_with_delta: one snapshot only → rank_change=None
+- get_with_delta: snapshot_id pinned to older snapshot → deltas vs. the one before it
+- get_with_delta: nav metadata (prev_snapshot_id / next_snapshot_id) at boundaries
+- get_with_delta: unknown snapshot_id → has_data=False
 - match preview QoP enrichment (unchanged from legacy model)
 """
 
@@ -385,6 +388,9 @@ class TestGetLatestWithDelta:
             "has_data": False,
             "week_of": None,
             "prior_week_of": None,
+            "snapshot_id": None,
+            "prev_snapshot_id": None,
+            "next_snapshot_id": None,
             "rankings": [],
         }
 
@@ -425,6 +431,10 @@ class TestGetLatestWithDelta:
         assert result["prior_week_of"] == "2026-04-10"
         assert result["rankings"][0]["rank"] == 3
         assert result["rankings"][0]["rank_change"] == 2
+        # Viewing latest: prev points at the older snapshot, next is None.
+        assert result["snapshot_id"] == 101
+        assert result["prev_snapshot_id"] == 7
+        assert result["next_snapshot_id"] is None
 
     def test_no_prior_rank_change_is_none(self):
         from backend.dao.qop_rankings_dao import QoPRankingsDAO
@@ -454,6 +464,146 @@ class TestGetLatestWithDelta:
         assert result["has_data"] is True
         assert result["prior_week_of"] is None
         assert result["rankings"][0]["rank_change"] is None
+        # Single snapshot in history → both nav directions closed off.
+        assert result["snapshot_id"] == 101
+        assert result["prev_snapshot_id"] is None
+        assert result["next_snapshot_id"] is None
+
+
+# ─── get_with_delta: snapshot_id navigation ────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestGetWithDeltaNavigation:
+    """Three snapshots exist — caller pins `snapshot_id` to step through them."""
+
+    # newest → oldest (DESC), matching what the DAO queries.
+    _SNAPSHOTS = [
+        {"id": 300, "detected_at": "2026-04-18"},
+        {"id": 200, "detected_at": "2026-04-10"},
+        {"id": 100, "detected_at": "2026-04-03"},
+    ]
+
+    def _client_for_middle_snapshot(self, current_rows, prior_rows):
+        """Mock client where pin=200 → current=snapshot 200, prior=snapshot 100."""
+        return _make_client(
+            {
+                "qop_snapshots": [self._SNAPSHOTS],
+                "qop_rankings": [current_rows, prior_rows],
+            }
+        )
+
+    def test_pinning_middle_snapshot_computes_delta_vs_prior(self):
+        """Pinning the middle snapshot means deltas compare it to snapshot 100,
+        NOT to the newest (snapshot 300). The frontend relies on this so the
+        +/- arrows match whatever week is on screen."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        current_rows = [
+            {
+                "rank": 2,
+                "team_name": "Team Alpha",
+                "team_id": 42,
+                "matches_played": 12,
+                "att_score": Decimal("85.0"),
+                "def_score": Decimal("80.0"),
+                "qop_score": Decimal("82.5"),
+            }
+        ]
+        # Prior (snapshot 100): rank 4 → current rank 2 means +2.
+        prior_rows = [{"rank": 4, "team_name": "Team Alpha"}]
+
+        client = self._client_for_middle_snapshot(current_rows, prior_rows)
+        result = QoPRankingsDAO.get_with_delta(
+            client, division_id=1, age_group_id=2, snapshot_id=200
+        )
+
+        assert result["has_data"] is True
+        assert result["snapshot_id"] == 200
+        assert result["week_of"] == "2026-04-10"
+        assert result["prior_week_of"] == "2026-04-03"
+        assert result["rankings"][0]["rank_change"] == 2
+        # From middle of history: prev points older, next points newer.
+        assert result["prev_snapshot_id"] == 100
+        assert result["next_snapshot_id"] == 300
+
+    def test_pinning_oldest_snapshot_hides_prev(self):
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        current_rows = [
+            {
+                "rank": 1,
+                "team_name": "Team Alpha",
+                "team_id": 42,
+                "matches_played": 5,
+                "att_score": Decimal("70.0"),
+                "def_score": Decimal("65.0"),
+                "qop_score": Decimal("68.0"),
+            }
+        ]
+
+        client = _make_client(
+            {
+                "qop_snapshots": [self._SNAPSHOTS],
+                "qop_rankings": [current_rows],
+            }
+        )
+        result = QoPRankingsDAO.get_with_delta(
+            client, division_id=1, age_group_id=2, snapshot_id=100
+        )
+
+        assert result["snapshot_id"] == 100
+        assert result["prior_week_of"] is None
+        assert result["rankings"][0]["rank_change"] is None
+        # Oldest snapshot → no prev, but next should point to the middle one.
+        assert result["prev_snapshot_id"] is None
+        assert result["next_snapshot_id"] == 200
+
+    def test_unknown_snapshot_id_returns_empty(self):
+        """If the caller pins an id that doesn't belong to this
+        (division, age_group), degrade to empty rather than silently
+        returning the latest — otherwise the UI nav state would lie."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        client = _make_client({"qop_snapshots": [self._SNAPSHOTS]})
+        result = QoPRankingsDAO.get_with_delta(
+            client, division_id=1, age_group_id=2, snapshot_id=9999
+        )
+        assert result["has_data"] is False
+        assert result["snapshot_id"] is None
+        assert result["prev_snapshot_id"] is None
+        assert result["next_snapshot_id"] is None
+
+    def test_omitting_snapshot_id_returns_latest(self):
+        """Back-compat: callers that don't pass snapshot_id still get the
+        newest snapshot, with prev pointing at the one before it."""
+        from backend.dao.qop_rankings_dao import QoPRankingsDAO
+
+        current_rows = [
+            {
+                "rank": 1,
+                "team_name": "Team Alpha",
+                "team_id": 42,
+                "matches_played": 16,
+                "att_score": Decimal("90.0"),
+                "def_score": Decimal("85.0"),
+                "qop_score": Decimal("87.5"),
+            }
+        ]
+        prior_rows = [{"rank": 1, "team_name": "Team Alpha"}]
+
+        client = _make_client(
+            {
+                "qop_snapshots": [self._SNAPSHOTS],
+                "qop_rankings": [current_rows, prior_rows],
+            }
+        )
+        result = QoPRankingsDAO.get_with_delta(
+            client, division_id=1, age_group_id=2
+        )
+        assert result["snapshot_id"] == 300
+        assert result["next_snapshot_id"] is None
+        assert result["prev_snapshot_id"] == 200
 
 
 # ─── Match Preview QoP enrichment (logic-only; unchanged) ──────────────────────

--- a/frontend/src/components/QoPStandings.vue
+++ b/frontend/src/components/QoPStandings.vue
@@ -70,11 +70,38 @@
 
     <!-- Rankings Table -->
     <div v-else class="overflow-x-auto">
-      <div v-if="weekOf" class="text-xs text-gray-400 mb-2">
-        Week of {{ weekOf
-        }}<span v-if="priorWeekOf">
-          &nbsp;·&nbsp; Prior week: {{ priorWeekOf }}</span
+      <div
+        v-if="weekOf"
+        class="flex items-center gap-2 text-xs text-gray-400 mb-2"
+      >
+        <button
+          v-if="prevSnapshotId != null"
+          type="button"
+          @click="goToSnapshot(prevSnapshotId)"
+          :disabled="loading"
+          class="px-2 py-0.5 rounded hover:bg-slate-100 text-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          :title="`Previous week${priorWeekOf ? ' (' + priorWeekOf + ')' : ''}`"
+          aria-label="Previous snapshot"
         >
+          ◀
+        </button>
+        <span>
+          Week of {{ weekOf
+          }}<span v-if="priorWeekOf">
+            &nbsp;·&nbsp; Prior week: {{ priorWeekOf }}</span
+          >
+        </span>
+        <button
+          v-if="nextSnapshotId != null"
+          type="button"
+          @click="goToSnapshot(nextSnapshotId)"
+          :disabled="loading"
+          class="px-2 py-0.5 rounded hover:bg-slate-100 text-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Next week"
+          aria-label="Next snapshot"
+        >
+          ▶
+        </button>
       </div>
 
       <table class="min-w-full divide-y divide-slate-200">
@@ -269,6 +296,9 @@ export default {
     const rankings = ref([]);
     const weekOf = ref(null);
     const priorWeekOf = ref(null);
+    const currentSnapshotId = ref(null);
+    const prevSnapshotId = ref(null);
+    const nextSnapshotId = ref(null);
     const loading = ref(false);
     const error = ref(null);
 
@@ -319,12 +349,18 @@ export default {
           division_id: selectedDivisionId.value,
           age_group_id: selectedAgeGroupId.value,
         });
+        if (currentSnapshotId.value != null) {
+          params.set('snapshot_id', currentSnapshotId.value);
+        }
         const data = await authStore.apiRequest(
           `${getApiBaseUrl()}/api/qop-rankings?${params}`
         );
         rankings.value = data.rankings ?? [];
         weekOf.value = data.week_of ?? null;
         priorWeekOf.value = data.prior_week_of ?? null;
+        currentSnapshotId.value = data.snapshot_id ?? null;
+        prevSnapshotId.value = data.prev_snapshot_id ?? null;
+        nextSnapshotId.value = data.next_snapshot_id ?? null;
       } catch (err) {
         error.value = err.message;
       } finally {
@@ -332,7 +368,18 @@ export default {
       }
     };
 
-    watch([selectedAgeGroupId, selectedDivisionId], fetchRankings);
+    const goToSnapshot = id => {
+      currentSnapshotId.value = id;
+      fetchRankings();
+    };
+
+    // Changing filters should always return to the newest snapshot for the
+    // new (division, age_group) pair — otherwise a stale snapshot_id from the
+    // prior selection would 404 and render empty.
+    watch([selectedAgeGroupId, selectedDivisionId], () => {
+      currentSnapshotId.value = null;
+      fetchRankings();
+    });
 
     onMounted(async () => {
       const ok = await resolveIds();
@@ -347,8 +394,11 @@ export default {
       rankings,
       weekOf,
       priorWeekOf,
+      prevSnapshotId,
+      nextSnapshotId,
       loading,
       error,
+      goToSnapshot,
     };
   },
 };


### PR DESCRIPTION
## Summary
- Adds ◀/▶ navigation to the QoP Rankings page so users can step backward/forward through every stored snapshot for a given (division, age_group). Buttons hide at the newest/oldest boundaries.
- `GET /api/qop-rankings` takes an optional `snapshot_id` and returns `snapshot_id` / `prev_snapshot_id` / `next_snapshot_id` alongside the rankings — deltas recompute against whichever snapshot is on screen, not always vs. the newest.
- Unknown `snapshot_id` degrades to `has_data=false` so the UI nav state can't lie; unrelated callers (match preview, /api/table enrichment) go through an unchanged `get_latest_with_delta` wrapper.

Closes #331

## Test plan
- [x] Backend unit tests (`test_qop_rankings.py`): existing coverage + new `TestGetWithDeltaNavigation` for pinned middle / pinned oldest / unknown id / omitted id — 24 passed.
- [x] Ruff + ESLint clean.
- [x] Manual UI walkthrough against local Supabase with 3 seeded snapshots:
  - Latest → shows ◀ only, deltas vs. middle snapshot.
  - Middle → shows ◀ and ▶, deltas vs. oldest snapshot (not vs. latest).
  - Oldest → shows ▶ only, all rank_change columns are `—`.
  - Switching age group (U14 → U13 → U14) resets to latest snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)