### PR TITLE
feat(api_client): add tournament + team-lookup methods

### DIFF
--- a/backend/api_client/client.py
+++ b/backend/api_client/client.py
@@ -58,6 +58,8 @@ from .models import (
     SeasonCreate,
     SeasonUpdate,
     Team,
+    TournamentCreate,
+    TournamentMatchCreate,
     UserProfileUpdate,
 )
 
@@ -867,9 +869,7 @@ class MissingTableClient:
 
     def create_player_history(self, history: PlayerHistoryCreate) -> dict[str, Any]:
         """Create a player history entry."""
-        response = self._request(
-            "POST", "/api/auth/profile/history", json_data=history.model_dump(exclude_none=True)
-        )
+        response = self._request("POST", "/api/auth/profile/history", json_data=history.model_dump(exclude_none=True))
         return response.json()
 
     def update_player_history(self, history_id: int, history: PlayerHistoryUpdate) -> dict[str, Any]:
@@ -929,9 +929,7 @@ class MissingTableClient:
 
     def create_roster_entry(self, team_id: int, entry: RosterPlayerCreate) -> dict[str, Any]:
         """Create a roster entry for a team."""
-        response = self._request(
-            "POST", f"/api/teams/{team_id}/roster", json_data=entry.model_dump(exclude_none=True)
-        )
+        response = self._request("POST", f"/api/teams/{team_id}/roster", json_data=entry.model_dump(exclude_none=True))
         return response.json()
 
     def bulk_create_roster(self, team_id: int, bulk: BulkRosterCreate) -> dict[str, Any]:
@@ -1064,9 +1062,7 @@ class MissingTableClient:
 
     def submit_match_async(self, submission: MatchSubmissionData) -> dict[str, Any]:
         """Submit a match asynchronously via message queue."""
-        response = self._request(
-            "POST", "/api/matches/submit", json_data=submission.model_dump(exclude_none=True)
-        )
+        response = self._request("POST", "/api/matches/submit", json_data=submission.model_dump(exclude_none=True))
         return response.json()
 
     def get_task_status(self, task_id: str) -> dict[str, Any]:
@@ -1163,9 +1159,7 @@ class MissingTableClient:
         response = self._request("GET", f"/api/invite-requests/{request_id}")
         return response.json()
 
