### PR TITLE
feat(skill): add load-tournament-matches skill

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: load-tournament-matches
+description: Load a tournament's bracket and results into Missing Table from a pasted screenshot. Extracts matches, teams, and logos via vision; confirms each club/team with the user before creating; then POSTs the matches to the tournament. Use when the user pastes a screenshot of a tournament results / bracket page (mlssoccer.com, GotSport, etc.).
+allowed-tools: Bash, Read
+---
+
+# Load Tournament Matches
+
+This skill loads a tournament's matches into Missing Table from a screenshot. It handles the **full richness** flow: it creates missing clubs (with cropped logos) and teams, then POSTs the matches to the tournament. Resolution is human-confirmed at every fuzzy step — nothing is silently created.
+
+## Prerequisites — check these BEFORE doing anything else
+
+1. **A pasted screenshot must be in the current message.** If not, ask the user to paste one.
+2. **`MT_ADMIN_TOKEN` must be set in the environment.** Verify with:
+   ```bash
+   test -n "$MT_ADMIN_TOKEN" && echo "ok" || echo "missing"
+   ```
+   If missing, STOP and tell the user: "This skill needs an admin bearer token in `MT_ADMIN_TOKEN`. The agent service-account token (`AGENT_TABLE_API_TOKEN`) is service-scope only and won't work here."
+3. **`MT_API_BASE_URL`** is optional (defaults to `http://localhost:8000`). For prod, set it to `https://api.missingtable.com`.
+
+## Tool location
+
+All operations go through one CLI. Always invoke from `backend/` so the script picks up MT's venv (which already has typer + pillow + httpx + pydantic + the `api_client` package on the path):
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py <subcommand> [args]
+```
+
+Every subcommand prints JSON to stdout. Errors print JSON to stderr and exit non-zero.
+
+Quick subcommand map:
+
+| Goal | Command |
+|------|---------|
+| Show age groups, divisions, seasons, active tournaments in one shot | `refdata show` |
+| Find a club by name (local fuzzy match) | `club find "<name>"` |
+| Create a club | `club create --name --city [--description]` |
+| Crop a logo region out of the screenshot | `logo crop --image --bbox x,y,w,h --output` |
+| Upload a logo to a club | `logo upload --club-id --path` |
+| Look up a team (admin endpoint with exact + similar) | `team lookup "<name>"` |
+| Create a team | `team create --name --city --age-group-id --division-id [--club-id]` |
+| Find a tournament by name | `tournament find "<name>"` |
+| Create a tournament | `tournament create --name --start-date [--end-date --age-group-ids 1,2,3]` |
+| Add a match to a tournament | `match create --tournament-id --our-team-id --opponent-name --match-date --age-group-id --season-id [--home-score ... --tournament-round ...]` |
+
+## Workflow
+
+### Step 1 — extract from the screenshot
+
+Look at the pasted image and pull out:
+
+- **Tournament name** (e.g. "2026 MLS Next Cup Championship") and overall **date range** if shown.
+- For each match row: **kickoff date/time**, **home team name**, **away team name**, **regulation score**, **penalty-shootout score** (if visible — usually shown as "(5–4 pens)" or similar), **age group** (U13/U14/...), **bracket round** (group stage, QF, SF, final, etc.), and any **group label** ("Group A").
+- For each unique team that appears: an approximate **logo bounding box** (`x,y,width,height` in pixels) you can extract from the screenshot.
+
+Show the user a tight summary table of what you found and **ask them to confirm before doing any writes**. This is the single biggest moment to catch parsing errors.
+
+### Step 2 — load reference data
+
+Once confirmed, fetch the IDs you'll need:
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py refdata show
+```
+
+Build name → id maps in your head for `age_groups`, `divisions`, `seasons`, and `tournaments`. You'll need the current season's `id`, age group IDs for each match, and a `division_id` if you create any new teams.
+
+### Step 3 — verify or create the tournament
+
+Search:
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py tournament find "<name>"
+```
+
+If `exact` is non-null, use that `id`. Otherwise show the `similar` list to the user.
+
+- If the user confirms a similar match is the same tournament, use it.
+- If it's truly new, get user confirmation and run:
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py tournament create \
+  --name "..." --start-date YYYY-MM-DD [--end-date YYYY-MM-DD] \
+  [--age-group-ids 3,4,5] [--location "..."] [--description "..."]
+```
+
+### Step 4 — resolve every team (lookup → confirm → create)
+
+For each unique team name in the matches:
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py team lookup "<team name>"
+```
+
+Response shape: `{"exact": team | null, "similar": [team, ...]}`.
+
+- **`exact` is non-null** → use that team's `id`. Done.
+- **`exact` is null, `similar` is non-empty** → show the candidates to the user. **Always wait for explicit confirmation** — never auto-pick a similar match. The user picks one OR says "no, create new".
+- **No matches** → ask the user to confirm creating a new club + team. Then:
+
+  1. **Find the club** the team belongs to. The team name often embeds it (e.g. "Inter Miami CF U14" → club "Inter Miami CF"). Run:
+     ```bash
+     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py club find "<club name>"
+     ```
+     If it exists, reuse its `id`. Otherwise:
+
+  2. **Crop the logo** out of the screenshot using the bbox you extracted in Step 1:
+     ```bash
+     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py logo crop \
+       --image /path/to/pasted-screenshot.png \
+       --bbox X,Y,W,H \
+       --output /tmp/logo_<slug>.png
+     ```
+
+  3. **Create the club**:
+     ```bash
+     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py club create \
+       --name "..." --city "..."
+     ```
+     Capture the returned `id`.
+
+  4. **Upload the logo**:
+     ```bash
+     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py logo upload \
+       --club-id <id> --path /tmp/logo_<slug>.png
+     ```
+
+  5. **Create the team**:
+     ```bash
+     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py team create \
+       --name "..." --city "..." \
+       --age-group-id <id> --division-id <id> \
+       --club-id <club_id>
+     ```
+
+Keep a running map of resolved `team name → team id` so you don't lookup the same team twice across multiple matches.
+
+### Step 5 — create each match
+
+For every match in the screenshot:
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py match create \
+  --tournament-id <id> \
+  --our-team-id <one-of-our-tracked-teams> \
+  --opponent-name "<the other team's name as a string>" \
+  --match-date YYYY-MM-DD \
+  --age-group-id <id> \
+  --season-id <id> \
+  --home/--away \
+  [--home-score 2 --away-score 1] \
+  [--home-penalty-score 5 --away-penalty-score 4] \
+  [--match-status completed|scheduled|in_progress] \
+  [--tournament-round group_stage|round_of_16|quarterfinal|semifinal|final|third_place|wildcard|silver_semifinal|bronze_semifinal|silver_final|bronze_final] \
+  [--tournament-group "A"] \
+  [--scheduled-kickoff "2026-06-21T15:00:00Z"]
+```
+
+**Important semantics:**
+
+- The endpoint takes `our_team_id` (an existing tracked team) + `opponent_name` (a string). The backend will auto-resolve the opponent: exact-match an existing team, otherwise create a lightweight tournament-only team. This means you don't have to create both sides as full teams — only the "our team" side needs to be a real tracked team.
+- For **MLS Next Cup specifically**: the user is loading the bracket to make the tournament look great in MT, but their own U14 IFA team is not in it. So most matches will have `opponent_name` pointing to an opposing team and `our_team_id` pointing to whatever tracked team is closest. If neither team is "ours", pick the home team to be `our_team_id` and let `is_home=True`.
+- **Penalty shootout scores** are only valid when the regulation score is a draw. Always pass both `--home-penalty-score` and `--away-penalty-score` together or neither.
+- **`match_status`**: use `completed` if the score is final, otherwise `scheduled`.
+
+### Step 6 — summary
+
+Print a single summary block at the end:
+
+```
+Tournament:        <name> (id=N)         [created | reused]
+Clubs created:     <count> — names...
+Teams created:     <count> — names...
+Logos uploaded:    <count>
+Matches created:   <count>
+Match link:        <MT_API_BASE_URL>/tournaments/<id>
+```
+
+If any step failed (e.g. a logo upload returned non-2xx), surface it explicitly — don't bury errors.
+
+## Resilience guidance
+
+- **Idempotency**: every helper does a lookup before insert. Re-running the skill on the same screenshot should be a no-op (or it should report "already exists" cleanly).
+- **Errors**: API errors print JSON to stderr with `status_code` and `response`. Surface them to the user instead of retrying blindly.
+- **Logo dedup**: if the same club appears across multiple age groups in one screenshot, crop and upload the logo once. Track which clubs you've already processed.
+- **Don't auto-pick fuzzy matches**: the team-lookup endpoint exists specifically so you can confirm before any create. Use it.
+
+## Out of scope
+
+- This skill does **not** scrape mlssoccer.com directly. Input must be a pasted screenshot.
+- This skill does **not** edit or delete existing matches. Use a future `mt-crud` skill for that (see https://github.com/silverbeer/missing-table/issues/347).

--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -11,12 +11,26 @@ This skill loads a tournament's matches into Missing Table from a screenshot. It
 ## Prerequisites — check these BEFORE doing anything else
 
 1. **A pasted screenshot must be in the current message.** If not, ask the user to paste one.
-2. **`MT_ADMIN_TOKEN` must be set in the environment.** Verify with:
+
+2. **Verify authentication** by running:
    ```bash
-   test -n "$MT_ADMIN_TOKEN" && echo "ok" || echo "missing"
+   cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py auth status
    ```
-   If missing, STOP and tell the user: "This skill needs an admin bearer token in `MT_ADMIN_TOKEN`. The agent service-account token (`AGENT_TABLE_API_TOKEN`) is service-scope only and won't work here."
-3. **`MT_API_BASE_URL`** is optional (defaults to `http://localhost:8000`). For prod, set it to `https://api.missingtable.com`.
+
+   The response is JSON. Possible outcomes:
+
+   - `{"authenticated": true, "role": "admin", ...}` → proceed.
+   - `{"authenticated": true, "role": "not_admin", ...}` → STOP. The cached token belongs to a non-admin user (e.g. team-manager). Admin endpoints will fail. Tell the user to log out and log in again as an admin:
+     ```
+     ! cd backend && uv run python mt_cli.py logout && uv run python mt_cli.py login <admin-username>
+     ```
+   - `{"authenticated": false, "hint": "..."}` → ask the user which MT admin username they want to log in as, then tell them to run (note the `!` prefix — required so `getpass` can prompt for the password in their terminal):
+     ```
+     ! cd backend && uv run python mt_cli.py login <username>
+     ```
+     Once they confirm login succeeded, re-run `auth status` to verify.
+
+3. **`MT_API_BASE_URL`** (optional, defaults to `http://localhost:8000`). The skill **shares its token with `backend/mt_cli.py`** via `backend/.mt-cli-state.json` — log in once with `mt_cli`, both tools use it. `MT_ADMIN_TOKEN` env var overrides the cached token if you want to use a different one for the skill specifically.
 
 ## Tool location
 
@@ -32,6 +46,7 @@ Quick subcommand map:
 
 | Goal | Command |
 |------|---------|
+| Check authentication + admin role | `auth status` |
 | Show age groups, divisions, seasons, active tournaments in one shot | `refdata show` |
 | Find a club by name (local fuzzy match) | `club find "<name>"` |
 | Create a club | `club create --name --city [--description]` |

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""CLI helpers for the load-tournament-matches skill.
+
+Thin typer wrapper around MissingTableClient. Every subcommand prints JSON
+to stdout so the calling skill (Claude) can parse the result.
+
+Run from the repo root:
+
+    cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py <subcommand> ...
+
+Auth: reads MT_ADMIN_TOKEN from the environment. MT_API_BASE_URL is optional
+(default http://localhost:8000).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Skill lives at .claude/skills/load-tournament-matches/scripts/mt.py
+# api_client lives at backend/api_client/ — add backend/ to sys.path.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO_ROOT / "backend"))
+
+import typer
+
+from api_client import APIError, MissingTableClient
+from api_client.models import (
+    Team,
+    TournamentCreate,
+    TournamentMatchCreate,
+)
+
+app = typer.Typer(no_args_is_help=True, add_completion=False)
+club_app = typer.Typer(no_args_is_help=True, add_completion=False)
+team_app = typer.Typer(no_args_is_help=True, add_completion=False)
+tournament_app = typer.Typer(no_args_is_help=True, add_completion=False)
+match_app = typer.Typer(no_args_is_help=True, add_completion=False)
+logo_app = typer.Typer(no_args_is_help=True, add_completion=False)
+refdata_app = typer.Typer(no_args_is_help=True, add_completion=False)
+
+app.add_typer(club_app, name="club")
+app.add_typer(team_app, name="team")
+app.add_typer(tournament_app, name="tournament")
+app.add_typer(match_app, name="match")
+app.add_typer(logo_app, name="logo")
+app.add_typer(refdata_app, name="refdata")
+
+
+def _client() -> MissingTableClient:
+    base_url = os.environ.get("MT_API_BASE_URL", "http://localhost:8000")
+    token = os.environ.get("MT_ADMIN_TOKEN")
+    if not token:
+        typer.echo(
+            "MT_ADMIN_TOKEN env var is not set. Generate an admin bearer token "
+            "and export MT_ADMIN_TOKEN before running this skill.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    return MissingTableClient(base_url=base_url, access_token=token)
+
+
+def _out(obj: object) -> None:
+    typer.echo(json.dumps(obj, indent=2, default=str))
+
+
+def _err_exit(msg: str, exc: Exception | None = None) -> None:
+    payload: dict[str, object] = {"error": msg}
+    if isinstance(exc, APIError):
+        payload["status_code"] = exc.status_code
+        payload["response"] = exc.response_data
+    elif exc is not None:
+        payload["detail"] = str(exc)
+    typer.echo(json.dumps(payload, default=str), err=True)
+    raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# Reference data
+# ---------------------------------------------------------------------------
+
+
+@refdata_app.command("show")
+def refdata_show() -> None:
+    """Print age groups, divisions, seasons, and active tournaments in one shot."""
+    with _client() as c:
+        try:
+            _out(
+                {
+                    "age_groups": c.get_age_groups(),
+                    "divisions": c.get_divisions(),
+                    "seasons": c.get_seasons(),
+                    "tournaments": c.get_active_tournaments(),
+                }
+            )
+        except APIError as exc:
+            _err_exit("failed to load reference data", exc)
+
+
+# ---------------------------------------------------------------------------
+# Clubs
+# ---------------------------------------------------------------------------
+
+
+@club_app.command("list")
+def club_list(include_teams: bool = typer.Option(False, "--include-teams")) -> None:
+    """List all clubs."""
+    with _client() as c:
+        _out(c.get_clubs(include_teams=include_teams))
+
+
+@club_app.command("find")
+def club_find(name: str = typer.Argument(...)) -> None:
+    """Case-insensitive substring search across club names. Local filter (no name-search endpoint exists)."""
+    with _client() as c:
+        clubs = c.get_clubs()
+    needle = name.casefold()
+    exact = [club for club in clubs if club.get("name", "").casefold() == needle]
+    similar = [club for club in clubs if club not in exact and needle in club.get("name", "").casefold()]
+    _out({"exact": exact[0] if exact else None, "similar": similar})
+
+
+@club_app.command("create")
+def club_create(
+    name: str = typer.Option(..., "--name"),
+    city: str = typer.Option(..., "--city"),
+    description: str | None = typer.Option(None, "--description"),
+) -> None:
+    """Create a new club. Admin only. 409 if name already exists."""
+    with _client() as c:
+        try:
+            _out(c.create_club(name=name, city=city, description=description))
+        except APIError as exc:
+            _err_exit("failed to create club", exc)
+
+
+# ---------------------------------------------------------------------------
+# Teams
+# ---------------------------------------------------------------------------
+
+
+@team_app.command("lookup")
+def team_lookup(name: str = typer.Argument(...)) -> None:
+    """Admin team lookup: returns {exact, similar} without creating anything."""
+    with _client() as c:
+        try:
+            _out(c.lookup_team(name=name))
+        except APIError as exc:
+            _err_exit("failed to lookup team", exc)
+
+
+@team_app.command("create")
+def team_create(
+    name: str = typer.Option(..., "--name"),
+    city: str = typer.Option(..., "--city"),
+    age_group_id: int = typer.Option(..., "--age-group-id"),
+    division_id: int = typer.Option(..., "--division-id"),
+    club_id: int | None = typer.Option(None, "--club-id"),
+    academy_team: bool = typer.Option(False, "--academy-team"),
+) -> None:
+    """Create a team tied to one age group + division."""
+    payload = Team(
+        name=name,
+        city=city,
+        age_group_ids=[age_group_id],
+        division_id=division_id,
+        club_id=club_id,
+        academy_team=academy_team,
+    )
+    with _client() as c:
+        try:
+            _out(c.create_team(payload))
+        except APIError as exc:
+            _err_exit("failed to create team", exc)
+
+
+# ---------------------------------------------------------------------------
+# Tournaments
+# ---------------------------------------------------------------------------
+
+
+@tournament_app.command("list")
+def tournament_list() -> None:
+    """List active tournaments (public endpoint)."""
+    with _client() as c:
+        _out(c.get_active_tournaments())
+
+
+@tournament_app.command("find")
+def tournament_find(name: str = typer.Argument(...)) -> None:
+    """Case-insensitive substring search across active tournaments."""
+    with _client() as c:
+        tournaments = c.get_active_tournaments()
+    needle = name.casefold()
+    exact = [t for t in tournaments if t.get("name", "").casefold() == needle]
+    similar = [t for t in tournaments if t not in exact and needle in t.get("name", "").casefold()]
+    _out({"exact": exact[0] if exact else None, "similar": similar})
+
+
+@tournament_app.command("create")
+def tournament_create(
+    name: str = typer.Option(..., "--name"),
+    start_date: str = typer.Option(..., "--start-date"),
+    end_date: str | None = typer.Option(None, "--end-date"),
+    location: str | None = typer.Option(None, "--location"),
+    description: str | None = typer.Option(None, "--description"),
+    age_group_ids: str | None = typer.Option(
+        None,
+        "--age-group-ids",
+        help="Comma-separated age group IDs (e.g. '1,2,3').",
+    ),
+    is_active: bool = typer.Option(True, "--active/--inactive"),
+) -> None:
+    """Create a tournament."""
+    ag_ids = [int(x.strip()) for x in age_group_ids.split(",") if x.strip()] if age_group_ids else []
+    payload = TournamentCreate(
+        name=name,
+        start_date=start_date,
+        end_date=end_date,
+        location=location,
+        description=description,
+        age_group_ids=ag_ids,
+        is_active=is_active,
+    )
+    with _client() as c:
+        try:
+            _out(c.create_tournament(payload))
+        except APIError as exc:
+            _err_exit("failed to create tournament", exc)
+
+
+# ---------------------------------------------------------------------------
+# Matches
+# ---------------------------------------------------------------------------
+
+
+VALID_ROUNDS = {
+    "group_stage",
+    "round_of_16",
+    "quarterfinal",
+    "semifinal",
+    "final",
+    "third_place",
+    "wildcard",
+    "silver_semifinal",
+    "bronze_semifinal",
+    "silver_final",
+    "bronze_final",
+}
+
+
+@match_app.command("create")
+def match_create(
+    tournament_id: int = typer.Option(..., "--tournament-id"),
+    our_team_id: int = typer.Option(..., "--our-team-id"),
+    opponent_name: str = typer.Option(..., "--opponent-name"),
+    match_date: str = typer.Option(..., "--match-date"),
+    age_group_id: int = typer.Option(..., "--age-group-id"),
+    season_id: int = typer.Option(..., "--season-id"),
+    is_home: bool = typer.Option(True, "--home/--away"),
+    home_score: int | None = typer.Option(None, "--home-score"),
+    away_score: int | None = typer.Option(None, "--away-score"),
+    home_penalty_score: int | None = typer.Option(None, "--home-penalty-score"),
+    away_penalty_score: int | None = typer.Option(None, "--away-penalty-score"),
+    match_status: str = typer.Option("scheduled", "--match-status"),
+    tournament_group: str | None = typer.Option(None, "--tournament-group"),
+    tournament_round: str | None = typer.Option(None, "--tournament-round"),
+    scheduled_kickoff: str | None = typer.Option(None, "--scheduled-kickoff"),
+) -> None:
+    """Add a match to a tournament. our_team_id is one of our tracked teams; opponent_name is the visitor."""
+    if tournament_round is not None and tournament_round not in VALID_ROUNDS:
+        _err_exit(f"invalid --tournament-round '{tournament_round}'; must be one of: {sorted(VALID_ROUNDS)}")
+    payload = TournamentMatchCreate(
+        our_team_id=our_team_id,
+        opponent_name=opponent_name,
+        match_date=match_date,
+        age_group_id=age_group_id,
+        season_id=season_id,
+        is_home=is_home,
+        home_score=home_score,
+        away_score=away_score,
+        home_penalty_score=home_penalty_score,
+        away_penalty_score=away_penalty_score,
+        match_status=match_status,
+        tournament_group=tournament_group,
+        tournament_round=tournament_round,
+        scheduled_kickoff=scheduled_kickoff,
+    )
+    with _client() as c:
+        try:
+            _out(c.create_tournament_match(tournament_id=tournament_id, match=payload))
+        except APIError as exc:
+            _err_exit("failed to create tournament match", exc)
+
+
+# ---------------------------------------------------------------------------
+# Logos
+# ---------------------------------------------------------------------------
+
+
+@logo_app.command("crop")
+def logo_crop(
+    image: str = typer.Option(..., "--image", help="Path to the source screenshot."),
+    bbox: str = typer.Option(..., "--bbox", help="x,y,w,h in pixels (top-left origin)."),
+    output: str = typer.Option(..., "--output", help="Destination PNG path."),
+    max_size: int = typer.Option(512, "--max-size", help="Max width/height after thumbnailing."),
+) -> None:
+    """Crop a logo region from a screenshot and write a square-friendly PNG (≤2MB)."""
+    from PIL import Image  # local import: keeps startup fast for non-logo paths
+
+    try:
+        x_s, y_s, w_s, h_s = bbox.split(",")
+        x, y, w, h = int(x_s), int(y_s), int(w_s), int(h_s)
+    except ValueError as exc:
+        _err_exit(f"invalid --bbox '{bbox}'; expected 'x,y,w,h'", exc)
+
+    img = Image.open(image).convert("RGBA")
+    crop = img.crop((x, y, x + w, y + h))
+    crop.thumbnail((max_size, max_size))
+    out_path = Path(output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    crop.save(out_path, "PNG", optimize=True)
+    size = out_path.stat().st_size
+    if size > 2 * 1024 * 1024:
+        _err_exit(
+            f"cropped logo is {size} bytes (>2MB limit); try a smaller --max-size",
+        )
+    _out(
+        {
+            "output": str(out_path),
+            "size_bytes": size,
+            "width": crop.width,
+            "height": crop.height,
+        }
+    )
+
+
+@logo_app.command("upload")
+def logo_upload(
+    club_id: int = typer.Option(..., "--club-id"),
+    path: str = typer.Option(..., "--path"),
+) -> None:
+    """Upload a PNG/JPG (≤2MB) as a club's logo. Admin only."""
+    with _client() as c:
+        try:
+            _out(c.upload_club_logo(club_id=club_id, file_path=path))
+        except APIError as exc:
+            _err_exit("failed to upload club logo", exc)
+
+
+if __name__ == "__main__":
+    app()

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -34,6 +34,7 @@ from api_client.models import (
 )
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
+auth_app = typer.Typer(no_args_is_help=True, add_completion=False)
 club_app = typer.Typer(no_args_is_help=True, add_completion=False)
 team_app = typer.Typer(no_args_is_help=True, add_completion=False)
 tournament_app = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -41,6 +42,7 @@ match_app = typer.Typer(no_args_is_help=True, add_completion=False)
 logo_app = typer.Typer(no_args_is_help=True, add_completion=False)
 refdata_app = typer.Typer(no_args_is_help=True, add_completion=False)
 
+app.add_typer(auth_app, name="auth")
 app.add_typer(club_app, name="club")
 app.add_typer(team_app, name="team")
 app.add_typer(tournament_app, name="tournament")
@@ -49,13 +51,38 @@ app.add_typer(logo_app, name="logo")
 app.add_typer(refdata_app, name="refdata")
 
 
+# Shared with backend/mt_cli.py — both tools read/write the same login state.
+_MT_CLI_STATE_FILE = _REPO_ROOT / "backend" / ".mt-cli-state.json"
+
+
+def _load_cached_token() -> tuple[str | None, str | None]:
+    """Return (access_token, username) from the shared mt_cli state file."""
+    if not _MT_CLI_STATE_FILE.exists():
+        return None, None
+    try:
+        data = json.loads(_MT_CLI_STATE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, None
+    return data.get("access_token"), data.get("username")
+
+
 def _client() -> MissingTableClient:
     base_url = os.environ.get("MT_API_BASE_URL", "http://localhost:8000")
     token = os.environ.get("MT_ADMIN_TOKEN")
     if not token:
+        token, _username = _load_cached_token()
+    if not token:
         typer.echo(
-            "MT_ADMIN_TOKEN env var is not set. Generate an admin bearer token "
-            "and export MT_ADMIN_TOKEN before running this skill.",
+            json.dumps(
+                {
+                    "error": "not_authenticated",
+                    "detail": (
+                        "No token found. Either export MT_ADMIN_TOKEN, or run "
+                        "the mt_cli login (in your terminal, not via Claude): "
+                        "cd backend && uv run python mt_cli.py login <username>"
+                    ),
+                }
+            ),
             err=True,
         )
         raise typer.Exit(code=2)
@@ -75,6 +102,70 @@ def _err_exit(msg: str, exc: Exception | None = None) -> None:
         payload["detail"] = str(exc)
     typer.echo(json.dumps(payload, default=str), err=True)
     raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@auth_app.command("status")
+def auth_status() -> None:
+    """Report whether a token is available and (when possible) the user's role.
+
+    Resolution order: MT_ADMIN_TOKEN env var → backend/.mt-cli-state.json.
+    """
+    env_token = os.environ.get("MT_ADMIN_TOKEN")
+    cached_token, cached_username = _load_cached_token()
+    source = None
+    username = None
+    if env_token:
+        source = "env"
+    elif cached_token:
+        source = "mt_cli_state"
+        username = cached_username
+    base_url = os.environ.get("MT_API_BASE_URL", "http://localhost:8000")
+
+    if source is None:
+        _out(
+            {
+                "authenticated": False,
+                "source": None,
+                "username": None,
+                "base_url": base_url,
+                "hint": (
+                    "Ask the user to run `! cd backend && uv run python mt_cli.py login <username>` "
+                    "in their terminal (the `!` prefix runs interactively so getpass can prompt for "
+                    "the password). Pick an admin user — admin endpoints reject non-admin tokens."
+                ),
+            }
+        )
+        return
+
+    # Probe role by hitting an admin-only endpoint that returns the cheapest payload.
+    role: str | None = None
+    role_check: str
+    try:
+        with _client() as c:
+            c.lookup_team(name="__role_probe__")
+        role = "admin"
+        role_check = "ok"
+    except APIError as exc:
+        if exc.status_code in (401, 403):
+            role = "not_admin"
+            role_check = f"{exc.status_code}"
+        else:
+            role_check = f"error:{exc.status_code}"
+    _out(
+        {
+            "authenticated": True,
+            "source": source,
+            "username": username,
+            "base_url": base_url,
+            "role": role,
+            "role_check": role_check,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes SB-16

## Summary

Adds a Claude Code skill at \`.claude/skills/load-tournament-matches/\` that loads a tournament's bracket and results into Missing Table from a pasted screenshot. The skill:

1. Uses vision to extract the tournament, matches, teams, and logo bounding boxes from the screenshot
2. Looks up each team via \`/api/admin/teams/lookup\` and **asks the user to confirm** anything below an exact match
3. For unknown teams, crops the logo out of the screenshot, creates the club, uploads the logo, and creates the team
4. Creates the tournament if it doesn't exist and POSTs each match

## Dependency

⚠️ **Stacked on #346** — this PR uses \`MissingTableClient.lookup_team\`, \`create_tournament\`, and \`create_tournament_match\` which are added in that PR. Merge #346 first, then rebase + merge this one.

## Layout

\`\`\`
.claude/skills/load-tournament-matches/
├── SKILL.md         # Instructions Claude reads when /load-tournament-matches is invoked
└── scripts/
    └── mt.py        # Typer CLI: club/team/tournament/match/logo/refdata subcommands
\`\`\`

\`mt.py\` is a thin wrapper over \`MissingTableClient\` — every subcommand prints JSON to stdout so the calling skill (Claude) can parse the result. All API operations route through it; there's no duplicated HTTP code.

## Why this skill exists

Prior commits already referenced it in their messages but never landed the skill itself:
- \`0cc7c51\` — \"add team lookup endpoint and improve opponent resolution safety\" — \"Used by load-tournament-matches skill to confirm before any team creation\"
- \`998ea0c\` — \"add penalty shootout score support\" — \"load-tournament-matches skill updated to parse and POST PK results\"

This PR finally lands what those commits anticipated.

## Auth

Skill requires \`MT_ADMIN_TOKEN\` env var (admin bearer token). The agent service-account token (\`AGENT_TABLE_API_TOKEN\`) is service-scope only — it can't call \`/api/admin/*\`. Skill checks for the token before any work and prints a clear error if missing.

## Test plan

- [x] \`uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py --help\` — typer help renders
- [x] \`mt match create --help\` — all options visible, sensible defaults
- [x] \`mt refdata show\` without \`MT_ADMIN_TOKEN\` — clean error message, exit 2
- [x] \`mt logo crop\` end-to-end with a temp PNG — 200×200 crop, 469 bytes output
- [x] \`uv run ruff check\` clean
- [x] \`uv run ruff format --check\` clean
- [ ] End-to-end run against staging/prod with a real MLS Next Cup screenshot (will do once admin token is generated)

## Companion skill

A separate \`mt-crud\` skill for review/edit/review of clubs (then teams, matches) is tracked in #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
