### PR TITLE
fix(ui): admin tab mobile UX + restore landing page tabs gate

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -322,7 +322,7 @@
 
         <!-- Tabs + Content card (authenticated users) -->
         <div
-          v-else
+          v-if="authStore.state.session"
           class="bg-white rounded-xl shadow-sm ring-1 ring-slate-200/60 overflow-hidden"
         >
           <nav

--- a/frontend/src/components/AdminPanel.vue
+++ b/frontend/src/components/AdminPanel.vue
@@ -23,9 +23,27 @@
       </div>
 
       <!-- Admin Navigation -->
-      <div class="mb-8" data-testid="admin-nav">
+      <div class="mb-6 sm:mb-8" data-testid="admin-nav">
+        <!-- Mobile: native select (large tap target, native picker) -->
+        <label for="admin-section-select" class="sr-only">Admin section</label>
+        <select
+          id="admin-section-select"
+          v-model="currentSection"
+          data-testid="admin-section-select"
+          class="sm:hidden block w-full px-3 py-2.5 text-base font-medium bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+        >
+          <option
+            v-for="section in adminSections"
+            :key="section.id"
+            :value="section.id"
+          >
+            {{ section.name }}
+          </option>
+        </select>
+
+        <!-- Desktop: scrollable button row -->
         <nav
-          class="flex space-x-1 bg-gray-100 p-1 rounded-lg"
+          class="hidden sm:flex space-x-1 bg-gray-100 p-1 rounded-lg overflow-x-auto"
           aria-label="Admin sections"
         >
           <button
@@ -37,7 +55,7 @@
               currentSection === section.id
                 ? 'bg-white text-gray-900 shadow'
                 : 'text-gray-600 hover:text-gray-900',
-              'px-4 py-2 text-sm font-medium rounded-md transition-colors',
+              'px-4 py-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap flex-shrink-0',
             ]"
           >
             {{ section.name }}
@@ -53,7 +71,7 @@
         <!-- Invite Requests Management -->
         <div
           v-if="currentSection === 'invite-requests'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-invite-requests"
         >
           <AdminInviteRequests />
@@ -62,7 +80,7 @@
         <!-- Channel Access Requests -->
         <div
           v-if="currentSection === 'channel-requests'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-channel-requests"
         >
           <AdminChannelRequests />
@@ -71,7 +89,7 @@
         <!-- Live Match Notifications (per-club Telegram/Discord) -->
         <div
           v-if="currentSection === 'club-notifications'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-club-notifications"
         >
           <AdminClubNotifications />
@@ -80,7 +98,7 @@
         <!-- Age Groups Management -->
         <div
           v-if="currentSection === 'age-groups'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-age-groups"
         >
           <AdminAgeGroups />
@@ -89,7 +107,7 @@
         <!-- Seasons Management -->
         <div
           v-if="currentSection === 'seasons'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-seasons"
         >
           <AdminSeasons />
@@ -98,7 +116,7 @@
         <!-- Leagues Management -->
         <div
           v-if="currentSection === 'leagues'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-leagues"
         >
           <AdminLeagues />
@@ -107,7 +125,7 @@
         <!-- Divisions Management -->
         <div
           v-if="currentSection === 'divisions'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-divisions"
         >
           <AdminDivisions />
@@ -116,7 +134,7 @@
         <!-- Clubs Management -->
         <div
           v-if="currentSection === 'clubs'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-clubs"
         >
           <AdminClubs />
@@ -125,7 +143,7 @@
         <!-- Teams Management -->
         <div
           v-if="currentSection === 'teams'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-teams"
         >
           <AdminTeams />
@@ -134,7 +152,7 @@
         <!-- Players Management -->
         <div
           v-if="currentSection === 'players'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-players"
         >
           <AdminPlayers />
@@ -143,7 +161,7 @@
         <!-- Matches Management -->
         <div
           v-if="currentSection === 'matches'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-matches"
         >
           <AdminMatches />
@@ -152,7 +170,7 @@
         <!-- Goals Management -->
         <div
           v-if="currentSection === 'goals'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-goals"
         >
           <AdminGoals />
@@ -161,7 +179,7 @@
         <!-- Playoffs Management -->
         <div
           v-if="currentSection === 'playoffs'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-playoffs"
         >
           <AdminPlayoffs />
@@ -170,7 +188,7 @@
         <!-- Invites Management -->
         <div
           v-if="currentSection === 'invites'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-invites"
         >
           <AdminInvites />