-    def update_invite_request_status(
-        self, request_id: str, update: InviteRequestStatusUpdate
-    ) -> dict[str, Any]:
+    def update_invite_request_status(self, request_id: str, update: InviteRequestStatusUpdate) -> dict[str, Any]:
         """Update invite request status (admin only)."""
         response = self._request(
             "PUT", f"/api/invite-requests/{request_id}/status", json_data=update.model_dump(exclude_none=True)
@@ -1222,9 +1216,7 @@ class MissingTableClient:
         response = self._request("GET", f"/api/channel-requests/{request_id}")
         return response.json()
 
-    def update_channel_request_status(
-        self, request_id: str, update: ChannelAccessStatusUpdate
-    ) -> dict[str, Any]:
+    def update_channel_request_status(self, request_id: str, update: ChannelAccessStatusUpdate) -> dict[str, Any]:
         """Update per-platform status on a channel access request (admin/club_manager only)."""
         response = self._request(
             "PUT",
@@ -1240,9 +1232,7 @@ class MissingTableClient:
 
     # Playoffs
 
-    def get_playoff_bracket(
-        self, league_id: int, season_id: int, age_group_id: int
-    ) -> dict[str, Any]:
+    def get_playoff_bracket(self, league_id: int, season_id: int, age_group_id: int) -> dict[str, Any]:
         """Get playoff bracket for a league/season/age group."""
         params = {"league_id": league_id, "season_id": season_id, "age_group_id": age_group_id}
         response = self._request("GET", "/api/playoffs/bracket", params=params)
@@ -1263,12 +1253,40 @@ class MissingTableClient:
         response = self._request("POST", "/api/admin/playoffs/advance", json_data=request.model_dump())
         return response.json()
 
-    def delete_playoff_bracket(
-        self, league_id: int, season_id: int, age_group_id: int
-    ) -> dict[str, Any]:
+    def delete_playoff_bracket(self, league_id: int, season_id: int, age_group_id: int) -> dict[str, Any]:
         """Delete an entire playoff bracket and its matches (admin only)."""
         params = {"league_id": league_id, "season_id": season_id, "age_group_id": age_group_id}
         response = self._request("DELETE", "/api/admin/playoffs/bracket", params=params)
+        return response.json()
+
+    # Tournaments
+
+    def get_active_tournaments(self) -> list[dict[str, Any]]:
+        """Get all active tournaments (public)."""
+        response = self._request("GET", "/api/tournaments")
+        return response.json()
+
+    def lookup_team(self, name: str) -> dict[str, Any]:
+        """Look up a team by name and return exact + similar matches without creating (admin only).
+
+        Returns:
+            {"exact": team | None, "similar": [team, ...]}
+        """
+        response = self._request("GET", "/api/admin/teams/lookup", params={"name": name})
+        return response.json()
+
+    def create_tournament(self, tournament: TournamentCreate) -> dict[str, Any]:
+        """Create a new tournament (admin only)."""
+        response = self._request("POST", "/api/admin/tournaments", json_data=tournament.model_dump())
+        return response.json()
+
+    def create_tournament_match(self, tournament_id: int, match: TournamentMatchCreate) -> dict[str, Any]:
+        """Add a match to a tournament (admin only)."""
+        response = self._request(
+            "POST",
+            f"/api/admin/tournaments/{tournament_id}/matches",
+            json_data=match.model_dump(),
+        )
         return response.json()
 
     # Cache management

--- a/backend/api_client/models.py
+++ b/backend/api_client/models.py
@@ -105,6 +105,35 @@ class Team(BaseModel):
     academy_team: bool | None = Field(False, title="Academy Team")
 
 
+# MANUAL: Tournament request models (mirrors app.py TournamentCreate / TournamentMatchCreate).
+# Kept in sync with backend until OpenAPI schema regeneration covers tournament routes.
+class TournamentCreate(BaseModel):
+    name: str = Field(..., title="Name")
+    start_date: str = Field(..., title="Start Date")
+    end_date: str | None = Field(None, title="End Date")
+    location: str | None = Field(None, title="Location")
+    description: str | None = Field(None, title="Description")
+    age_group_ids: list[int] = Field(default_factory=list, title="Age Group Ids")
+    is_active: bool = Field(True, title="Is Active")
+
+
+class TournamentMatchCreate(BaseModel):
+    our_team_id: int = Field(..., title="Our Team Id")
+    opponent_name: str = Field(..., title="Opponent Name")
+    match_date: str = Field(..., title="Match Date")
+    age_group_id: int = Field(..., title="Age Group Id")
+    season_id: int = Field(..., title="Season Id")
+    is_home: bool = Field(True, title="Is Home")
+    home_score: int | None = Field(None, title="Home Score")
+    away_score: int | None = Field(None, title="Away Score")
+    home_penalty_score: int | None = Field(None, title="Home Penalty Score")
+    away_penalty_score: int | None = Field(None, title="Away Penalty Score")
+    match_status: str = Field("scheduled", title="Match Status")
+    tournament_group: str | None = Field(None, title="Tournament Group")
+    tournament_round: str | None = Field(None, title="Tournament Round")
+    scheduled_kickoff: str | None = Field(None, title="Scheduled Kickoff")
+
+
 class TeamGameTypeMapping(BaseModel):
     game_type_id: int = Field(..., title="Game Type Id")
     age_group_id: int = Field(..., title="Age Group Id")

--- a/backend/tests/contract/test_tournaments_contract.py
+++ b/backend/tests/contract/test_tournaments_contract.py
@@ -1,0 +1,49 @@
+"""Contract tests for tournament endpoints."""
+
+import pytest
+
+from api_client import AuthenticationError, AuthorizationError, MissingTableClient
+from api_client.models import TournamentCreate, TournamentMatchCreate
+
+
+@pytest.mark.contract
+class TestTournamentsReadContract:
+    """Test read operations for tournament endpoints."""
+
+    def test_get_active_tournaments_returns_list(self, api_client: MissingTableClient):
+        """GET /api/tournaments is public and returns a list."""
+        tournaments = api_client.get_active_tournaments()
+        assert isinstance(tournaments, list)
+
+
+@pytest.mark.contract
+class TestTeamLookupContract:
+    """Test admin team lookup endpoint."""
+
+    def test_lookup_team_requires_auth(self, api_client: MissingTableClient):
+        """Team lookup requires admin authentication."""
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.lookup_team(name="Anything")
+
+
+@pytest.mark.contract
+class TestTournamentsWriteContract:
+    """Test write operations for tournament endpoints."""
+
+    def test_create_tournament_requires_auth(self, api_client: MissingTableClient):
+        """Creating a tournament requires admin authentication."""
+        payload = TournamentCreate(name="Test Tournament", start_date="2026-06-01")
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.create_tournament(payload)
+
+    def test_create_tournament_match_requires_auth(self, api_client: MissingTableClient):
+        """Creating a tournament match requires admin authentication."""
+        payload = TournamentMatchCreate(
+            our_team_id=1,
+            opponent_name="Opponent",
+            match_date="2026-06-01",
+            age_group_id=1,
+            season_id=1,
+        )
+        with pytest.raises((AuthenticationError, AuthorizationError)):
+            api_client.create_tournament_match(tournament_id=999999, match=payload)


### PR DESCRIPTION
## Summary

Adds `MissingTableClient` methods for tournament + admin team-lookup endpoints that have existed in the backend since the tournament tracking feature shipped, but were never exposed in the SDK. Unblocks downstream tooling (specifically a `load-tournament-matches` skill referenced in prior commits but never landed).

### New client methods
- `get_active_tournaments()` → `GET /api/tournaments`
- `lookup_team(name)` → `GET /api/admin/teams/lookup`
- `create_tournament(payload)` → `POST /api/admin/tournaments`
- `create_tournament_match(tournament_id, payload)` → `POST /api/admin/tournaments/{id}/matches`

### New models
`TournamentCreate` and `TournamentMatchCreate` added to `api_client/models.py` as manual overrides (same pattern as existing `Division*` overrides), kept in sync with `app.py`.

### Tests
`backend/tests/contract/test_tournaments_contract.py` — read + auth-gating tests matching `test_clubs_contract.py` style. Skips cleanly when no local backend is running; runs against prod in the post-deploy quality-contract workflow.

## Scope notes

- **Update/delete tournament + match methods deliberately omitted** (YAGNI). Easy to add when something needs them.
- **`api_inventory.json` regen NOT included.** Inventory is already drifted on main (44 endpoints missing client methods pre-existing this PR). Regenerating would sweep unrelated debt into this PR. The `api-coverage-review` workflow regenerates on its own and reports drift informationally — it does not block.

## Test plan

- [x] `cd backend && uv run ruff check api_client/ tests/contract/test_tournaments_contract.py` — clean
- [x] `cd backend && uv run ruff format --check api_client/ tests/contract/test_tournaments_contract.py` — clean
- [x] Smoke import: `from api_client import MissingTableClient; from api_client.models import TournamentCreate, TournamentMatchCreate` — works
- [x] Local pytest run skips cleanly without backend (expected for contract tests)
- [ ] Post-merge: quality-contract workflow runs new contract tests against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)