### PR TITLE
fix(deploy): disable celery worker to unblock prod rollout

### DIFF
--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -38,8 +38,12 @@ redis:
   enabled: true
 
 # Celery Worker — consumes match data from RabbitMQ (match-scraper namespace)
+# Temporarily disabled: RabbitMQ auth is failing (admin/admin123 rejected,
+# 6d23h CrashLoopBackOff with 1900+ restarts) AND its 200m CPU request was
+# blocking rolling updates on the single 2-CPU LKE node. Re-enable once
+# RabbitMQ creds are fixed in the match-scraper namespace.
 celeryWorker:
-  enabled: true
+  enabled: false
   replicaCount: 1
 
   rabbitmq:


### PR DESCRIPTION
## Summary

Prod has been stuck on **1.2.4.715** since PR #339 merged. Diagnosis:

- New backend/frontend/celery pods Pending for 99+ min
- `FailedScheduling: 0/1 nodes are available: 1 Insufficient cpu`
- Single 2-CPU LKE node at **1893m / 2000m allocated (94%)** — no surge room

Celery has been crash-looping for 6d23h (1900+ restarts) due to RabbitMQ auth failure (`admin:admin123` rejected by broker in `match-scraper` namespace) — pre-existing, unrelated to #339. Disabling celery frees ~400m CPU (one running + one pending claim), unblocking backend + frontend rollouts.

## Changes

- `helm/missing-table/values-prod.yaml`: `celeryWorker.enabled: false`

## What this gets us

- Footer flips from `1.2.4.715` → `1.3.0.<next_build>`
- New endpoint `POST /api/matches/{id}/live/reopen` actually reachable in prod
- End Match confirm + Reopen Match button visible

## Followups (separate PRs)

- [ ] Fix RabbitMQ credentials in match-scraper namespace (rotate / sync via External Secrets)
- [ ] Bump LKE node count in `missingtable-platform-bootstrap` so a single rolling update doesn't exhaust cluster CPU
- [ ] Re-enable celery worker after both above are done

## Test plan

- [ ] Merge → CI runs → ArgoCD syncs values
- [ ] `kubectl -n missing-table get pods` shows celery-worker pods removed
- [ ] New backend + frontend pods transition to Running
- [ ] `curl https://api.missingtable.com/api/version` returns `1.3.0.*`
- [ ] Footer on missingtable.com shows new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)