@@ -179,7 +197,7 @@
         <!-- Tournaments Management -->
         <div
           v-if="currentSection === 'tournaments'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-tournaments"
         >
           <AdminTournaments />
@@ -188,7 +206,7 @@
         <!-- Cache Management -->
         <div
           v-if="currentSection === 'cache'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-cache"
         >
           <AdminCache />
@@ -197,7 +215,7 @@
         <!-- Users / Login Activity -->
         <div
           v-if="currentSection === 'users'"
-          class="p-6"
+          class="p-3 sm:p-6"
           data-testid="admin-section-users"
         >
           <AdminUsers />

--- a/frontend/src/components/admin/AdminAgeGroups.vue
+++ b/frontend/src/components/admin/AdminAgeGroups.vue
@@ -28,7 +28,7 @@
     <!-- Age Groups Table -->
     <div
       v-else
-      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
+      class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">

--- a/frontend/src/components/admin/AdminDivisions.vue
+++ b/frontend/src/components/admin/AdminDivisions.vue
@@ -28,7 +28,7 @@
     <!-- Divisions Table -->
     <div
       v-else
-      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
+      class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">

--- a/frontend/src/components/admin/AdminLeagues.vue
+++ b/frontend/src/components/admin/AdminLeagues.vue
@@ -28,7 +28,7 @@
     <!-- Leagues Table -->
     <div
       v-else
-      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
+      class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">

--- a/frontend/src/components/admin/AdminPlayers.vue
+++ b/frontend/src/components/admin/AdminPlayers.vue
@@ -59,7 +59,7 @@
     <!-- Players Table -->
     <div
       v-else-if="!loading"
-      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
+      class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">

--- a/frontend/src/components/admin/AdminSeasons.vue
+++ b/frontend/src/components/admin/AdminSeasons.vue
@@ -28,7 +28,7 @@
     <!-- Seasons Table -->
     <div
       v-else
-      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
+      class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">

--- a/frontend/src/components/admin/AdminTeams.vue
+++ b/frontend/src/components/admin/AdminTeams.vue
@@ -34,7 +34,7 @@
     <!-- Teams Table -->
     <div
       v-else
-      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
+      class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
       data-testid="teams-table-container"
     >
       <table

--- a/frontend/src/components/admin/AdminTournaments.vue
+++ b/frontend/src/components/admin/AdminTournaments.vue
@@ -110,108 +110,107 @@
 
           <template v-else>
             <!-- Matches table -->
-            <table
-              v-if="selectedMatches.length > 0"
-              class="min-w-full mb-4 text-sm"
-            >
-              <thead>
-                <tr class="border-b border-gray-200">
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Date
-                  </th>
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Round
-                  </th>
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Group
-                  </th>
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Home
-                  </th>
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Score
-                  </th>
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Away
-                  </th>
-                  <th
-                    class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Status
-                  </th>
-                  <th
-                    class="text-right py-2 font-medium text-gray-500 text-xs uppercase"
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-100">
-                <tr v-for="match in selectedMatches" :key="match.id">
-                  <td class="py-2 pr-4 text-gray-700">
-                    {{ formatDate(match.match_date) }}
-                  </td>
-                  <td class="py-2 pr-4 text-gray-500">
-                    {{ formatRound(match.tournament_round) }}
-                  </td>
-                  <td class="py-2 pr-4 text-gray-500">
-                    {{ match.tournament_group || '—' }}
-                  </td>
-                  <td class="py-2 pr-4 font-medium text-gray-900">
-                    {{ match.home_team?.name }}
-                  </td>
-                  <td class="py-2 pr-4 text-gray-700 font-mono">
-                    <span v-if="match.home_score != null">
-                      {{ match.home_score }} – {{ match.away_score }}
-                      <span
-                        v-if="match.home_penalty_score != null"
-                        class="text-xs text-gray-500 ml-1"
-                      >
-                        ({{ match.home_penalty_score }}–{{
-                          match.away_penalty_score
-                        }}
-                        pens)
+            <div v-if="selectedMatches.length > 0" class="overflow-x-auto mb-4">
+              <table class="min-w-full text-sm">
+                <thead>
+                  <tr class="border-b border-gray-200">
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Date
+                    </th>
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Round
+                    </th>
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Group
+                    </th>
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Home
+                    </th>
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Score
+                    </th>
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Away
+                    </th>
+                    <th
+                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Status
+                    </th>
+                    <th
+                      class="text-right py-2 font-medium text-gray-500 text-xs uppercase"
+                    >
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                  <tr v-for="match in selectedMatches" :key="match.id">
+                    <td class="py-2 pr-4 text-gray-700">
+                      {{ formatDate(match.match_date) }}
+                    </td>
+                    <td class="py-2 pr-4 text-gray-500">
+                      {{ formatRound(match.tournament_round) }}
+                    </td>
+                    <td class="py-2 pr-4 text-gray-500">
+                      {{ match.tournament_group || '—' }}
+                    </td>
+                    <td class="py-2 pr-4 font-medium text-gray-900">
+                      {{ match.home_team?.name }}
+                    </td>
+                    <td class="py-2 pr-4 text-gray-700 font-mono">
+                      <span v-if="match.home_score != null">
+                        {{ match.home_score }} – {{ match.away_score }}
+                        <span
+                          v-if="match.home_penalty_score != null"
+                          class="text-xs text-gray-500 ml-1"
+                        >
+                          ({{ match.home_penalty_score }}–{{
+                            match.away_penalty_score
+                          }}
+                          pens)
+                        </span>
                       </span>
