### PR TITLE
feat(qop): Redis cache for QoP rankings endpoint (SB-12)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5771,7 +5771,7 @@ async def clear_cache_by_type(
     from dao.base_dao import clear_cache
 
     # Validate cache type to prevent arbitrary pattern injection
-    valid_types = ["playoffs", "matches", "players", "clubs", "teams", "standings", "rosters"]
+    valid_types = ["playoffs", "matches", "players", "clubs", "teams", "standings", "rosters", "qop"]
     if cache_type not in valid_types:
         raise HTTPException(
             status_code=400,
@@ -6479,6 +6479,10 @@ async def ingest_qop_rankings(
     """
     try:
         result = QoPRankingsDAO.record_snapshot(match_dao.client, snapshot.model_dump())
+        if result.get("status") == "inserted":
+            from dao.base_dao import clear_cache
+
+            clear_cache("mt:dao:qop:*")
         return result
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
@@ -6503,11 +6507,27 @@ async def get_qop_rankings(
     returns that specific snapshot. In both cases the response carries
     `prev_snapshot_id` / `next_snapshot_id` (null at boundaries) so the client
     can step through history.
+
+    Cached in Redis for 1 hour. Invalidated by POST /api/qop-rankings when a
+    new snapshot is inserted, or via DELETE /api/admin/cache/qop.
     """
+    from dao.base_dao import cache_get, cache_set
+
+    cache_key = (
+        f"mt:dao:qop:{division_id}:{age_group_id}:{snapshot_id}"
+        if snapshot_id is not None
+        else f"mt:dao:qop:{division_id}:{age_group_id}"
+    )
+    cached = cache_get(cache_key)
+    if cached is not None:
+        return cached
+
     try:
         result = QoPRankingsDAO.get_with_delta(
             match_dao.client, division_id, age_group_id, snapshot_id
         )
+        if result.get("has_data"):
+            cache_set(cache_key, result, ttl=3600)
         return result
     except Exception as e:
         logger.error(f"Error retrieving QoP rankings: {e!s}", exc_info=True)

--- a/backend/tests/unit/test_qop_cache.py
+++ b/backend/tests/unit/test_qop_cache.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for Redis caching of QoP rankings endpoints (SB-12).
+
+Covers:
+- GET /api/qop-rankings cache hit → DAO not invoked
+- GET cache miss with data → DAO invoked, cache_set called with correct key + TTL
+- GET cache miss with no data (has_data=False) → cache_set NOT called
+- GET with explicit snapshot_id → cache key includes snapshot_id
+- POST /api/qop-rankings status=inserted → clear_cache called
+- POST status=unchanged → clear_cache NOT called
+- Admin DELETE /api/admin/cache/{cache_type} accepts "qop"
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.mark.unit
+class TestGetQoPRankingsCache:
+    """Cache wiring on GET /api/qop-rankings."""
+
+    def test_cache_hit_returns_cached_without_dao_call(self):
+        cached_payload = {"has_data": True, "week_of": "2026-04-18", "rankings": []}
+        with patch("dao.base_dao.cache_get", return_value=cached_payload) as mock_get, \
+             patch("dao.base_dao.cache_set") as mock_set, \
+             patch("dao.qop_rankings_dao.QoPRankingsDAO.get_with_delta") as mock_dao:
+            from app import get_qop_rankings
+
+            result = _run(get_qop_rankings(division_id=10, age_group_id=20, snapshot_id=None))
+
+            assert result is cached_payload
+            mock_get.assert_called_once_with("mt:dao:qop:10:20")
+            mock_dao.assert_not_called()
+            mock_set.assert_not_called()
+
+    def test_cache_miss_calls_dao_and_caches_result(self):
+        dao_result = {"has_data": True, "week_of": "2026-04-18", "rankings": [{"rank": 1}]}
+        with patch("dao.base_dao.cache_get", return_value=None), \
+             patch("dao.base_dao.cache_set") as mock_set, \
+             patch("dao.qop_rankings_dao.QoPRankingsDAO.get_with_delta", return_value=dao_result) as mock_dao:
+            from app import get_qop_rankings
+
+            result = _run(get_qop_rankings(division_id=10, age_group_id=20, snapshot_id=None))
+
+            assert result == dao_result
+            mock_dao.assert_called_once()
+            mock_set.assert_called_once_with("mt:dao:qop:10:20", dao_result, ttl=3600)
+
+    def test_cache_miss_with_no_data_does_not_cache(self):
+        dao_result = {"has_data": False, "week_of": None, "rankings": []}
+        with patch("dao.base_dao.cache_get", return_value=None), \
+             patch("dao.base_dao.cache_set") as mock_set, \
+             patch("dao.qop_rankings_dao.QoPRankingsDAO.get_with_delta", return_value=dao_result):
+            from app import get_qop_rankings
+
+            result = _run(get_qop_rankings(division_id=10, age_group_id=20, snapshot_id=None))
+
+            assert result == dao_result
+            mock_set.assert_not_called()
+
+    def test_explicit_snapshot_id_in_cache_key(self):
+        cached_payload = {"has_data": True, "rankings": []}
+        with patch("dao.base_dao.cache_get", return_value=cached_payload) as mock_get, \
+             patch("dao.qop_rankings_dao.QoPRankingsDAO.get_with_delta"):
+            from app import get_qop_rankings
+
+            _run(get_qop_rankings(division_id=10, age_group_id=20, snapshot_id=42))
+
+            mock_get.assert_called_once_with("mt:dao:qop:10:20:42")
+
+
+@pytest.mark.unit
+class TestIngestQoPRankingsInvalidation:
+    """Cache invalidation on POST /api/qop-rankings."""
+
+    @staticmethod
+    def _payload():
+        return MagicMock(
+            model_dump=MagicMock(
+                return_value={
+                    "detected_at": "2026-04-18",
+                    "division": "Northeast",
+                    "age_group": "U14",
+                    "rankings": [],
+                }
+            )
+        )
+
+    def test_inserted_triggers_cache_clear(self):
+        with patch("dao.base_dao.clear_cache") as mock_clear, \
+             patch(
+                 "dao.qop_rankings_dao.QoPRankingsDAO.record_snapshot",
+                 return_value={"status": "inserted", "snapshot_id": 99, "rankings_count": 5},
+             ):
+            from app import ingest_qop_rankings
+
+            _run(ingest_qop_rankings(self._payload(), current_user={"username": "admin"}))
+
+            mock_clear.assert_called_once_with("mt:dao:qop:*")
+
+    def test_unchanged_skips_cache_clear(self):
+        with patch("dao.base_dao.clear_cache") as mock_clear, \
+             patch(
+                 "dao.qop_rankings_dao.QoPRankingsDAO.record_snapshot",
+                 return_value={"status": "unchanged", "snapshot_id": 99, "rankings_count": 0},
+             ):
+            from app import ingest_qop_rankings
+
+            _run(ingest_qop_rankings(self._payload(), current_user={"username": "admin"}))
+
+            mock_clear.assert_not_called()
+
+
+@pytest.mark.unit
+class TestAdminCacheTypeQoP:
+    """qop is accepted as a cache type to clear via the admin endpoint."""
+
+    def test_qop_is_valid_cache_type(self):
+        with patch("dao.base_dao.clear_cache", return_value=3) as mock_clear:
+            from app import clear_cache_by_type
+
+            result = _run(
+                clear_cache_by_type(cache_type="qop", current_user={"username": "admin"})
+            )
+
+            mock_clear.assert_called_once_with("mt:dao:qop:*")
+            assert result["deleted"] == 3
+            assert "qop" in result["message"]


### PR DESCRIPTION
## Summary

Wires the `/api/qop-rankings` read endpoint into the shared `mt:dao:*` Redis cache layer. QoP data updates weekly, so cache hits should be the common case.

- **GET `/api/qop-rankings`** — read-through cache. Key `mt:dao:qop:<div>:<age>` (plus `:<snapshot_id>` for pinned navigation). TTL 1 hour. Only caches when `has_data=True` (empty/error responses aren't pinned).
- **POST `/api/qop-rankings`** — clears `mt:dao:qop:*` on `status="inserted"`; `unchanged` ingests skip the wipe.
- **DELETE `/api/admin/cache/{cache_type}`** — accepts `qop` for manual bust.

Graceful degradation is inherited from `cache_get` / `cache_set` — when `CACHE_ENABLED` is false or Redis is unreachable, the helpers no-op and traffic goes straight to Supabase (existing behavior).

Implementation deliberately wraps at the endpoint level rather than decorating the DAO: `QoPRankingsDAO` uses `@staticmethod` throughout, so the `@dao_cache` decorator (which assumes `self`) doesn't fit cleanly. The free-function cache helpers do.

Fixes SB-12

## Test plan

- [x] `uv run pytest tests/unit/test_qop_cache.py` — 7 tests pass covering hit / miss / no-data / pinned snapshot / inserted-invalidates / unchanged-skips / admin-accepts-qop
- [x] `uv run ruff check` — clean
- [x] **Manual smoke**: `CACHE_ENABLED=true` locally, GET `/api/qop-rankings?division_id=1&age_group_id=2` produces `dao_cache_hit` log when key is present in Redis. Log line observed:
  ```json
  {"key": "mt:dao:qop:1:2", "event": "dao_cache_hit", "logger": "dao.base_dao", ...}
  ```
- [ ] Manual: POST a new snapshot, confirm `dao_cache_cleared` log entry (skipped — local DB not migrated; behavior covered by unit test `test_inserted_triggers_cache_clear`)
- [ ] Manual: `DELETE /api/admin/cache/qop` returns deleted count (skipped — needs admin auth; behavior covered by unit test `test_qop_is_valid_cache_type`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)