### PR TITLE
feat(skill): consult mls-next-clubs.json for division lookup

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -48,12 +48,13 @@ Quick subcommand map:
 |------|---------|
 | Check authentication + admin role | `auth status` |
 | Show age groups, divisions, seasons, active tournaments in one shot | `refdata show` |
+| Look up an MLS NEXT club's division by name + age group | `clubmap lookup --team "<name>" --age-group U14` |
 | Find a club by name (local fuzzy match) | `club find "<name>"` |
 | Create a club | `club create --name --city [--description]` |
 | Crop a logo region out of the screenshot | `logo crop --image --bbox x,y,w,h --output` |
 | Upload a logo to a club | `logo upload --club-id --path` |
 | Look up a team (admin endpoint with exact + similar) | `team lookup "<name>"` |
-| Create a team | `team create --name --city --age-group-id --division-id [--club-id]` |
+| Create a team | `team create --name --city --age-group-id --division-id [--club-id] [--academy-team]` |
 | Find a tournament by name | `tournament find "<name>"` |
 | Create a tournament | `tournament create --name --start-date [--end-date --age-group-ids 1,2,3]` |
 | Add a match to a tournament | `match create --tournament-id --our-team-id --opponent-name --match-date --age-group-id --season-id [--home-score ... --tournament-round ...]` |
@@ -113,13 +114,22 @@ Response shape: `{"exact": team | null, "similar": [team, ...]}`.
 - **`exact` is null, `similar` is non-empty** → show the candidates to the user. **Always wait for explicit confirmation** — never auto-pick a similar match. The user picks one OR says "no, create new".
 - **No matches** → ask the user to confirm creating a new club + team. Then:
 
-  1. **Find the club** the team belongs to. The team name often embeds it (e.g. "Inter Miami CF U14" → club "Inter Miami CF"). Run:
+  1. **Look up the team in the MLS NEXT clubs mapping** to find its canonical division and pro-academy status. The mapping (`backend/data/mls-next-clubs.json`) covers all current MLS NEXT Allstate Homegrown + Pro Player Pathway teams:
+     ```bash
+     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py clubmap lookup \
+       --team "<team name>" --age-group U14
+     ```
+     - **`match` is non-null** → use `match.division` as the division for team creation (find its `id` via `refdata show`'s divisions list — match by name; if the MT division doesn't exist yet, surface that to the user). Use `match.is_pro_academy` to set `--academy-team`.
+     - **`match` is null, `all_age_groups_for_team` is non-empty** → the team plays at *other* age groups but not this one. Surface to the user — the screenshot may have a typo or the roster has changed.
+     - **No matches at all** → not an MLS NEXT Allstate Homegrown / PPP team. Ask the user for division + whether it's a pro academy.
+
+  2. **Find the club** the team belongs to. The team name often embeds it (e.g. "Inter Miami CF U14" → club "Inter Miami CF"). Run:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py club find "<club name>"
      ```
      If it exists, reuse its `id`. Otherwise:
 
-  2. **Crop the logo** out of the screenshot using the bbox you extracted in Step 1:
+  3. **Crop the logo** out of the screenshot using the bbox you extracted in Step 1:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py logo crop \
        --image /path/to/pasted-screenshot.png \
@@ -127,25 +137,26 @@ Response shape: `{"exact": team | null, "similar": [team, ...]}`.
        --output /tmp/logo_<slug>.png
      ```
 
-  3. **Create the club**:
+  4. **Create the club**:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py club create \
        --name "..." --city "..."
      ```
      Capture the returned `id`.
 
-  4. **Upload the logo**:
+  5. **Upload the logo**:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py logo upload \
        --club-id <id> --path /tmp/logo_<slug>.png
      ```
 
-  5. **Create the team**:
+  6. **Create the team**:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py team create \
        --name "..." --city "..." \
        --age-group-id <id> --division-id <id> \
