### PR TITLE
fix(ui): autofocus username field when login modal opens

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -19,6 +19,7 @@
           <label for="username">Username:</label>
           <input
             id="username"
+            ref="usernameInput"
             v-model="form.username"
             type="text"
             required
@@ -258,7 +259,7 @@
 </template>
 
 <script>
-import { ref, reactive, onMounted, watch } from 'vue';
+import { ref, reactive, onMounted, nextTick, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 
@@ -274,6 +275,7 @@ export default {
     const selectedTeamId = ref('');
     const teams = ref([]);
     const inviteInfo = ref(null);
+    const usernameInput = ref(null);
 
     const form = reactive({
       username: '',
@@ -444,6 +446,8 @@ export default {
 
         // Validate the invite code automatically
         validateInviteCode();
+      } else {
+        nextTick(() => usernameInput.value?.focus());
       }
     });
 
@@ -452,6 +456,7 @@ export default {
       isSignup,
       showInviteSignup,
       form,
+      usernameInput,
       showRoleSelection,
       selectedRole,
       selectedTeamId,


### PR DESCRIPTION
## Summary
- Adds template ref to username input in `LoginForm.vue` and focuses it via `nextTick` on mount, so users can type immediately after clicking Login.
- Skips autofocus when an invite code is present in the URL (that flow uses a different first field).

## Test plan
- [ ] Click Login on home page → cursor blinks in Username field, can type without clicking
- [ ] Visit `/?code=<invite>` → does not steal focus from invite flow
- [ ] Existing login still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)