### PR TITLE
fix(data): register TSF Academy in HG Northeast match types

### DIFF
--- a/supabase-local/migrations/20260510000000_register_tsf_academy_match_types.sql
+++ b/supabase-local/migrations/20260510000000_register_tsf_academy_match_types.sql
@@ -1,0 +1,21 @@
+-- Register TSF Academy (id=35, HG Northeast) for Friendly + Tournament
+-- across U13, U14, U15, U16. Team had zero rows in team_match_types
+-- so it was invisible in age-group filtered views.
+--
+-- Sync the id sequence first in case prior data loads inserted rows with
+-- explicit ids (sequence can lag behind max(id) and cause silent PK
+-- conflicts swallowed by ON CONFLICT). pg_get_serial_sequence is used so
+-- the migration works regardless of whether the sequence is named
+-- team_match_types_id_seq (new) or team_game_types_id_seq (legacy).
+SELECT setval(
+  pg_get_serial_sequence('team_match_types', 'id'),
+  GREATEST((SELECT COALESCE(MAX(id), 1) FROM team_match_types), 1)
+);
+
+INSERT INTO team_match_types (team_id, age_group_id, match_type_id, is_active)
+SELECT 35, ag.id, mt.id, true
+FROM age_groups ag
+CROSS JOIN match_types mt
+WHERE ag.name IN ('U13','U14','U15','U16')
+  AND mt.name IN ('Friendly','Tournament')
+ON CONFLICT (team_id, match_type_id, age_group_id) DO NOTHING;

--- a/supabase-local/migrations/20260511000000_tsf_academy_add_league.sql
+++ b/supabase-local/migrations/20260511000000_tsf_academy_add_league.sql
@@ -1,0 +1,14 @@
+-- Add League match type for TSF Academy (id=35) across U13-U16.
+-- Follow-up to 20260510000000 which registered Friendly + Tournament only.
+SELECT setval(
+  pg_get_serial_sequence('team_match_types', 'id'),
+  GREATEST((SELECT COALESCE(MAX(id), 1) FROM team_match_types), 1)
+);
+
+INSERT INTO team_match_types (team_id, age_group_id, match_type_id, is_active)
+SELECT 35, ag.id, mt.id, true
+FROM age_groups ag
+CROSS JOIN match_types mt
+WHERE ag.name IN ('U13','U14','U15','U16')
+  AND mt.name = 'League'
+ON CONFLICT (team_id, match_type_id, age_group_id) DO NOTHING;


### PR DESCRIPTION
## Summary
- TSF Academy (id=35) had zero rows in `team_match_types`, so it was invisible in the team dropdown for any age-group / match-type filtered view.
- Registers U13, U14, U15, U16 across Friendly, League, and Tournament (12 rows total).
- Also calls `setval(pg_get_serial_sequence(...))` first to repair sequence drift that was silently swallowing PK conflicts on inserts.

## Migrations
- `20260510000000_register_tsf_academy_match_types.sql` — Friendly + Tournament
- `20260511000000_tsf_academy_add_league.sql` — League

Both use `pg_get_serial_sequence('team_match_types','id')` so they work regardless of the underlying sequence name (local: `team_match_types_id_seq`; prod legacy: `team_game_types_id_seq`).

## Test plan
- [x] Applied locally via `APP_ENV=local ./scripts/db_tools.sh migrate local`
- [x] Verified TSF Academy shows 12 rows in `team_match_types` locally
- [x] Confirmed TSF Academy appears in the Edit Match team dropdown for League matches
- [ ] Apply to prod via `./scripts/db_tools.sh migrate prod` after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)