-       --club-id <club_id>
+       --club-id <club_id> \
+       [--academy-team]    # pass if clubmap.match.is_pro_academy was true
      ```
 
 Keep a running map of resolved `team name → team id` so you don't lookup the same team twice across multiple matches.

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -41,6 +41,7 @@ tournament_app = typer.Typer(no_args_is_help=True, add_completion=False)
 match_app = typer.Typer(no_args_is_help=True, add_completion=False)
 logo_app = typer.Typer(no_args_is_help=True, add_completion=False)
 refdata_app = typer.Typer(no_args_is_help=True, add_completion=False)
+clubmap_app = typer.Typer(no_args_is_help=True, add_completion=False)
 
 app.add_typer(auth_app, name="auth")
 app.add_typer(club_app, name="club")
@@ -49,6 +50,7 @@ app.add_typer(tournament_app, name="tournament")
 app.add_typer(match_app, name="match")
 app.add_typer(logo_app, name="logo")
 app.add_typer(refdata_app, name="refdata")
+app.add_typer(clubmap_app, name="clubmap")
 
 
 # Shared with backend/mt_cli.py — both tools read/write the same login state.
@@ -188,6 +190,43 @@ def refdata_show() -> None:
             )
         except APIError as exc:
             _err_exit("failed to load reference data", exc)
+
+
+# ---------------------------------------------------------------------------
+# Local club mapping (MLS NEXT)
+# ---------------------------------------------------------------------------
+
+_CLUBMAP_PATH = _REPO_ROOT / "backend" / "data" / "mls-next-clubs.json"
+
+
+@clubmap_app.command("lookup")
+def clubmap_lookup(
+    team: str = typer.Option(..., "--team"),
+    age_group: str = typer.Option(..., "--age-group", help="e.g. U13, U14, U15, U16, U17, U19"),
+) -> None:
+    """Look up an MLS NEXT club in backend/data/mls-next-clubs.json.
+
+    Match is case-insensitive on team name. Returns:
+      {
+        "match": {age_group, division, team, is_pro_academy} | null,
+        "all_age_groups_for_team": [...rows for that team across all age groups...]
+      }
+
+    Use this when the API team_lookup returns no exact match — it gives the
+    correct (division, is_pro_academy) defaults for team creation without
+    having to ask the user to guess.
+    """
+    try:
+        data = json.loads(_CLUBMAP_PATH.read_text())
+    except FileNotFoundError:
+        _err_exit(f"clubmap file not found at {_CLUBMAP_PATH}")
+    except json.JSONDecodeError as exc:
+        _err_exit("clubmap file is not valid JSON", exc)
+
+    team_lower = team.lower()
+    same_team = [r for r in data.get("teams", []) if r["team"].lower() == team_lower]
+    match = next((r for r in same_team if r["age_group"] == age_group), None)
+    _out({"match": match, "all_age_groups_for_team": same_team})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/data/mls-next-clubs.json
+++ b/backend/data/mls-next-clubs.json
@@ -3,758 +3,4960 @@
     "source": "https://www.modular11.com/standings (iframe embedded on https://www.mlssoccer.com/mlsnext/standings/<age-group>/)",
     "scraped_at": "2026-05-19",
     "season": "2025-2026",
-    "scope": "MLS NEXT Allstate Homegrown Division only",
-    "excluded": "Pro Player Pathway divisions (Central/West/Southeast/Northeast) — these are the Academy Division side, present in U16/U17/U19 widgets only. Excluded per scope: 'Homegrown only'.",
+    "scope": "MLS NEXT Allstate Homegrown Division + Pro Player Pathway (Academy Division, U16/U17/U19 only). Each row has is_pro_academy=true if the club fields a team in the Pro Player Pathway divisions at any age group.",
     "notes": [
       "Each row is a unique (age_group, division, team) triple.",
       "Not every club fields a team in every age group (sparse coverage).",
-      "Division names have been stripped of the 'U<NN> ' age-group prefix (e.g. 'U15 Mid-Atlantic' → 'Mid-Atlantic').",
-      "Team names are as they appear in the widget — minor variants may exist between age groups (e.g. 'Los Angeles SC' vs 'Los Angeles Soccer Club')."
+      "Homegrown division names have been stripped of the 'U<NN> ' age-group prefix.",
+      "Pro Player Pathway division names keep their '(Pro Player Pathway)' suffix to disambiguate from the similarly-named Homegrown divisions (Southeast/Northeast).",
+      "is_pro_academy=true marks teams whose club has an MLS Pro Player Pathway academy team at some age group. This includes their Homegrown rows at U13-U15.",
+      "Team names are as they appear in the widget \u2014 minor variants may exist between age groups (e.g. 'Los Angeles SC' vs 'Los Angeles Soccer Club')."
     ]
   },
   "teams": [
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Philadelphia Union"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Real Futbol Academy"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Northern Virginia Alliance"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Springfield SYC"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Baltimore Armour"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "FC DELCO"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Alexandria SA"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Cedar Stars Academy Monmouth"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "The Football Academy"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Players Development Academy"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Bethesda SC"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Keystone FC"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "PA Classics"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Sporting Athletic Club"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Achilles FC"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "Beadling SC"},
-    {"age_group": "U13", "division": "Mid-Atlantic", "team": "West Virginia Soccer"},
-    {"age_group": "U13", "division": "Mid-America", "team": "St. Louis Scott Gallagher"},
-    {"age_group": "U13", "division": "Mid-America", "team": "FC Cincinnati"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Lou Fusz Athletic"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Cincinnati United Soccer Club"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Indy Eleven"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Michigan Wolves"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Michigan Jaguars"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Chicago FC United"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Hoosier Premier"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Bavarian United SC"},
-    {"age_group": "U13", "division": "Mid-America", "team": "SC Wave"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Michigan Futbol Academy"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Midwest United FC"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Vardar Soccer Club"},
-    {"age_group": "U13", "division": "Mid-America", "team": "Sockers FC Chicago"},
-    {"age_group": "U13", "division": "Frontier", "team": "FC Dallas"},
-    {"age_group": "U13", "division": "Frontier", "team": "Austin FC"},
-    {"age_group": "U13", "division": "Frontier", "team": "ALBION SC Colorado"},
-    {"age_group": "U13", "division": "Frontier", "team": "Tulsa Greenwood SC"},
-    {"age_group": "U13", "division": "Frontier", "team": "AC River"},
-    {"age_group": "U13", "division": "Frontier", "team": "Global Football Innovation Academy"},
-    {"age_group": "U13", "division": "Frontier", "team": "Houston Rangers"},
-    {"age_group": "U13", "division": "Frontier", "team": "Colorado Rapids"},
-    {"age_group": "U13", "division": "Frontier", "team": "Dallas Hornets"},
-    {"age_group": "U13", "division": "Frontier", "team": "Capital City SC"},
-    {"age_group": "U13", "division": "Northwest", "team": "Sacramento Republic FC"},
-    {"age_group": "U13", "division": "Northwest", "team": "Silicon Valley Soccer Academy"},
-    {"age_group": "U13", "division": "Northwest", "team": "FC Bay Area Surf"},
-    {"age_group": "U13", "division": "Northwest", "team": "Modesto Ajax United"},
-    {"age_group": "U13", "division": "Northwest", "team": "The Town FC Academy"},
-    {"age_group": "U13", "division": "Northwest", "team": "De Anza Force"},
-    {"age_group": "U13", "division": "Northwest", "team": "San Francisco Glens SC"},
-    {"age_group": "U13", "division": "Northwest", "team": "Ballistic United"},
-    {"age_group": "U13", "division": "Northwest", "team": "Sacramento United"},
-    {"age_group": "U13", "division": "Northwest", "team": "ALBION SC Merced"},
-    {"age_group": "U13", "division": "Northwest", "team": "Napa United"},
-    {"age_group": "U13", "division": "Northwest", "team": "Atletico Santa Rosa"},
-    {"age_group": "U13", "division": "Northwest", "team": "San Francisco Seals"},
-    {"age_group": "U13", "division": "Northwest", "team": "Lamorinda Soccer Club"},
-    {"age_group": "U13", "division": "Northwest", "team": "Woodside Soccer Club Crush"},
-    {"age_group": "U13", "division": "Southwest", "team": "LA Galaxy"},
-    {"age_group": "U13", "division": "Southwest", "team": "Strikers FC"},
-    {"age_group": "U13", "division": "Southwest", "team": "Los Angeles Football Club"},
-    {"age_group": "U13", "division": "Southwest", "team": "Total Futbol Academy"},
-    {"age_group": "U13", "division": "Southwest", "team": "San Diego FC"},
-    {"age_group": "U13", "division": "Southwest", "team": "RSL Arizona"},
-    {"age_group": "U13", "division": "Southwest", "team": "Los Angeles Soccer Club"},
-    {"age_group": "U13", "division": "Southwest", "team": "Chula Vista FC"},
-    {"age_group": "U13", "division": "Southwest", "team": "ALBION SC Los Angeles"},
-    {"age_group": "U13", "division": "Southwest", "team": "Los Angeles Surf"},
-    {"age_group": "U13", "division": "Southwest", "team": "City SC San Diego"},
-    {"age_group": "U13", "division": "Southwest", "team": "FC Golden State"},
-    {"age_group": "U13", "division": "Southwest", "team": "ALBION SC Las Vegas"},
-    {"age_group": "U13", "division": "Southwest", "team": "Santa Barbara Soccer Club"},
-    {"age_group": "U13", "division": "Southwest", "team": "ALBION SC San Diego"},
-    {"age_group": "U13", "division": "Southwest", "team": "City SC Southwest"},
-    {"age_group": "U13", "division": "Southwest", "team": "Las Vegas Sports Academy"},
-    {"age_group": "U13", "division": "Southwest", "team": "Phoenix Rising FC"},
-    {"age_group": "U13", "division": "Southwest", "team": "SoCal Reds FC"},
-    {"age_group": "U13", "division": "Southwest", "team": "LA Bulls"},
-    {"age_group": "U13", "division": "Southwest", "team": "RSL Arizona Mesa"},
-    {"age_group": "U13", "division": "Southwest", "team": "SC Del Sol"},
-    {"age_group": "U13", "division": "Southwest", "team": "Ventura County Fusion"},
-    {"age_group": "U13", "division": "Florida", "team": "Orlando City SC"},
-    {"age_group": "U13", "division": "Florida", "team": "Inter Miami CF"},
-    {"age_group": "U13", "division": "Florida", "team": "Weston FC"},
-    {"age_group": "U13", "division": "Florida", "team": "South Florida Football Academy"},
-    {"age_group": "U13", "division": "Florida", "team": "Tampa Bay United"},
-    {"age_group": "U13", "division": "Florida", "team": "Jacksonville FC"},
-    {"age_group": "U13", "division": "Florida", "team": "IdeaSport SA"},
-    {"age_group": "U13", "division": "Florida", "team": "Miami Futbol Academy Rush"},
-    {"age_group": "U13", "division": "Florida", "team": "IMG"},
-    {"age_group": "U13", "division": "Florida", "team": "Orlando City Soccer School South"},
-    {"age_group": "U13", "division": "Florida", "team": "West Florida Flames"},
-    {"age_group": "U13", "division": "Florida", "team": "Athletum FC Academy"},
-    {"age_group": "U13", "division": "Florida", "team": "Sol SC Florida"},
-    {"age_group": "U13", "division": "Florida", "team": "Orlando City Youth SC"},
-    {"age_group": "U13", "division": "Florida", "team": "Chargers Soccer Club"},
-    {"age_group": "U13", "division": "Southeast", "team": "Atlanta United"},
-    {"age_group": "U13", "division": "Southeast", "team": "Carolina Core FC"},
-    {"age_group": "U13", "division": "Southeast", "team": "Inter Atlanta FC"},
-    {"age_group": "U13", "division": "Southeast", "team": "Queen City Mutiny FC"},
-    {"age_group": "U13", "division": "Southeast", "team": "Wake FC"},
-    {"age_group": "U13", "division": "Southeast", "team": "Charlotte Independence"},
-    {"age_group": "U13", "division": "Southeast", "team": "Southern Soccer Academy"},
-    {"age_group": "U13", "division": "Southeast", "team": "Nashville United Soccer Academy"},
-    {"age_group": "U13", "division": "Southeast", "team": "AFC Lightning"},
-    {"age_group": "U13", "division": "Southeast", "team": "Lanier Soccer Association"},
-    {"age_group": "U13", "division": "Southeast", "team": "Chattanooga FC"},
-    {"age_group": "U13", "division": "Southeast", "team": "Huntsville City FC"},
-    {"age_group": "U13", "division": "Southeast", "team": "Triangle United Soccer Association"},
-    {"age_group": "U13", "division": "Southeast", "team": "Hoover-Vestavia Soccer"},
-    {"age_group": "U13", "division": "Southeast", "team": "KSA"},
-    {"age_group": "U13", "division": "Northeast", "team": "New York Red Bulls"},
-    {"age_group": "U13", "division": "Northeast", "team": "New York City FC"},
-    {"age_group": "U13", "division": "Northeast", "team": "Cedar Stars Academy Bergen"},
-    {"age_group": "U13", "division": "Northeast", "team": "New York SC"},
-    {"age_group": "U13", "division": "Northeast", "team": "NEFC"},
-    {"age_group": "U13", "division": "Northeast", "team": "Beachside of Connecticut"},
-    {"age_group": "U13", "division": "Northeast", "team": "FC Greater Boston Bolts"},
-    {"age_group": "U13", "division": "Northeast", "team": "FC Westchester"},
-    {"age_group": "U13", "division": "Northeast", "team": "Long Island Soccer Club"},
-    {"age_group": "U13", "division": "Northeast", "team": "TSF Academy"},
-    {"age_group": "U13", "division": "Northeast", "team": "New England Revolution"},
-    {"age_group": "U13", "division": "Northeast", "team": "Downtown United Soccer Club"},
-    {"age_group": "U13", "division": "Northeast", "team": "Blau Weiss Gottschee"},
-    {"age_group": "U13", "division": "Northeast", "team": "Intercontinental Football Academy of New England"},
-    {"age_group": "U13", "division": "Northeast", "team": "Seacoast United"},
-    {"age_group": "U13", "division": "Northeast", "team": "Oakwood Soccer Club"},
-    {"age_group": "U13", "division": "Northeast", "team": "Metropolitan Oval"},
-    {"age_group": "U13", "division": "Northeast", "team": "FA Euro New York"},
-    {"age_group": "U13", "division": "Northeast", "team": "Ironbound Soccer Club"},
-    {"age_group": "U13", "division": "Northeast", "team": "Valeo Futbol Club"},
-    {"age_group": "U13", "division": "Northeast", "team": "Rochester NY FC"},
-    {"age_group": "U13", "division": "Northeast", "team": "Bayside FC"},
-
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Philadelphia Union"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Springfield SYC"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "FC DELCO"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Sporting Athletic Club"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Alexandria SA"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Bethesda SC"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Real Futbol Academy"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Baltimore Armour"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Players Development Academy"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "The Football Academy"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Achilles FC"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Keystone FC"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Beadling SC"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "West Virginia Soccer"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Northern Virginia Alliance"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "Cedar Stars Academy Monmouth"},
-    {"age_group": "U14", "division": "Mid-Atlantic", "team": "PA Classics"},
-    {"age_group": "U14", "division": "Mid-America", "team": "FC Cincinnati"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Bavarian United SC"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Michigan Jaguars"},
-    {"age_group": "U14", "division": "Mid-America", "team": "St. Louis Scott Gallagher"},
-    {"age_group": "U14", "division": "Mid-America", "team": "St. Louis CITY SC"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Vardar Soccer Club"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Michigan Wolves"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Hoosier Premier"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Chicago FC United"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Cincinnati United Soccer Club"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Lou Fusz Athletic"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Sockers FC Chicago"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Michigan Futbol Academy"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Indy Eleven"},
-    {"age_group": "U14", "division": "Mid-America", "team": "Midwest United FC"},
-    {"age_group": "U14", "division": "Mid-America", "team": "SC Wave"},
-    {"age_group": "U14", "division": "Frontier", "team": "Houston Dynamo FC"},
-    {"age_group": "U14", "division": "Frontier", "team": "Colorado Rapids"},
-    {"age_group": "U14", "division": "Frontier", "team": "FC Dallas"},
-    {"age_group": "U14", "division": "Frontier", "team": "Austin FC"},
-    {"age_group": "U14", "division": "Frontier", "team": "ALBION SC Colorado"},
-    {"age_group": "U14", "division": "Frontier", "team": "Tulsa Greenwood SC"},
-    {"age_group": "U14", "division": "Frontier", "team": "Houston Rangers"},
-    {"age_group": "U14", "division": "Frontier", "team": "Dallas Hornets"},
-    {"age_group": "U14", "division": "Frontier", "team": "Global Football Innovation Academy"},
-    {"age_group": "U14", "division": "Frontier", "team": "AC River"},
-    {"age_group": "U14", "division": "Frontier", "team": "Capital City SC"},
-    {"age_group": "U14", "division": "Northwest", "team": "San Jose Earthquakes"},
-    {"age_group": "U14", "division": "Northwest", "team": "Sacramento Republic FC"},
-    {"age_group": "U14", "division": "Northwest", "team": "Silicon Valley Soccer Academy"},
-    {"age_group": "U14", "division": "Northwest", "team": "The Town FC Academy"},
-    {"age_group": "U14", "division": "Northwest", "team": "FC Bay Area Surf"},
-    {"age_group": "U14", "division": "Northwest", "team": "Modesto Ajax United"},
-    {"age_group": "U14", "division": "Northwest", "team": "San Francisco Glens SC"},
-    {"age_group": "U14", "division": "Northwest", "team": "De Anza Force"},
-    {"age_group": "U14", "division": "Northwest", "team": "Woodside Soccer Club Crush"},
-    {"age_group": "U14", "division": "Northwest", "team": "Sacramento United"},
-    {"age_group": "U14", "division": "Northwest", "team": "Ballistic United"},
-    {"age_group": "U14", "division": "Northwest", "team": "Atletico Santa Rosa"},
-    {"age_group": "U14", "division": "Northwest", "team": "Napa United"},
-    {"age_group": "U14", "division": "Northwest", "team": "Lamorinda Soccer Club"},
-    {"age_group": "U14", "division": "Northwest", "team": "ALBION SC Merced"},
-    {"age_group": "U14", "division": "Northwest", "team": "San Francisco Seals"},
-    {"age_group": "U14", "division": "Southwest", "team": "Los Angeles Football Club"},
-    {"age_group": "U14", "division": "Southwest", "team": "LA Galaxy"},
-    {"age_group": "U14", "division": "Southwest", "team": "Strikers FC"},
-    {"age_group": "U14", "division": "Southwest", "team": "FC Golden State"},
-    {"age_group": "U14", "division": "Southwest", "team": "Total Futbol Academy"},
-    {"age_group": "U14", "division": "Southwest", "team": "RSL Arizona"},
-    {"age_group": "U14", "division": "Southwest", "team": "Chula Vista FC"},
-    {"age_group": "U14", "division": "Southwest", "team": "LA Bulls"},
-    {"age_group": "U14", "division": "Southwest", "team": "Los Angeles Soccer Club"},
-    {"age_group": "U14", "division": "Southwest", "team": "Phoenix Rising FC"},
-    {"age_group": "U14", "division": "Southwest", "team": "City SC San Diego"},
-    {"age_group": "U14", "division": "Southwest", "team": "ALBION SC San Diego"},
-    {"age_group": "U14", "division": "Southwest", "team": "SoCal Reds FC"},
-    {"age_group": "U14", "division": "Southwest", "team": "ALBION SC Las Vegas"},
-    {"age_group": "U14", "division": "Southwest", "team": "Santa Barbara Soccer Club"},
-    {"age_group": "U14", "division": "Southwest", "team": "ALBION SC Los Angeles"},
-    {"age_group": "U14", "division": "Southwest", "team": "Los Angeles Surf"},
-    {"age_group": "U14", "division": "Southwest", "team": "Ventura County Fusion"},
-    {"age_group": "U14", "division": "Southwest", "team": "SC Del Sol"},
-    {"age_group": "U14", "division": "Southwest", "team": "City SC Southwest"},
-    {"age_group": "U14", "division": "Southwest", "team": "Las Vegas Sports Academy"},
-    {"age_group": "U14", "division": "Southwest", "team": "RSL Arizona Mesa"},
-    {"age_group": "U14", "division": "Florida", "team": "Orlando City SC"},
-    {"age_group": "U14", "division": "Florida", "team": "Inter Miami CF"},
-    {"age_group": "U14", "division": "Florida", "team": "Weston FC"},
-    {"age_group": "U14", "division": "Florida", "team": "Miami Futbol Academy Rush"},
-    {"age_group": "U14", "division": "Florida", "team": "Tampa Bay United"},
-    {"age_group": "U14", "division": "Florida", "team": "South Florida Football Academy"},
-    {"age_group": "U14", "division": "Florida", "team": "IMG"},
-    {"age_group": "U14", "division": "Florida", "team": "IdeaSport SA"},
-    {"age_group": "U14", "division": "Florida", "team": "Athletum FC Academy"},
-    {"age_group": "U14", "division": "Florida", "team": "Orlando City Soccer School South"},
-    {"age_group": "U14", "division": "Florida", "team": "Jacksonville FC"},
-    {"age_group": "U14", "division": "Florida", "team": "Sol SC Florida"},
-    {"age_group": "U14", "division": "Florida", "team": "West Florida Flames"},
-    {"age_group": "U14", "division": "Florida", "team": "Orlando City Youth SC"},
-    {"age_group": "U14", "division": "Florida", "team": "Chargers Soccer Club"},
-    {"age_group": "U14", "division": "Southeast", "team": "Charlotte FC"},
-    {"age_group": "U14", "division": "Southeast", "team": "Carolina Core FC"},
-    {"age_group": "U14", "division": "Southeast", "team": "Atlanta United"},
-    {"age_group": "U14", "division": "Southeast", "team": "Wake FC"},
-    {"age_group": "U14", "division": "Southeast", "team": "Inter Atlanta FC"},
-    {"age_group": "U14", "division": "Southeast", "team": "Southern Soccer Academy"},
-    {"age_group": "U14", "division": "Southeast", "team": "Triangle United Soccer Association"},
-    {"age_group": "U14", "division": "Southeast", "team": "Queen City Mutiny FC"},
-    {"age_group": "U14", "division": "Southeast", "team": "Charlotte Independence"},
-    {"age_group": "U14", "division": "Southeast", "team": "Lanier Soccer Association"},
-    {"age_group": "U14", "division": "Southeast", "team": "Nashville United Soccer Academy"},
-    {"age_group": "U14", "division": "Southeast", "team": "Chattanooga FC"},
-    {"age_group": "U14", "division": "Southeast", "team": "AFC Lightning"},
-    {"age_group": "U14", "division": "Southeast", "team": "Hoover-Vestavia Soccer"},
-    {"age_group": "U14", "division": "Southeast", "team": "KSA"},
-    {"age_group": "U14", "division": "Southeast", "team": "Huntsville City FC"},
-    {"age_group": "U14", "division": "Northeast", "team": "New York Red Bulls"},
-    {"age_group": "U14", "division": "Northeast", "team": "New York City FC"},
-    {"age_group": "U14", "division": "Northeast", "team": "Cedar Stars Academy Bergen"},
-    {"age_group": "U14", "division": "Northeast", "team": "Beachside of Connecticut"},
-    {"age_group": "U14", "division": "Northeast", "team": "Metropolitan Oval"},
-    {"age_group": "U14", "division": "Northeast", "team": "FC Westchester"},
-    {"age_group": "U14", "division": "Northeast", "team": "New England Revolution"},
-    {"age_group": "U14", "division": "Northeast", "team": "NEFC"},
-    {"age_group": "U14", "division": "Northeast", "team": "Ironbound Soccer Club"},
-    {"age_group": "U14", "division": "Northeast", "team": "Blau Weiss Gottschee"},
-    {"age_group": "U14", "division": "Northeast", "team": "Long Island Soccer Club"},
-    {"age_group": "U14", "division": "Northeast", "team": "New York SC"},
-    {"age_group": "U14", "division": "Northeast", "team": "Intercontinental Football Academy of New England"},
-    {"age_group": "U14", "division": "Northeast", "team": "TSF Academy"},
-    {"age_group": "U14", "division": "Northeast", "team": "Rochester NY FC"},
-    {"age_group": "U14", "division": "Northeast", "team": "Seacoast United"},
-    {"age_group": "U14", "division": "Northeast", "team": "FC Greater Boston Bolts"},
-    {"age_group": "U14", "division": "Northeast", "team": "Bayside FC"},
-    {"age_group": "U14", "division": "Northeast", "team": "Downtown United Soccer Club"},
-    {"age_group": "U14", "division": "Northeast", "team": "FA Euro New York"},
-    {"age_group": "U14", "division": "Northeast", "team": "Valeo Futbol Club"},
-    {"age_group": "U14", "division": "Northeast", "team": "Oakwood Soccer Club"},
-
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "FC DELCO"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Sporting Athletic Club"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "The Football Academy"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Springfield SYC"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Players Development Academy"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Beadling SC"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Keystone FC"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Real Futbol Academy"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Bethesda SC"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Baltimore Armour"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Northern Virginia Alliance"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Alexandria SA"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Cedar Stars Academy Monmouth"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "PA Classics"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "Achilles FC"},
-    {"age_group": "U15", "division": "Mid-Atlantic", "team": "West Virginia Soccer"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Sockers FC Chicago"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Chicago FC United"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Cincinnati United Soccer Club"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Vardar Soccer Club"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Michigan Futbol Academy"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Michigan Wolves"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Lou Fusz Athletic"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Midwest United FC"},
-    {"age_group": "U15", "division": "Mid-America", "team": "St. Louis Scott Gallagher"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Bavarian United SC"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Indy Eleven"},
-    {"age_group": "U15", "division": "Mid-America", "team": "SC Wave"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Michigan Jaguars"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Hoosier Premier"},
-    {"age_group": "U15", "division": "Mid-America", "team": "Shattuck-St. Mary's"},
-    {"age_group": "U15", "division": "Frontier", "team": "Houston Rangers"},
-    {"age_group": "U15", "division": "Frontier", "team": "Global Football Innovation Academy"},
-    {"age_group": "U15", "division": "Frontier", "team": "Dallas Hornets"},
-    {"age_group": "U15", "division": "Frontier", "team": "ALBION SC Colorado"},
-    {"age_group": "U15", "division": "Frontier", "team": "AC River"},
-    {"age_group": "U15", "division": "Frontier", "team": "Capital City SC"},
-    {"age_group": "U15", "division": "Frontier", "team": "Tulsa Greenwood SC"},
-    {"age_group": "U15", "division": "Frontier", "team": "IDEA Toros Fútbol Academy"},
-    {"age_group": "U15", "division": "Northwest", "team": "Woodside Soccer Club Crush"},
-    {"age_group": "U15", "division": "Northwest", "team": "Atletico Santa Rosa"},
-    {"age_group": "U15", "division": "Northwest", "team": "San Francisco Glens SC"},
-    {"age_group": "U15", "division": "Northwest", "team": "FC Bay Area Surf"},
-    {"age_group": "U15", "division": "Northwest", "team": "Lamorinda Soccer Club"},
-    {"age_group": "U15", "division": "Northwest", "team": "Silicon Valley Soccer Academy"},
-    {"age_group": "U15", "division": "Northwest", "team": "Sacramento Republic FC"},
-    {"age_group": "U15", "division": "Northwest", "team": "De Anza Force"},
-    {"age_group": "U15", "division": "Northwest", "team": "The Town FC Academy"},
-    {"age_group": "U15", "division": "Northwest", "team": "Napa United"},
-    {"age_group": "U15", "division": "Northwest", "team": "ALBION SC Merced"},
-    {"age_group": "U15", "division": "Northwest", "team": "Modesto Ajax United"},
-    {"age_group": "U15", "division": "Northwest", "team": "Sacramento United"},
-    {"age_group": "U15", "division": "Northwest", "team": "San Francisco Seals"},
-    {"age_group": "U15", "division": "Northwest", "team": "Ballistic United"},
-    {"age_group": "U15", "division": "Southwest", "team": "ALBION SC San Diego"},
-    {"age_group": "U15", "division": "Southwest", "team": "Strikers FC"},
-    {"age_group": "U15", "division": "Southwest", "team": "Barca Residency Academy"},
-    {"age_group": "U15", "division": "Southwest", "team": "City SC San Diego"},
-    {"age_group": "U15", "division": "Southwest", "team": "Total Futbol Academy"},
-    {"age_group": "U15", "division": "Southwest", "team": "ALBION SC Los Angeles"},
-    {"age_group": "U15", "division": "Southwest", "team": "RSL Arizona"},
-    {"age_group": "U15", "division": "Southwest", "team": "Phoenix Rising FC"},
-    {"age_group": "U15", "division": "Southwest", "team": "FC Golden State"},
-    {"age_group": "U15", "division": "Southwest", "team": "Ventura County Fusion"},
-    {"age_group": "U15", "division": "Southwest", "team": "Las Vegas Sports Academy"},
-    {"age_group": "U15", "division": "Southwest", "team": "City SC Southwest"},
-    {"age_group": "U15", "division": "Southwest", "team": "Los Angeles SC"},
-    {"age_group": "U15", "division": "Southwest", "team": "Chula Vista FC"},
-    {"age_group": "U15", "division": "Southwest", "team": "SoCal Reds FC"},
-    {"age_group": "U15", "division": "Southwest", "team": "SC Del Sol"},
-    {"age_group": "U15", "division": "Southwest", "team": "LA Bulls"},
-    {"age_group": "U15", "division": "Southwest", "team": "Santa Barbara Soccer Club"},
-    {"age_group": "U15", "division": "Southwest", "team": "ALBION SC Las Vegas"},
-    {"age_group": "U15", "division": "Southwest", "team": "Los Angeles Surf"},
-    {"age_group": "U15", "division": "Florida", "team": "Orlando City Soccer School South"},
-    {"age_group": "U15", "division": "Florida", "team": "IdeaSport SA"},
-    {"age_group": "U15", "division": "Florida", "team": "Athletum FC Academy"},
-    {"age_group": "U15", "division": "Florida", "team": "Tampa Bay United"},
-    {"age_group": "U15", "division": "Florida", "team": "Weston FC"},
-    {"age_group": "U15", "division": "Florida", "team": "IMG"},
-    {"age_group": "U15", "division": "Florida", "team": "Miami Futbol Academy Rush"},
-    {"age_group": "U15", "division": "Florida", "team": "Sol SC Florida"},
-    {"age_group": "U15", "division": "Florida", "team": "South Florida Football Academy"},
-    {"age_group": "U15", "division": "Florida", "team": "Jacksonville FC"},
-    {"age_group": "U15", "division": "Florida", "team": "West Florida Flames"},
-    {"age_group": "U15", "division": "Florida", "team": "Orlando City Youth SC"},
-    {"age_group": "U15", "division": "Florida", "team": "Chargers Soccer Club"},
-    {"age_group": "U15", "division": "Southeast", "team": "Inter Atlanta FC"},
-    {"age_group": "U15", "division": "Southeast", "team": "Carolina Core FC"},
-    {"age_group": "U15", "division": "Southeast", "team": "Chattanooga FC"},
-    {"age_group": "U15", "division": "Southeast", "team": "KSA"},
-    {"age_group": "U15", "division": "Southeast", "team": "Southern Soccer Academy"},
-    {"age_group": "U15", "division": "Southeast", "team": "AFC Lightning"},
-    {"age_group": "U15", "division": "Southeast", "team": "Wake FC"},
-    {"age_group": "U15", "division": "Southeast", "team": "Queen City Mutiny FC"},
-    {"age_group": "U15", "division": "Southeast", "team": "Lanier Soccer Association"},
-    {"age_group": "U15", "division": "Southeast", "team": "Charlotte Independence"},
-    {"age_group": "U15", "division": "Southeast", "team": "Nashville United Soccer Academy"},
-    {"age_group": "U15", "division": "Southeast", "team": "Triangle United Soccer Association"},
-    {"age_group": "U15", "division": "Southeast", "team": "Hoover-Vestavia Soccer"},
-    {"age_group": "U15", "division": "Northeast", "team": "Cedar Stars Academy Bergen"},
-    {"age_group": "U15", "division": "Northeast", "team": "Intercontinental Football Academy of New England"},
-    {"age_group": "U15", "division": "Northeast", "team": "NEFC"},
-    {"age_group": "U15", "division": "Northeast", "team": "TSF Academy"},
-    {"age_group": "U15", "division": "Northeast", "team": "Metropolitan Oval"},
-    {"age_group": "U15", "division": "Northeast", "team": "FC Greater Boston Bolts"},
-    {"age_group": "U15", "division": "Northeast", "team": "New York SC"},
-    {"age_group": "U15", "division": "Northeast", "team": "Connecticut United FC"},
-    {"age_group": "U15", "division": "Northeast", "team": "Bayside FC"},
-    {"age_group": "U15", "division": "Northeast", "team": "FA Euro New York"},
-    {"age_group": "U15", "division": "Northeast", "team": "Ironbound Soccer Club"},
-    {"age_group": "U15", "division": "Northeast", "team": "Seacoast United"},
-    {"age_group": "U15", "division": "Northeast", "team": "Blau Weiss Gottschee"},
-    {"age_group": "U15", "division": "Northeast", "team": "Beachside of Connecticut"},
-    {"age_group": "U15", "division": "Northeast", "team": "Long Island Soccer Club"},
-    {"age_group": "U15", "division": "Northeast", "team": "Downtown United Soccer Club"},
-    {"age_group": "U15", "division": "Northeast", "team": "Oakwood Soccer Club"},
-    {"age_group": "U15", "division": "Northeast", "team": "Valeo Futbol Club"},
-    {"age_group": "U15", "division": "Northeast", "team": "FC Westchester"},
-    {"age_group": "U15", "division": "Northeast", "team": "Rochester NY FC"},
-
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Players Development Academy"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "FC DELCO"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Bethesda SC"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Baltimore Armour"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Sporting Athletic Club"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Real Futbol Academy"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Springfield SYC"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Northern Virginia Alliance"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Keystone FC"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Cedar Stars Academy Monmouth"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Beadling SC"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "The Football Academy"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Achilles FC"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "PA Classics"},
-    {"age_group": "U16", "division": "Mid-Atlantic", "team": "Alexandria SA"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Michigan Wolves"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Indy Eleven"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Sockers FC Chicago"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Vardar Soccer Club"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Midwest United FC"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Chicago FC United"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Cincinnati United Soccer Club"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Michigan Futbol Academy"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Michigan Jaguars"},
-    {"age_group": "U16", "division": "Mid-America", "team": "St. Louis Scott Gallagher"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Hoosier Premier"},
-    {"age_group": "U16", "division": "Mid-America", "team": "SC Wave"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Shattuck-St. Mary's"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Lou Fusz Athletic"},
-    {"age_group": "U16", "division": "Mid-America", "team": "Bavarian United SC"},
-    {"age_group": "U16", "division": "Frontier", "team": "Capital City SC"},
-    {"age_group": "U16", "division": "Frontier", "team": "Global Football Innovation Academy"},
-    {"age_group": "U16", "division": "Frontier", "team": "ALBION SC Colorado"},
-    {"age_group": "U16", "division": "Frontier", "team": "Houston Rangers"},
-    {"age_group": "U16", "division": "Frontier", "team": "Tulsa Greenwood SC"},
-    {"age_group": "U16", "division": "Frontier", "team": "Dallas Hornets"},
-    {"age_group": "U16", "division": "Frontier", "team": "AC River"},
-    {"age_group": "U16", "division": "Frontier", "team": "IDEA Toros Fútbol Academy"},
-    {"age_group": "U16", "division": "Northwest", "team": "Sacramento Republic FC"},
-    {"age_group": "U16", "division": "Northwest", "team": "FC Bay Area Surf"},
-    {"age_group": "U16", "division": "Northwest", "team": "Silicon Valley Soccer Academy"},
-    {"age_group": "U16", "division": "Northwest", "team": "De Anza Force"},
-    {"age_group": "U16", "division": "Northwest", "team": "Lamorinda Soccer Club"},
-    {"age_group": "U16", "division": "Northwest", "team": "The Town FC Academy"},
-    {"age_group": "U16", "division": "Northwest", "team": "ALBION SC Merced"},
-    {"age_group": "U16", "division": "Northwest", "team": "Atletico Santa Rosa"},
-    {"age_group": "U16", "division": "Northwest", "team": "Ballistic United"},
-    {"age_group": "U16", "division": "Northwest", "team": "San Francisco Glens SC"},
-    {"age_group": "U16", "division": "Northwest", "team": "Sacramento United"},
-    {"age_group": "U16", "division": "Northwest", "team": "Modesto Ajax United"},
-    {"age_group": "U16", "division": "Northwest", "team": "Napa United"},
-    {"age_group": "U16", "division": "Northwest", "team": "Woodside Soccer Club Crush"},
-    {"age_group": "U16", "division": "Northwest", "team": "San Francisco Seals"},
-    {"age_group": "U16", "division": "Southwest", "team": "Total Futbol Academy"},
-    {"age_group": "U16", "division": "Southwest", "team": "ALBION SC Los Angeles"},
-    {"age_group": "U16", "division": "Southwest", "team": "Barca Residency Academy"},
-    {"age_group": "U16", "division": "Southwest", "team": "Los Angeles SC"},
-    {"age_group": "U16", "division": "Southwest", "team": "ALBION SC San Diego"},
-    {"age_group": "U16", "division": "Southwest", "team": "LA Bulls"},
-    {"age_group": "U16", "division": "Southwest", "team": "Strikers FC"},
-    {"age_group": "U16", "division": "Southwest", "team": "Phoenix Rising FC"},
-    {"age_group": "U16", "division": "Southwest", "team": "Chula Vista FC"},
-    {"age_group": "U16", "division": "Southwest", "team": "FC Golden State"},
-    {"age_group": "U16", "division": "Southwest", "team": "ALBION SC Las Vegas"},
-    {"age_group": "U16", "division": "Southwest", "team": "Santa Barbara Soccer Club"},
-    {"age_group": "U16", "division": "Southwest", "team": "SC Del Sol"},
-    {"age_group": "U16", "division": "Southwest", "team": "RSL Arizona"},
-    {"age_group": "U16", "division": "Southwest", "team": "Las Vegas Sports Academy"},
-    {"age_group": "U16", "division": "Southwest", "team": "SoCal Reds FC"},
-    {"age_group": "U16", "division": "Southwest", "team": "Los Angeles Surf"},
-    {"age_group": "U16", "division": "Southwest", "team": "Ventura County Fusion"},
-    {"age_group": "U16", "division": "Southwest", "team": "City SC San Diego"},
-    {"age_group": "U16", "division": "Southwest", "team": "City SC Southwest"},
-    {"age_group": "U16", "division": "Florida", "team": "Miami Futbol Academy Rush"},
-    {"age_group": "U16", "division": "Florida", "team": "Orlando City Youth SC"},
-    {"age_group": "U16", "division": "Florida", "team": "Weston FC"},
-    {"age_group": "U16", "division": "Florida", "team": "Tampa Bay United"},
-    {"age_group": "U16", "division": "Florida", "team": "South Florida Football Academy"},
-    {"age_group": "U16", "division": "Florida", "team": "Jacksonville Armada FC"},
-    {"age_group": "U16", "division": "Florida", "team": "Orlando City Soccer School South"},
-    {"age_group": "U16", "division": "Florida", "team": "IMG"},
-    {"age_group": "U16", "division": "Florida", "team": "West Florida Flames"},
-    {"age_group": "U16", "division": "Florida", "team": "Athletum FC Academy"},
-    {"age_group": "U16", "division": "Florida", "team": "Sol SC Florida"},
-    {"age_group": "U16", "division": "Florida", "team": "IdeaSport SA"},
-    {"age_group": "U16", "division": "Florida", "team": "Chargers Soccer Club"},
-    {"age_group": "U16", "division": "Southeast", "team": "Wake FC"},
-    {"age_group": "U16", "division": "Southeast", "team": "Inter Atlanta FC"},
-    {"age_group": "U16", "division": "Southeast", "team": "KSA"},
-    {"age_group": "U16", "division": "Southeast", "team": "Queen City Mutiny FC"},
-    {"age_group": "U16", "division": "Southeast", "team": "Charlotte Independence"},
-    {"age_group": "U16", "division": "Southeast", "team": "Triangle United Soccer Association"},
-    {"age_group": "U16", "division": "Southeast", "team": "Southern Soccer Academy"},
-    {"age_group": "U16", "division": "Southeast", "team": "AFC Lightning"},
-    {"age_group": "U16", "division": "Southeast", "team": "Hoover-Vestavia Soccer"},
-    {"age_group": "U16", "division": "Southeast", "team": "Nashville United Soccer Academy"},
-    {"age_group": "U16", "division": "Southeast", "team": "Lanier Soccer Association"},
-    {"age_group": "U16", "division": "Northeast", "team": "Blau Weiss Gottschee"},
-    {"age_group": "U16", "division": "Northeast", "team": "Metropolitan Oval"},
-    {"age_group": "U16", "division": "Northeast", "team": "Intercontinental Football Academy of New England"},
-    {"age_group": "U16", "division": "Northeast", "team": "FA Euro New York"},
-    {"age_group": "U16", "division": "Northeast", "team": "Ironbound Soccer Club"},
-    {"age_group": "U16", "division": "Northeast", "team": "Beachside of Connecticut"},
-    {"age_group": "U16", "division": "Northeast", "team": "Valeo Futbol Club"},
-    {"age_group": "U16", "division": "Northeast", "team": "TSF Academy"},
-    {"age_group": "U16", "division": "Northeast", "team": "Cedar Stars Academy Bergen"},
-    {"age_group": "U16", "division": "Northeast", "team": "Connecticut United FC"},
-    {"age_group": "U16", "division": "Northeast", "team": "Rochester NY FC"},
-    {"age_group": "U16", "division": "Northeast", "team": "FC Greater Boston Bolts"},
-    {"age_group": "U16", "division": "Northeast", "team": "NEFC"},
-    {"age_group": "U16", "division": "Northeast", "team": "New York SC"},
-    {"age_group": "U16", "division": "Northeast", "team": "Oakwood Soccer Club"},
-    {"age_group": "U16", "division": "Northeast", "team": "Seacoast United"},
-    {"age_group": "U16", "division": "Northeast", "team": "Long Island Soccer Club"},
-    {"age_group": "U16", "division": "Northeast", "team": "FC Westchester"},
-    {"age_group": "U16", "division": "Northeast", "team": "Downtown United Soccer Club"},
-    {"age_group": "U16", "division": "Northeast", "team": "Bayside FC"},
-
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Real Futbol Academy"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Bethesda SC"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "FC DELCO"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "PA Classics"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Players Development Academy"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Baltimore Armour"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Achilles FC"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Alexandria SA"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Springfield SYC"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Northern Virginia Alliance"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Cedar Stars Academy Monmouth"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Sporting Athletic Club"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Keystone FC"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "The Football Academy"},
-    {"age_group": "U17", "division": "Mid-Atlantic", "team": "Beadling SC"},
-    {"age_group": "U17", "division": "Mid-America", "team": "St. Louis Scott Gallagher"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Michigan Wolves"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Indy Eleven"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Sockers FC Chicago"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Shattuck-St. Mary's"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Chicago FC United"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Bavarian United SC"},
-    {"age_group": "U17", "division": "Mid-America", "team": "SC Wave"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Cincinnati United Soccer Club"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Hoosier Premier"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Michigan Jaguars"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Michigan Futbol Academy"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Midwest United FC"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Lou Fusz Athletic"},
-    {"age_group": "U17", "division": "Mid-America", "team": "Vardar Soccer Club"},
-    {"age_group": "U17", "division": "Frontier", "team": "Capital City SC"},
-    {"age_group": "U17", "division": "Frontier", "team": "Global Football Innovation Academy"},
-    {"age_group": "U17", "division": "Frontier", "team": "FC Dallas"},
-    {"age_group": "U17", "division": "Frontier", "team": "Dallas Hornets"},
-    {"age_group": "U17", "division": "Frontier", "team": "AC River"},
-    {"age_group": "U17", "division": "Frontier", "team": "Houston Rangers"},
-    {"age_group": "U17", "division": "Frontier", "team": "ALBION SC Colorado"},
-    {"age_group": "U17", "division": "Frontier", "team": "IDEA Toros Fútbol Academy"},
-    {"age_group": "U17", "division": "Frontier", "team": "Tulsa Greenwood SC"},
-    {"age_group": "U17", "division": "Northwest", "team": "FC Bay Area Surf"},
-    {"age_group": "U17", "division": "Northwest", "team": "ALBION SC Merced"},
-    {"age_group": "U17", "division": "Northwest", "team": "Sacramento Republic FC"},
-    {"age_group": "U17", "division": "Northwest", "team": "San Francisco Glens SC"},
-    {"age_group": "U17", "division": "Northwest", "team": "De Anza Force"},
-    {"age_group": "U17", "division": "Northwest", "team": "Silicon Valley Soccer Academy"},
-    {"age_group": "U17", "division": "Northwest", "team": "Sacramento United"},
-    {"age_group": "U17", "division": "Northwest", "team": "Woodside Soccer Club Crush"},
-    {"age_group": "U17", "division": "Northwest", "team": "Modesto Ajax United"},
-    {"age_group": "U17", "division": "Northwest", "team": "Ballistic United"},
-    {"age_group": "U17", "division": "Northwest", "team": "Atletico Santa Rosa"},
-    {"age_group": "U17", "division": "Northwest", "team": "Napa United"},
-    {"age_group": "U17", "division": "Northwest", "team": "The Town FC Academy"},
-    {"age_group": "U17", "division": "Northwest", "team": "Lamorinda Soccer Club"},
-    {"age_group": "U17", "division": "Northwest", "team": "San Francisco Seals"},
-    {"age_group": "U17", "division": "Southwest", "team": "Barca Residency Academy"},
-    {"age_group": "U17", "division": "Southwest", "team": "ALBION SC San Diego"},
-    {"age_group": "U17", "division": "Southwest", "team": "Strikers FC"},
-    {"age_group": "U17", "division": "Southwest", "team": "Total Futbol Academy"},
-    {"age_group": "U17", "division": "Southwest", "team": "ALBION SC Los Angeles"},
-    {"age_group": "U17", "division": "Southwest", "team": "Ventura County Fusion"},
-    {"age_group": "U17", "division": "Southwest", "team": "SoCal Reds FC"},
-    {"age_group": "U17", "division": "Southwest", "team": "Santa Barbara Soccer Club"},
-    {"age_group": "U17", "division": "Southwest", "team": "City SC Southwest"},
-    {"age_group": "U17", "division": "Southwest", "team": "City SC San Diego"},
-    {"age_group": "U17", "division": "Southwest", "team": "Los Angeles SC"},
-    {"age_group": "U17", "division": "Southwest", "team": "ALBION SC Las Vegas"},
-    {"age_group": "U17", "division": "Southwest", "team": "Chula Vista FC"},
-    {"age_group": "U17", "division": "Southwest", "team": "SC Del Sol"},
-    {"age_group": "U17", "division": "Southwest", "team": "Phoenix Rising FC"},
-    {"age_group": "U17", "division": "Southwest", "team": "Los Angeles Surf"},
-    {"age_group": "U17", "division": "Southwest", "team": "RSL Arizona"},
-    {"age_group": "U17", "division": "Southwest", "team": "LA Bulls"},
-    {"age_group": "U17", "division": "Southwest", "team": "FC Golden State"},
-    {"age_group": "U17", "division": "Southwest", "team": "Las Vegas Sports Academy"},
-    {"age_group": "U17", "division": "Florida", "team": "Weston FC"},
-    {"age_group": "U17", "division": "Florida", "team": "Orlando City Youth SC"},
-    {"age_group": "U17", "division": "Florida", "team": "Miami Futbol Academy Rush"},
-    {"age_group": "U17", "division": "Florida", "team": "IMG"},
-    {"age_group": "U17", "division": "Florida", "team": "Inter Miami CF"},
-    {"age_group": "U17", "division": "Florida", "team": "Tampa Bay United"},
-    {"age_group": "U17", "division": "Florida", "team": "Jacksonville Armada FC"},
-    {"age_group": "U17", "division": "Florida", "team": "Athletum FC Academy"},
-    {"age_group": "U17", "division": "Florida", "team": "South Florida Football Academy"},
-    {"age_group": "U17", "division": "Florida", "team": "Orlando City Soccer School South"},
-    {"age_group": "U17", "division": "Florida", "team": "Sol SC Florida"},
-    {"age_group": "U17", "division": "Florida", "team": "IdeaSport SA"},
-    {"age_group": "U17", "division": "Florida", "team": "West Florida Flames"},
-    {"age_group": "U17", "division": "Florida", "team": "Chargers Soccer Club"},
-    {"age_group": "U17", "division": "Southeast", "team": "Inter Atlanta FC"},
-    {"age_group": "U17", "division": "Southeast", "team": "Wake FC"},
-    {"age_group": "U17", "division": "Southeast", "team": "Southern Soccer Academy"},
-    {"age_group": "U17", "division": "Southeast", "team": "Queen City Mutiny FC"},
-    {"age_group": "U17", "division": "Southeast", "team": "Triangle United Soccer Association"},
-    {"age_group": "U17", "division": "Southeast", "team": "Charlotte Independence"},
-    {"age_group": "U17", "division": "Southeast", "team": "AFC Lightning"},
-    {"age_group": "U17", "division": "Southeast", "team": "Nashville United Soccer Academy"},
-    {"age_group": "U17", "division": "Southeast", "team": "Lanier Soccer Association"},
-    {"age_group": "U17", "division": "Southeast", "team": "KSA"},
-    {"age_group": "U17", "division": "Southeast", "team": "Hoover-Vestavia Soccer"},
-    {"age_group": "U17", "division": "Northeast", "team": "TSF Academy"},
-    {"age_group": "U17", "division": "Northeast", "team": "Intercontinental Football Academy of New England"},
-    {"age_group": "U17", "division": "Northeast", "team": "Cedar Stars Academy Bergen"},
-    {"age_group": "U17", "division": "Northeast", "team": "FC Greater Boston Bolts"},
-    {"age_group": "U17", "division": "Northeast", "team": "Metropolitan Oval"},
-    {"age_group": "U17", "division": "Northeast", "team": "New York SC"},
-    {"age_group": "U17", "division": "Northeast", "team": "Seacoast United"},
-    {"age_group": "U17", "division": "Northeast", "team": "NEFC"},
-    {"age_group": "U17", "division": "Northeast", "team": "Blau Weiss Gottschee"},
-    {"age_group": "U17", "division": "Northeast", "team": "Bayside FC"},
-    {"age_group": "U17", "division": "Northeast", "team": "Beachside of Connecticut"},
-    {"age_group": "U17", "division": "Northeast", "team": "FC Westchester"},
-    {"age_group": "U17", "division": "Northeast", "team": "Long Island Soccer Club"},
-    {"age_group": "U17", "division": "Northeast", "team": "Ironbound Soccer Club"},
-    {"age_group": "U17", "division": "Northeast", "team": "Downtown United Soccer Club"},
-    {"age_group": "U17", "division": "Northeast", "team": "FA Euro New York"},
-    {"age_group": "U17", "division": "Northeast", "team": "Oakwood Soccer Club"},
-    {"age_group": "U17", "division": "Northeast", "team": "Rochester NY FC"},
-    {"age_group": "U17", "division": "Northeast", "team": "Valeo Futbol Club"},
-
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "FC DELCO"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Players Development Academy"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Baltimore Armour"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Bethesda SC"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Northern Virginia Alliance"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Springfield SYC"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Real Futbol Academy"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Cedar Stars Academy Monmouth"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Sporting Athletic Club"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Beadling SC"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Keystone FC"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Achilles FC"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "Alexandria SA"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "The Football Academy"},
-    {"age_group": "U19", "division": "Mid-Atlantic", "team": "PA Classics"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Indy Eleven"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Sockers FC Chicago"},
-    {"age_group": "U19", "division": "Mid-America", "team": "St. Louis Scott Gallagher"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Chicago FC United"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Midwest United FC"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Shattuck-St. Mary's"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Michigan Wolves"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Michigan Futbol Academy"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Cincinnati United Soccer Club"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Hoosier Premier"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Bavarian United SC"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Lou Fusz Athletic"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Vardar Soccer Club"},
-    {"age_group": "U19", "division": "Mid-America", "team": "SC Wave"},
-    {"age_group": "U19", "division": "Mid-America", "team": "Michigan Jaguars"},
-    {"age_group": "U19", "division": "Frontier", "team": "Global Football Innovation Academy"},
-    {"age_group": "U19", "division": "Frontier", "team": "Dallas Hornets"},
-    {"age_group": "U19", "division": "Frontier", "team": "Capital City SC"},
-    {"age_group": "U19", "division": "Frontier", "team": "ALBION SC Colorado"},
-    {"age_group": "U19", "division": "Frontier", "team": "Houston Rangers"},
-    {"age_group": "U19", "division": "Frontier", "team": "AC River"},
-    {"age_group": "U19", "division": "Frontier", "team": "Tulsa Greenwood SC"},
-    {"age_group": "U19", "division": "Frontier", "team": "IDEA Toros Fútbol Academy"},
-    {"age_group": "U19", "division": "Northwest", "team": "Sacramento Republic FC"},
-    {"age_group": "U19", "division": "Northwest", "team": "De Anza Force"},
-    {"age_group": "U19", "division": "Northwest", "team": "Sacramento United"},
-    {"age_group": "U19", "division": "Northwest", "team": "Silicon Valley Soccer Academy"},
-    {"age_group": "U19", "division": "Northwest", "team": "San Francisco Glens SC"},
-    {"age_group": "U19", "division": "Northwest", "team": "FC Bay Area Surf"},
-    {"age_group": "U19", "division": "Northwest", "team": "Woodside Soccer Club Crush"},
-    {"age_group": "U19", "division": "Northwest", "team": "Ballistic United"},
-    {"age_group": "U19", "division": "Northwest", "team": "The Town FC Academy"},
-    {"age_group": "U19", "division": "Northwest", "team": "Lamorinda Soccer Club"},
-    {"age_group": "U19", "division": "Northwest", "team": "Atletico Santa Rosa"},
-    {"age_group": "U19", "division": "Northwest", "team": "Napa United"},
-    {"age_group": "U19", "division": "Northwest", "team": "Modesto Ajax United"},
-    {"age_group": "U19", "division": "Northwest", "team": "ALBION SC Merced"},
-    {"age_group": "U19", "division": "Northwest", "team": "San Francisco Seals"},
-    {"age_group": "U19", "division": "Southwest", "team": "Barca Residency Academy"},
-    {"age_group": "U19", "division": "Southwest", "team": "Ventura County Fusion"},
-    {"age_group": "U19", "division": "Southwest", "team": "Strikers FC"},
-    {"age_group": "U19", "division": "Southwest", "team": "SC Del Sol"},
-    {"age_group": "U19", "division": "Southwest", "team": "Los Angeles Surf"},
-    {"age_group": "U19", "division": "Southwest", "team": "ALBION SC San Diego"},
-    {"age_group": "U19", "division": "Southwest", "team": "Santa Barbara Soccer Club"},
-    {"age_group": "U19", "division": "Southwest", "team": "Total Futbol Academy"},
-    {"age_group": "U19", "division": "Southwest", "team": "Chula Vista FC"},
-    {"age_group": "U19", "division": "Southwest", "team": "ALBION SC Los Angeles"},
-    {"age_group": "U19", "division": "Southwest", "team": "FC Golden State"},
-    {"age_group": "U19", "division": "Southwest", "team": "Los Angeles SC"},
-    {"age_group": "U19", "division": "Southwest", "team": "ALBION SC Las Vegas"},
-    {"age_group": "U19", "division": "Southwest", "team": "City SC San Diego"},
-    {"age_group": "U19", "division": "Southwest", "team": "RSL Arizona"},
-    {"age_group": "U19", "division": "Southwest", "team": "Las Vegas Sports Academy"},
-    {"age_group": "U19", "division": "Southwest", "team": "Phoenix Rising FC"},
-    {"age_group": "U19", "division": "Southwest", "team": "SoCal Reds FC"},
-    {"age_group": "U19", "division": "Southwest", "team": "City SC Southwest"},
-    {"age_group": "U19", "division": "Southwest", "team": "LA Bulls"},
-    {"age_group": "U19", "division": "Florida", "team": "IMG"},
-    {"age_group": "U19", "division": "Florida", "team": "Orlando City Youth SC"},
-    {"age_group": "U19", "division": "Florida", "team": "Miami Futbol Academy Rush"},
-    {"age_group": "U19", "division": "Florida", "team": "Weston FC"},
-    {"age_group": "U19", "division": "Florida", "team": "Jacksonville Armada FC"},
-    {"age_group": "U19", "division": "Florida", "team": "IdeaSport SA"},
-    {"age_group": "U19", "division": "Florida", "team": "Athletum FC Academy"},
-    {"age_group": "U19", "division": "Florida", "team": "South Florida Football Academy"},
-    {"age_group": "U19", "division": "Florida", "team": "Tampa Bay United"},
-    {"age_group": "U19", "division": "Florida", "team": "Orlando City Soccer School South"},
-    {"age_group": "U19", "division": "Florida", "team": "Sol SC Florida"},
-    {"age_group": "U19", "division": "Florida", "team": "West Florida Flames"},
-    {"age_group": "U19", "division": "Florida", "team": "Chargers Soccer Club"},
-    {"age_group": "U19", "division": "Southeast", "team": "Queen City Mutiny FC"},
-    {"age_group": "U19", "division": "Southeast", "team": "Charlotte Independence"},
-    {"age_group": "U19", "division": "Southeast", "team": "Southern Soccer Academy"},
-    {"age_group": "U19", "division": "Southeast", "team": "KSA"},
-    {"age_group": "U19", "division": "Southeast", "team": "Wake FC"},
-    {"age_group": "U19", "division": "Southeast", "team": "Lanier Soccer Association"},
-    {"age_group": "U19", "division": "Southeast", "team": "Nashville United Soccer Academy"},
-    {"age_group": "U19", "division": "Southeast", "team": "Triangle United Soccer Association"},
-    {"age_group": "U19", "division": "Southeast", "team": "Hoover-Vestavia Soccer"},
-    {"age_group": "U19", "division": "Southeast", "team": "AFC Lightning"},
-    {"age_group": "U19", "division": "Southeast", "team": "Inter Atlanta FC"},
-    {"age_group": "U19", "division": "Northeast", "team": "Blau Weiss Gottschee"},
-    {"age_group": "U19", "division": "Northeast", "team": "Cedar Stars Academy Bergen"},
-    {"age_group": "U19", "division": "Northeast", "team": "FC Greater Boston Bolts"},
-    {"age_group": "U19", "division": "Northeast", "team": "Long Island Soccer Club"},
-    {"age_group": "U19", "division": "Northeast", "team": "TSF Academy"},
-    {"age_group": "U19", "division": "Northeast", "team": "Metropolitan Oval"},
-    {"age_group": "U19", "division": "Northeast", "team": "NEFC"},
-    {"age_group": "U19", "division": "Northeast", "team": "Beachside of Connecticut"},
-    {"age_group": "U19", "division": "Northeast", "team": "Seacoast United"},
-    {"age_group": "U19", "division": "Northeast", "team": "Bayside FC"},
-    {"age_group": "U19", "division": "Northeast", "team": "Intercontinental Football Academy of New England"},
-    {"age_group": "U19", "division": "Northeast", "team": "Connecticut United FC"},
-    {"age_group": "U19", "division": "Northeast", "team": "FC Westchester"},
-    {"age_group": "U19", "division": "Northeast", "team": "New York SC"},
-    {"age_group": "U19", "division": "Northeast", "team": "Downtown United Soccer Club"},
-    {"age_group": "U19", "division": "Northeast", "team": "Ironbound Soccer Club"},
-    {"age_group": "U19", "division": "Northeast", "team": "FA Euro New York"},
-    {"age_group": "U19", "division": "Northeast", "team": "Oakwood Soccer Club"},
-    {"age_group": "U19", "division": "Northeast", "team": "Rochester NY FC"}
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Philadelphia Union",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Real Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Northern Virginia Alliance",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Springfield SYC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Baltimore Armour",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "FC DELCO",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Alexandria SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Cedar Stars Academy Monmouth",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "The Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Players Development Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Bethesda SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Keystone FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "PA Classics",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Sporting Athletic Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Achilles FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "Beadling SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-Atlantic",
+      "team": "West Virginia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "St. Louis Scott Gallagher",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "FC Cincinnati",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Lou Fusz Athletic",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Cincinnati United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Indy Eleven",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Michigan Wolves",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Michigan Jaguars",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Chicago FC United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Hoosier Premier",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Bavarian United SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "SC Wave",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Michigan Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Midwest United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Vardar Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Mid-America",
+      "team": "Sockers FC Chicago",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "FC Dallas",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Austin FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "ALBION SC Colorado",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Tulsa Greenwood SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "AC River",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Global Football Innovation Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Houston Rangers",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Colorado Rapids",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Dallas Hornets",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Frontier",
+      "team": "Capital City SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Sacramento Republic FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Silicon Valley Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "FC Bay Area Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Modesto Ajax United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "The Town FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "De Anza Force",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "San Francisco Glens SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Ballistic United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Sacramento United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "ALBION SC Merced",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Napa United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Atletico Santa Rosa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "San Francisco Seals",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Lamorinda Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northwest",
+      "team": "Woodside Soccer Club Crush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "LA Galaxy",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Strikers FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Los Angeles Football Club",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Total Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "San Diego FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "RSL Arizona",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Los Angeles Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Chula Vista FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "ALBION SC Los Angeles",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Los Angeles Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "City SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "FC Golden State",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "ALBION SC Las Vegas",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Santa Barbara Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "ALBION SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "City SC Southwest",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Las Vegas Sports Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Phoenix Rising FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "SoCal Reds FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "LA Bulls",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "RSL Arizona Mesa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "SC Del Sol",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southwest",
+      "team": "Ventura County Fusion",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Orlando City SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Inter Miami CF",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Weston FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "South Florida Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Tampa Bay United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Jacksonville FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "IdeaSport SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Miami Futbol Academy Rush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "IMG",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Orlando City Soccer School South",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "West Florida Flames",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Athletum FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Sol SC Florida",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Orlando City Youth SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Florida",
+      "team": "Chargers Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Atlanta United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Carolina Core FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Inter Atlanta FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Queen City Mutiny FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Wake FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Charlotte Independence",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Southern Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Nashville United Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "AFC Lightning",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Lanier Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Chattanooga FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Huntsville City FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Triangle United Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "Hoover-Vestavia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Southeast",
+      "team": "KSA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "New York Red Bulls",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "New York City FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Cedar Stars Academy Bergen",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "New York SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "NEFC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Beachside of Connecticut",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "FC Greater Boston Bolts",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "FC Westchester",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Long Island Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "TSF Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "New England Revolution",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Downtown United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Blau Weiss Gottschee",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Intercontinental Football Academy of New England",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Seacoast United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Oakwood Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Metropolitan Oval",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "FA Euro New York",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Ironbound Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Valeo Futbol Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Rochester NY FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U13",
+      "division": "Northeast",
+      "team": "Bayside FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Philadelphia Union",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Springfield SYC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "FC DELCO",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Sporting Athletic Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Alexandria SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Bethesda SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Real Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Baltimore Armour",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Players Development Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "The Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Achilles FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Keystone FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Beadling SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "West Virginia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Northern Virginia Alliance",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "Cedar Stars Academy Monmouth",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-Atlantic",
+      "team": "PA Classics",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "FC Cincinnati",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Bavarian United SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Michigan Jaguars",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "St. Louis Scott Gallagher",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "St. Louis CITY SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Vardar Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Michigan Wolves",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Hoosier Premier",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Chicago FC United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Cincinnati United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Lou Fusz Athletic",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Sockers FC Chicago",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Michigan Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Indy Eleven",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "Midwest United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Mid-America",
+      "team": "SC Wave",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Houston Dynamo FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Colorado Rapids",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "FC Dallas",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Austin FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "ALBION SC Colorado",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Tulsa Greenwood SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Houston Rangers",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Dallas Hornets",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Global Football Innovation Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "AC River",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Frontier",
+      "team": "Capital City SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "San Jose Earthquakes",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Sacramento Republic FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Silicon Valley Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "The Town FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "FC Bay Area Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Modesto Ajax United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "San Francisco Glens SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "De Anza Force",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Woodside Soccer Club Crush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Sacramento United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Ballistic United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Atletico Santa Rosa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Napa United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "Lamorinda Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "ALBION SC Merced",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northwest",
+      "team": "San Francisco Seals",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Los Angeles Football Club",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "LA Galaxy",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Strikers FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "FC Golden State",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Total Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "RSL Arizona",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Chula Vista FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "LA Bulls",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Los Angeles Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Phoenix Rising FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "City SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "ALBION SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "SoCal Reds FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "ALBION SC Las Vegas",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Santa Barbara Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "ALBION SC Los Angeles",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Los Angeles Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Ventura County Fusion",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "SC Del Sol",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "City SC Southwest",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "Las Vegas Sports Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southwest",
+      "team": "RSL Arizona Mesa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Orlando City SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Inter Miami CF",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Weston FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Miami Futbol Academy Rush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Tampa Bay United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "South Florida Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "IMG",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "IdeaSport SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Athletum FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Orlando City Soccer School South",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Jacksonville FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Sol SC Florida",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "West Florida Flames",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Orlando City Youth SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Florida",
+      "team": "Chargers Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Charlotte FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Carolina Core FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Atlanta United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Wake FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Inter Atlanta FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Southern Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Triangle United Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Queen City Mutiny FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Charlotte Independence",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Lanier Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Nashville United Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Chattanooga FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "AFC Lightning",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Hoover-Vestavia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "KSA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Southeast",
+      "team": "Huntsville City FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "New York Red Bulls",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "New York City FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Cedar Stars Academy Bergen",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Beachside of Connecticut",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Metropolitan Oval",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "FC Westchester",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "New England Revolution",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "NEFC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Ironbound Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Blau Weiss Gottschee",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Long Island Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "New York SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Intercontinental Football Academy of New England",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "TSF Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Rochester NY FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Seacoast United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "FC Greater Boston Bolts",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Bayside FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Downtown United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "FA Euro New York",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Valeo Futbol Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U14",
+      "division": "Northeast",
+      "team": "Oakwood Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "FC DELCO",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Sporting Athletic Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "The Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Springfield SYC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Players Development Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Beadling SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Keystone FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Real Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Bethesda SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Baltimore Armour",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Northern Virginia Alliance",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Alexandria SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Cedar Stars Academy Monmouth",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "PA Classics",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "Achilles FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-Atlantic",
+      "team": "West Virginia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Sockers FC Chicago",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Chicago FC United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Cincinnati United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Vardar Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Michigan Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Michigan Wolves",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Lou Fusz Athletic",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Midwest United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "St. Louis Scott Gallagher",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Bavarian United SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Indy Eleven",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "SC Wave",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Michigan Jaguars",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Hoosier Premier",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Mid-America",
+      "team": "Shattuck-St. Mary's",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "Houston Rangers",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "Global Football Innovation Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "Dallas Hornets",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "ALBION SC Colorado",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "AC River",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "Capital City SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "Tulsa Greenwood SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Frontier",
+      "team": "IDEA Toros F\u00fatbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Woodside Soccer Club Crush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Atletico Santa Rosa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "San Francisco Glens SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "FC Bay Area Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Lamorinda Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Silicon Valley Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Sacramento Republic FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "De Anza Force",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "The Town FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Napa United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "ALBION SC Merced",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Modesto Ajax United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Sacramento United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "San Francisco Seals",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northwest",
+      "team": "Ballistic United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "ALBION SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Strikers FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Barca Residency Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "City SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Total Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "ALBION SC Los Angeles",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "RSL Arizona",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Phoenix Rising FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "FC Golden State",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Ventura County Fusion",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Las Vegas Sports Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "City SC Southwest",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Los Angeles SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Chula Vista FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "SoCal Reds FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "SC Del Sol",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "LA Bulls",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Santa Barbara Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "ALBION SC Las Vegas",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southwest",
+      "team": "Los Angeles Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Orlando City Soccer School South",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "IdeaSport SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Athletum FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Tampa Bay United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Weston FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "IMG",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Miami Futbol Academy Rush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Sol SC Florida",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "South Florida Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Jacksonville FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "West Florida Flames",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Orlando City Youth SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Florida",
+      "team": "Chargers Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Inter Atlanta FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Carolina Core FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Chattanooga FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "KSA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Southern Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "AFC Lightning",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Wake FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Queen City Mutiny FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Lanier Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Charlotte Independence",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Nashville United Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Triangle United Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Southeast",
+      "team": "Hoover-Vestavia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Cedar Stars Academy Bergen",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Intercontinental Football Academy of New England",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "NEFC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "TSF Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Metropolitan Oval",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "FC Greater Boston Bolts",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "New York SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Connecticut United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Bayside FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "FA Euro New York",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Ironbound Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Seacoast United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Blau Weiss Gottschee",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Beachside of Connecticut",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Long Island Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Downtown United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Oakwood Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Valeo Futbol Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "FC Westchester",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U15",
+      "division": "Northeast",
+      "team": "Rochester NY FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Players Development Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "FC DELCO",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Bethesda SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Baltimore Armour",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Sporting Athletic Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Real Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Springfield SYC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Northern Virginia Alliance",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Keystone FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Cedar Stars Academy Monmouth",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Beadling SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "The Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Achilles FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "PA Classics",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-Atlantic",
+      "team": "Alexandria SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Michigan Wolves",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Indy Eleven",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Sockers FC Chicago",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Vardar Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Midwest United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Chicago FC United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Cincinnati United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Michigan Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Michigan Jaguars",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "St. Louis Scott Gallagher",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Hoosier Premier",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "SC Wave",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Shattuck-St. Mary's",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Lou Fusz Athletic",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Mid-America",
+      "team": "Bavarian United SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "Capital City SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "Global Football Innovation Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "ALBION SC Colorado",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "Houston Rangers",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "Tulsa Greenwood SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "Dallas Hornets",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "AC River",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Frontier",
+      "team": "IDEA Toros F\u00fatbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Sacramento Republic FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "FC Bay Area Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Silicon Valley Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "De Anza Force",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Lamorinda Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "The Town FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "ALBION SC Merced",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Atletico Santa Rosa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Ballistic United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "San Francisco Glens SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Sacramento United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Modesto Ajax United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Napa United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "Woodside Soccer Club Crush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northwest",
+      "team": "San Francisco Seals",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Total Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "ALBION SC Los Angeles",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Barca Residency Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Los Angeles SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "ALBION SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "LA Bulls",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Strikers FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Phoenix Rising FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Chula Vista FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "FC Golden State",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "ALBION SC Las Vegas",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Santa Barbara Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "SC Del Sol",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "RSL Arizona",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Las Vegas Sports Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "SoCal Reds FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Los Angeles Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "Ventura County Fusion",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "City SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southwest",
+      "team": "City SC Southwest",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Miami Futbol Academy Rush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Orlando City Youth SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Weston FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Tampa Bay United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "South Florida Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Jacksonville Armada FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Orlando City Soccer School South",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "IMG",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "West Florida Flames",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Athletum FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Sol SC Florida",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "IdeaSport SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Florida",
+      "team": "Chargers Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Wake FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Inter Atlanta FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "KSA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Queen City Mutiny FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Charlotte Independence",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Triangle United Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Southern Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "AFC Lightning",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Hoover-Vestavia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Nashville United Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast",
+      "team": "Lanier Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Blau Weiss Gottschee",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Metropolitan Oval",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Intercontinental Football Academy of New England",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "FA Euro New York",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Ironbound Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Beachside of Connecticut",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Valeo Futbol Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "TSF Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Cedar Stars Academy Bergen",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Connecticut United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Rochester NY FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "FC Greater Boston Bolts",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "NEFC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "New York SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Oakwood Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Seacoast United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Long Island Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "FC Westchester",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Downtown United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast",
+      "team": "Bayside FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Real Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Bethesda SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "FC DELCO",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "PA Classics",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Players Development Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Baltimore Armour",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Achilles FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Alexandria SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Springfield SYC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Northern Virginia Alliance",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Cedar Stars Academy Monmouth",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Sporting Athletic Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Keystone FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "The Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-Atlantic",
+      "team": "Beadling SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "St. Louis Scott Gallagher",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Michigan Wolves",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Indy Eleven",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Sockers FC Chicago",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Shattuck-St. Mary's",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Chicago FC United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Bavarian United SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "SC Wave",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Cincinnati United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Hoosier Premier",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Michigan Jaguars",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Michigan Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Midwest United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Lou Fusz Athletic",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Mid-America",
+      "team": "Vardar Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "Capital City SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "Global Football Innovation Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "FC Dallas",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "Dallas Hornets",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "AC River",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "Houston Rangers",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "ALBION SC Colorado",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "IDEA Toros F\u00fatbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Frontier",
+      "team": "Tulsa Greenwood SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "FC Bay Area Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "ALBION SC Merced",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Sacramento Republic FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "San Francisco Glens SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "De Anza Force",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Silicon Valley Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Sacramento United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Woodside Soccer Club Crush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Modesto Ajax United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Ballistic United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Atletico Santa Rosa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Napa United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "The Town FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "Lamorinda Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northwest",
+      "team": "San Francisco Seals",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Barca Residency Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "ALBION SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Strikers FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Total Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "ALBION SC Los Angeles",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Ventura County Fusion",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "SoCal Reds FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Santa Barbara Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "City SC Southwest",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "City SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Los Angeles SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "ALBION SC Las Vegas",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Chula Vista FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "SC Del Sol",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Phoenix Rising FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Los Angeles Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "RSL Arizona",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "LA Bulls",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "FC Golden State",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southwest",
+      "team": "Las Vegas Sports Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Weston FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Orlando City Youth SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Miami Futbol Academy Rush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "IMG",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Inter Miami CF",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Tampa Bay United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Jacksonville Armada FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Athletum FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "South Florida Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Orlando City Soccer School South",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Sol SC Florida",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "IdeaSport SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "West Florida Flames",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Florida",
+      "team": "Chargers Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Inter Atlanta FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Wake FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Southern Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Queen City Mutiny FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Triangle United Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Charlotte Independence",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "AFC Lightning",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Nashville United Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Lanier Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "KSA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast",
+      "team": "Hoover-Vestavia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "TSF Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Intercontinental Football Academy of New England",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Cedar Stars Academy Bergen",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "FC Greater Boston Bolts",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Metropolitan Oval",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "New York SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Seacoast United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "NEFC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Blau Weiss Gottschee",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Bayside FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Beachside of Connecticut",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "FC Westchester",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Long Island Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Ironbound Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Downtown United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "FA Euro New York",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Oakwood Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Rochester NY FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast",
+      "team": "Valeo Futbol Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "FC DELCO",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Players Development Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Baltimore Armour",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Bethesda SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Northern Virginia Alliance",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Springfield SYC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Real Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Cedar Stars Academy Monmouth",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Sporting Athletic Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Beadling SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Keystone FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Achilles FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "Alexandria SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "The Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-Atlantic",
+      "team": "PA Classics",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Indy Eleven",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Sockers FC Chicago",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "St. Louis Scott Gallagher",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Chicago FC United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Midwest United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Shattuck-St. Mary's",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Michigan Wolves",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Michigan Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Cincinnati United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Hoosier Premier",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Bavarian United SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Lou Fusz Athletic",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Vardar Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "SC Wave",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Mid-America",
+      "team": "Michigan Jaguars",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "Global Football Innovation Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "Dallas Hornets",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "Capital City SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "ALBION SC Colorado",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "Houston Rangers",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "AC River",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "Tulsa Greenwood SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Frontier",
+      "team": "IDEA Toros F\u00fatbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Sacramento Republic FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "De Anza Force",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Sacramento United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Silicon Valley Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "San Francisco Glens SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "FC Bay Area Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Woodside Soccer Club Crush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Ballistic United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "The Town FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Lamorinda Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Atletico Santa Rosa",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Napa United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "Modesto Ajax United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "ALBION SC Merced",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northwest",
+      "team": "San Francisco Seals",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Barca Residency Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Ventura County Fusion",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Strikers FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "SC Del Sol",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Los Angeles Surf",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "ALBION SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Santa Barbara Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Total Futbol Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Chula Vista FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "ALBION SC Los Angeles",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "FC Golden State",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Los Angeles SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "ALBION SC Las Vegas",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "City SC San Diego",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "RSL Arizona",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Las Vegas Sports Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "Phoenix Rising FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "SoCal Reds FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "City SC Southwest",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southwest",
+      "team": "LA Bulls",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "IMG",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Orlando City Youth SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Miami Futbol Academy Rush",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Weston FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Jacksonville Armada FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "IdeaSport SA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Athletum FC Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "South Florida Football Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Tampa Bay United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Orlando City Soccer School South",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Sol SC Florida",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "West Florida Flames",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Florida",
+      "team": "Chargers Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Queen City Mutiny FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Charlotte Independence",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Southern Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "KSA",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Wake FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Lanier Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Nashville United Soccer Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Triangle United Soccer Association",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Hoover-Vestavia Soccer",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "AFC Lightning",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast",
+      "team": "Inter Atlanta FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Blau Weiss Gottschee",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Cedar Stars Academy Bergen",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "FC Greater Boston Bolts",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Long Island Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "TSF Academy",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Metropolitan Oval",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "NEFC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Beachside of Connecticut",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Seacoast United",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Bayside FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Intercontinental Football Academy of New England",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Connecticut United FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "FC Westchester",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "New York SC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Downtown United Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Ironbound Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "FA Euro New York",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Oakwood Soccer Club",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast",
+      "team": "Rochester NY FC",
+      "is_pro_academy": false
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "FC Cincinnati",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Colorado Rapids",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Chicago Fire FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Columbus Crew",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "St. Louis CITY SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Sporting Kansas City",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Minnesota United FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "West (Pro Player Pathway)",
+      "team": "San Jose Earthquakes",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "West (Pro Player Pathway)",
+      "team": "Los Angeles Football Club",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "West (Pro Player Pathway)",
+      "team": "Seattle Sounders FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "West (Pro Player Pathway)",
+      "team": "LA Galaxy",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "West (Pro Player Pathway)",
+      "team": "Real Salt Lake",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "West (Pro Player Pathway)",
+      "team": "Portland Timbers",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Houston Dynamo FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Orlando City SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Atlanta United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Inter Miami CF",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "FC Dallas",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Austin FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Nashville SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Charlotte FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New England Revolution",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "Toronto FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "Philadelphia Union",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New York City FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New York Red Bulls",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "D.C. United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U16",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "CF Montreal",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "St. Louis CITY SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Columbus Crew",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Sporting Kansas City",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Minnesota United FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "FC Cincinnati",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Chicago Fire FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Colorado Rapids",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "Seattle Sounders FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "Los Angeles Football Club",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "Real Salt Lake",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "Vancouver Whitecaps FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "LA Galaxy",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "San Jose Earthquakes",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "West (Pro Player Pathway)",
+      "team": "Portland Timbers",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Orlando City SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Atlanta United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Inter Miami CF",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Austin FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Houston Dynamo FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "FC Dallas",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Charlotte FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Nashville SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "Philadelphia Union",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "Toronto FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New York Red Bulls",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "CF Montreal",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New England Revolution",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "D.C. United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U17",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New York City FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Columbus Crew",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Colorado Rapids",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Chicago Fire FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "St. Louis CITY SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "FC Cincinnati",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Sporting Kansas City",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Central (Pro Player Pathway)",
+      "team": "Minnesota United FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "Real Salt Lake",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "Los Angeles Football Club",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "Portland Timbers",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "LA Galaxy",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "San Jose Earthquakes",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "Seattle Sounders FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "West (Pro Player Pathway)",
+      "team": "Vancouver Whitecaps FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Orlando City SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Charlotte FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Inter Miami CF",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Houston Dynamo FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Atlanta United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Austin FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "Nashville SC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Southeast (Pro Player Pathway)",
+      "team": "FC Dallas",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New York Red Bulls",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "Philadelphia Union",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New England Revolution",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "Toronto FC",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "D.C. United",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "CF Montreal",
+      "is_pro_academy": true
+    },
+    {
+      "age_group": "U19",
+      "division": "Northeast (Pro Player Pathway)",
+      "team": "New York City FC",
+      "is_pro_academy": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Two changes:

1. **Re-applies the `is_pro_academy` flag + Pro Player Pathway rows** to `backend/data/mls-next-clubs.json` (commit 271eb3a). This work was originally on PR #350 as a second commit but didn't land because the PR was merged before the commit propagated. Adds 86 PPP rows and an `is_pro_academy` boolean to every row; 824 rows total, 118 of them pro-academy, 29 unique pro-academy clubs.

2. **Wires the skill to use the mapping** (commit 09b6a3e). Adds a new `clubmap lookup` subcommand to `mt.py` and updates the SKILL.md team-resolve step to consult it before falling back to user prompts.

## Why

Before: when a team in a screenshot didn't exist in MT, the skill had no source of truth for which division it belonged to. It would either guess (often wrong — Springfield SYC is Mid-Atlantic, not Northeast) or block to ask the user every time.

After: a deterministic `(team_name, age_group) → division` lookup, plus an `is_pro_academy` flag that drives the existing `--academy-team` flag on `team create`. The skill only asks the user when the team genuinely isn't in any MLS NEXT roster.

## Smoke tests

```bash
$ mt.py clubmap lookup --team "Springfield SYC" --age-group U14
# → match.division="Mid-Atlantic", is_pro_academy=false

$ mt.py clubmap lookup --team "albion sc colorado" --age-group U14  # case-insensitive
# → match.division="Frontier", is_pro_academy=false

$ mt.py clubmap lookup --team "Philadelphia Union" --age-group U14
# → match.division="Mid-Atlantic", is_pro_academy=true
# → all_age_groups_for_team shows U13/U14 Mid-Atlantic, U16-U19 Northeast (Pro Player Pathway)
```

## Test plan

- [ ] Run all three smoke tests above
- [ ] Skim SKILL.md Step 4 — confirm the new `clubmap lookup` step reads naturally
- [ ] Confirm `mt.py clubmap lookup --team "Made Up Club" --age-group U14` returns `{"match": null, "all_age_groups_for_team": []}` (not an error)
- [ ] Re-paste the original Springfield SYC vs ALBION SC Colorado screenshot and confirm the skill resolves divisions automatically without asking the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)