-                    </span>
-                    <span v-else class="text-gray-400">vs</span>
-                  </td>
-                  <td class="py-2 pr-4 font-medium text-gray-900">
-                    {{ match.away_team?.name }}
-                  </td>
-                  <td class="py-2 pr-4">
-                    <span :class="statusClass(match.match_status)">
-                      {{ match.match_status }}
-                    </span>
-                  </td>
-                  <td class="py-2 text-right">
-                    <button
-                      @click="openEditMatch(match)"
-                      class="text-brand-600 hover:text-brand-900 mr-3"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      @click="deleteMatch(match)"
-                      class="text-red-600 hover:text-red-900"
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <span v-else class="text-gray-400">vs</span>
+                    </td>
+                    <td class="py-2 pr-4 font-medium text-gray-900">
+                      {{ match.away_team?.name }}
+                    </td>
+                    <td class="py-2 pr-4">
+                      <span :class="statusClass(match.match_status)">
+                        {{ match.match_status }}
+                      </span>
+                    </td>
+                    <td class="py-2 text-right">
+                      <button
+                        @click="openEditMatch(match)"
+                        class="text-brand-600 hover:text-brand-900 mr-3"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        @click="deleteMatch(match)"
+                        class="text-red-600 hover:text-red-900"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
 
             <p v-else class="text-gray-500 text-sm mb-4">No matches yet.</p>
 


### PR DESCRIPTION
## Summary

- **Admin tab mobile UX**: 17-tab nav row was clipping on phones; tables used `overflow-hidden` so wider columns disappeared. Mobile now gets a native `<select>` for sections; desktop keeps a button row but is now horizontally scrollable. Table wrappers swap to `overflow-x-auto` so users can swipe to see all columns. Section padding `p-3 sm:p-6` (was `p-6`) reclaims horizontal space.
- **Restore landing page fix**: commit `4973564` (originally on `feature/header-logo-wordmark`) never reached main — squash merge of #334 dropped it. Re-applies the `v-else → v-if="authStore.state.session"` gate on the tabs+content card so logged-out users no longer see the orphan **Age Groups** filter below the landing hero.

## Files

- `frontend/src/App.vue` — tabs card auth gate
- `frontend/src/components/AdminPanel.vue` — mobile select / desktop scrollable row + responsive padding
- `frontend/src/components/admin/{AdminAgeGroups,AdminDivisions,AdminLeagues,AdminPlayers,AdminSeasons,AdminTeams,AdminTournaments}.vue` — table overflow fixes

## Test plan

- [ ] Logged out at desktop width: hero + Invite-Only card + 3 feature cards only — no Age Groups filter visible
- [ ] Logged out at mobile width (390px): same — clean landing page
- [ ] Admin tab at 390px (logged in as admin): section picker is a native `<select>`, all 17 sections selectable, content card shows reduced padding
- [ ] Admin tab at >=640px: section nav is a scrollable button row; growing the list does not clip
- [ ] Pick `Divisions` (and other table sections) on mobile — table is horizontally swipeable, all columns reachable
- [ ] Existing desktop admin functionality unchanged (Add/Edit/Delete on Divisions, Teams, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)