### PR TITLE
feat(tournaments): add round_of_32 to bracket round enum

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -166,7 +166,7 @@ cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt
   [--home-score 2 --away-score 1] \
   [--home-penalty-score 5 --away-penalty-score 4] \
   [--match-status completed|scheduled|in_progress] \
-  [--tournament-round group_stage|round_of_16|quarterfinal|semifinal|final|third_place|wildcard|silver_semifinal|bronze_semifinal|silver_final|bronze_final] \
+  [--tournament-round group_stage|round_of_32|round_of_16|quarterfinal|semifinal|final|third_place|wildcard|silver_semifinal|bronze_semifinal|silver_final|bronze_final] \
   [--tournament-group "A"] \
   [--scheduled-kickoff "2026-06-21T15:00:00Z"]
 ```

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -329,6 +329,7 @@ def tournament_create(
 
 VALID_ROUNDS = {
     "group_stage",
+    "round_of_32",
     "round_of_16",
     "quarterfinal",
     "semifinal",

--- a/backend/dao/tournament_dao.py
+++ b/backend/dao/tournament_dao.py
@@ -20,6 +20,7 @@ TOURNAMENT_MATCH_TYPE_ID = 2
 
 VALID_ROUNDS = {
     "group_stage",
+    "round_of_32",
     "round_of_16",
     "quarterfinal",
     "semifinal",

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -514,6 +514,7 @@ import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 
 const KNOCKOUT_ROUNDS = new Set([
+  'round_of_32',
   'round_of_16',
   'quarterfinal',
   'semifinal',
@@ -523,6 +524,7 @@ const KNOCKOUT_ROUNDS = new Set([
 
 const ROUND_LABELS = {
   group_stage: 'Group Stage',
+  round_of_32: 'R32',
   round_of_16: 'R16',
   quarterfinal: 'QF',
   semifinal: 'SF',
@@ -643,6 +645,7 @@ export default {
         .filter(m => KNOCKOUT_ROUNDS.has(m.tournament_round))
         .sort((a, b) => {
           const order = [
+            'round_of_32',
             'round_of_16',
             'quarterfinal',
             'semifinal',

--- a/frontend/src/components/admin/AdminTournaments.vue
+++ b/frontend/src/components/admin/AdminTournaments.vue
@@ -500,6 +500,7 @@
                 >
                   <option value="">— none —</option>
                   <option value="group_stage">Group Stage</option>
+                  <option value="round_of_32">Round of 32</option>
                   <option value="round_of_16">Round of 16</option>
                   <option value="quarterfinal">Quarterfinal</option>
                   <option value="semifinal">Semifinal</option>
@@ -670,6 +671,7 @@ import { getApiBaseUrl } from '../../config/api';
 
 const ROUND_LABELS = {
   group_stage: 'Group Stage',
+  round_of_32: 'Round of 32',
   round_of_16: 'Round of 16',
   quarterfinal: 'Quarterfinal',
   semifinal: 'Semifinal',


### PR DESCRIPTION
## Summary
- MLS Next Cup Championship/Premier brackets seat 32 teams, so their first playoff round is a round of 32 — previously unrepresentable in MT's round enum
- Adds `round_of_32` to every place the enum is enumerated: backend `VALID_ROUNDS`, frontend `KNOCKOUT_ROUNDS`/`ROUND_LABELS`/sort order, the AdminTournaments edit-match dropdown, and the load-tournament-matches skill CLI + docs
- No DB migration needed — `tournament_round` is plain `TEXT` with no CHECK constraint, so adding the value at the app layer is sufficient

## Test plan
- [ ] Edit a tournament match in AdminPanel → confirm "Round of 32" appears in the round dropdown and saves
- [ ] Create a match via `/api/admin/tournaments/{id}/matches` with `tournament_round=round_of_32` and confirm 200
- [ ] Confirm a `round_of_32` match shows under the knockout view in TournamentMatchCenter, sorted before R16
- [ ] Run `mt.py match create ... --tournament-round round_of_32` and confirm it doesn't fail the local validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)