### PR TITLE
fix(api): make POST /api/clubs and /api/teams idempotent on duplicate name

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -123,13 +123,7 @@ Response shape: `{"exact": team | null, "similar": [team, ...]}`.
      - **`match` is null, `all_age_groups_for_team` is non-empty** → the team plays at *other* age groups but not this one. Surface to the user — the screenshot may have a typo or the roster has changed.
      - **No matches at all** → not an MLS NEXT Allstate Homegrown / PPP team. Ask the user for division + whether it's a pro academy.
 
-  2. **Find the club** the team belongs to. The team name often embeds it (e.g. "Inter Miami CF U14" → club "Inter Miami CF"). Run:
-     ```bash
-     cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py club find "<club name>"
-     ```
-     If it exists, reuse its `id`. Otherwise:
-
-  3. **Crop the logo** out of the screenshot using the bbox you extracted in Step 1:
+  2. **Crop the logo** out of the screenshot using the bbox you extracted in Step 1:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py logo crop \
        --image /path/to/pasted-screenshot.png \
@@ -137,20 +131,20 @@ Response shape: `{"exact": team | null, "similar": [team, ...]}`.
        --output /tmp/logo_<slug>.png
      ```
 
-  4. **Create the club**:
+  3. **Create the club** (idempotent — duplicate name returns the existing club row with HTTP 200):
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py club create \
        --name "..." --city "..."
      ```
-     Capture the returned `id`.
+     Capture the returned `id`. No need for `club find` first — the endpoint handles duplicates.
 
-  5. **Upload the logo**:
+  4. **Upload the logo**:
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py logo upload \
        --club-id <id> --path /tmp/logo_<slug>.png
      ```
 
-  6. **Create the team**:
+  5. **Create the team** (idempotent — duplicate `(name, division_id)` returns the existing team row):
      ```bash
      cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py team create \
        --name "..." --city "..." \
@@ -158,6 +152,7 @@ Response shape: `{"exact": team | null, "similar": [team, ...]}`.
        --club-id <club_id> \
        [--academy-team]    # pass if clubmap.match.is_pro_academy was true
      ```
+     The response is `{"message": "...", "team": {row}}`. Parse `team.id` directly — no follow-up `team lookup` needed.
 
 Keep a running map of resolved `team name → team id` so you don't lookup the same team twice across multiple matches.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -2151,7 +2151,7 @@ async def add_team(
             team.club_id = user_club_id
 
         # Call add_team with keyword arguments
-        success = team_dao.add_team(
+        created = team_dao.add_team(
             name=team.name,
             city=team.city,
             age_group_ids=team.age_group_ids,
@@ -2160,15 +2160,30 @@ async def add_team(
             club_id=team.club_id,
             academy_team=team.academy_team,
         )
-        if success:
-            return {"message": "Team added successfully"}
-        else:
-            raise HTTPException(status_code=500, detail="Failed to add team")
+        if created:
+            return {"message": "Team added successfully", "team": created}
+        raise HTTPException(status_code=500, detail="Failed to add team")
     except Exception as e:
         error_str = str(e)
+
+        # Idempotency: teams.(name, division_id) is unique. If we hit that
+        # constraint, the caller asked to add a team that already exists in
+        # the same division — fetch the existing row and return it with 200
+        # so the skill (and other callers) can recover deterministically.
+        is_div_dup = "teams_name_division_unique" in error_str
+        if is_div_dup:
+            existing = team_dao.get_team_by_name_and_division(team.name, team.division_id)
+            if existing:
+                logger.info(
+                    f"Returning existing team: {existing['name']} (id={existing['id']}, division_id={team.division_id})"
+                )
+                return {"message": "Team already exists", "team": existing}
+            logger.error(
+                f"Duplicate (name, division_id) for '{team.name}'/{team.division_id} but lookup found nothing"
+            )
+
         logger.error(f"Error adding team: {error_str}", exc_info=True)
 
-        # Check for duplicate team constraint violation
         if (
             "teams_name_division_unique" in error_str
             or "teams_name_academy_unique" in error_str
@@ -4261,7 +4276,13 @@ async def get_club_teams(
 
 @app.post("/api/clubs")
 async def create_club(club: Club, current_user: dict[str, Any] = Depends(require_admin)):
-    """Create a new club (admin only)."""
+    """Create a new club, or return the existing club if one with the same name exists.
+
+    Idempotent on the club's name (case-insensitive). A duplicate-name insert
+    is recovered by looking up the existing row and returning it with HTTP 200
+    instead of 409. This lets the load-tournament-matches skill (and any other
+    caller) re-run safely without having to look up first.
+    """
     try:
         new_club = club_dao.create_club(
             name=club.name,
@@ -4276,19 +4297,27 @@ async def create_club(club: Club, current_user: dict[str, Any] = Depends(require
         return new_club
     except Exception as e:
         error_str = str(e)
+
+        # Idempotency: clubs.name is unique. If we hit that constraint, the
+        # caller asked to create a club that's already there — fetch the
+        # existing row and return it with 200 instead of 409.
+        is_name_dup = (
+            "duplicate key value violates unique constraint" in error_str.lower()
+            and ("clubs_name_unique" in error_str.lower() or "clubs_name_key" in error_str.lower())
+        )
+        if is_name_dup:
+            existing = club_dao.get_club_by_name(club.name)
+            if existing:
+                logger.info(f"Returning existing club: {existing['name']} (id={existing['id']})")
+                return existing
+            # Should be unreachable, but fall through to the explicit 409 below.
+            logger.error(f"Duplicate-name conflict for '{club.name}' but lookup found nothing")
+
         logger.error(f"Error creating club: {error_str}", exc_info=True)
 
-        # Check for duplicate key constraint violation
         if "duplicate key value violates unique constraint" in error_str.lower():
-            if "clubs_name_unique" in error_str.lower() or "clubs_name_key" in error_str.lower():
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"A club with the name '{club.name}' already exists. Please use a different name.",
-                ) from e
-            else:
-                raise HTTPException(status_code=409, detail="A club with this information already exists.") from e
+            raise HTTPException(status_code=409, detail="A club with this information already exists.") from e
 
-        # For any other unexpected errors, return 500
         raise HTTPException(status_code=500, detail="An unexpected error occurred while creating the club.") from e
 
 

--- a/backend/dao/club_dao.py
+++ b/backend/dao/club_dao.py
@@ -71,6 +71,19 @@ class ClubDAO(BaseDAO):
             return club_response.data[0]
         return None
 
+    def get_club_by_name(self, name: str) -> dict | None:
+        """Get a club by name (exact match, case-sensitive).
+
+        Matches the clubs_name_unique DB constraint, which is `UNIQUE (name)`
+        case-sensitively. Used by the create-club endpoint to recover the
+        existing row when the DB raises that unique violation. Returns the
+        full club row if found, None otherwise.
+        """
+        response = self.client.table("clubs").select("*").eq("name", name).limit(1).execute()
+        if response.data and len(response.data) > 0:
+            return response.data[0]
+        return None
+
     # === Club CRUD Methods ===
 
     @invalidates_cache(CLUBS_CACHE_PATTERN)

--- a/backend/dao/team_dao.py
+++ b/backend/dao/team_dao.py
@@ -183,6 +183,26 @@ class TeamDAO(BaseDAO):
             return response.data[0]
         return None
 
+    def get_team_by_name_and_division(self, name: str, division_id: int | None) -> dict | None:
+        """Get a team by name (exact match, case-sensitive) within a specific division.
+
+        Matches the teams_name_division_unique DB constraint exactly: team
+        names are unique within a division (and within the (name, NULL) slot
+        for guest/tournament teams with no division). The constraint is
+        case-sensitive, so this lookup is too — anything else risks returning
+        the wrong row when two rows differ only by case. Used by the
+        create-team endpoint to recover the existing row when the DB raises
+        that unique violation, so the endpoint becomes idempotent.
+
+        Returns the full team row if found, None otherwise.
+        """
+        query = self.client.table("teams").select("*").eq("name", name)
+        query = query.is_("division_id", "null") if division_id is None else query.eq("division_id", division_id)
+        response = query.limit(1).execute()
+        if response.data and len(response.data) > 0:
+            return response.data[0]
+        return None
+
     @dao_cache("teams:by_id:{team_id}")
     def get_team_by_id(self, team_id: int) -> dict | None:
         """Get a team by ID.
@@ -356,7 +376,7 @@ class TeamDAO(BaseDAO):
         division_id: int | None = None,
         club_id: int | None = None,
         academy_team: bool = False,
-    ) -> bool:
+    ) -> dict | None:
         """Add a new team with age groups, division, and optional club.
 
         Args:
@@ -367,6 +387,10 @@ class TeamDAO(BaseDAO):
             division_id: Division ID (optional, only required for league teams)
             club_id: Optional club ID
             academy_team: Whether this is an academy team
+
+        Returns:
+            The created team row dict on success, None on failure. Callers
+            that previously checked truthiness (`if add_team(...)`) keep working.
         """
         logger.info(
             "Creating team",
@@ -403,9 +427,10 @@ class TeamDAO(BaseDAO):
         team_response = self.client.table("teams").insert(team_data).execute()
 
         if not team_response.data:
-            return False
+            return None
 
-        team_id = team_response.data[0]["id"]
+        created_team = team_response.data[0]
+        team_id = created_team["id"]
         logger.info("Team record created", team_id=team_id, team_name=name)
 
         # Add age group associations
@@ -436,7 +461,7 @@ class TeamDAO(BaseDAO):
             age_groups=len(age_group_ids),
             match_types=len(match_type_ids) if match_type_ids else 0,
         )
-        return True
+        return created_team
 
     @invalidates_cache(TEAMS_CACHE_PATTERN)
     def update_team(

--- a/backend/tests/dao/test_team_dao.py
+++ b/backend/tests/dao/test_team_dao.py
@@ -83,7 +83,7 @@ def test_team_factory(team_dao, test_data_ids):
         if division_id is _UNSET:
             division_id = test_data_ids['division_id']
 
-        success = team_dao.add_team(
+        team = team_dao.add_team(
             name=name,
             city=city,
             age_group_ids=age_group_ids,
@@ -93,12 +93,9 @@ def test_team_factory(team_dao, test_data_ids):
             academy_team=academy_team
         )
 
-        if success:
-            # Get the team ID
-            team = team_dao.get_team_by_name(name)
-            if team:
-                created_team_ids.append(team['id'])
-                return team['id']
+        if team:
+            created_team_ids.append(team['id'])
+            return team['id']
 
         return None
 
@@ -256,7 +253,7 @@ class TestTeamCRUD:
             club_id=test_data_ids['club_id']
         )
 
-        assert success is True
+        assert success is not None
 
         # Verify team was created
         team = team_dao.get_team_by_name("Test Team CRUD Create")
@@ -277,7 +274,7 @@ class TestTeamCRUD:
             division_id=test_data_ids['division_id']
         )
 
-        assert success is True
+        assert success is not None
 
         # Verify team has both age groups
         team = team_dao.get_team_by_name("Test Multi Age Group Team")
@@ -302,7 +299,7 @@ class TestTeamCRUD:
             club_id=None
         )
 
-        assert success is True
+        assert success is not None
 
         # Verify team was created
         team = team_dao.get_team_by_name("Test Guest Team")

--- a/backend/tests/test_clubs_teams_integration.py
+++ b/backend/tests/test_clubs_teams_integration.py
@@ -168,9 +168,12 @@ class TestClubsTeamsIntegration:
         assert team_response.status_code == 200, f"Failed to create team: {team_response.text}"
 
         team = team_response.json()
-        # The response might be a message dict, check if it has an id or if we need to fetch it
-        if "message" in team:
-            # Need to fetch the team to get its ID
+        # POST /api/teams returns {"message": "...", "team": {row}} since the
+        # idempotency fix; use team["team"] for the row.
+        if "team" in team:
+            team = team["team"]
+        elif "message" in team:
+            # Legacy fallback — should be unreachable now, kept for safety.
             teams_response = client.get("/api/teams", headers=self.headers)
             assert teams_response.status_code == 200
             teams = teams_response.json()
@@ -392,6 +395,59 @@ class TestClubsTeamsIntegration:
             "Expected to find 'Test Team With Parent' in club teams"
 
         print("✅ All tests passed!")
+
+    def test_create_club_idempotent_on_duplicate_name(self):
+        """POST /api/clubs with a duplicate name returns the existing club (HTTP 200), not 409.
+
+        Regression test for SB-23. Lets the load-tournament-matches skill (and
+        any other caller) re-run without hand-rolling a `club find` prefix.
+        """
+        club_data = {
+            "name": "Test Idempotent Club",
+            "city": "Boston, MA",
+            "description": "Idempotency regression test"
+        }
+
+        first = client.post("/api/clubs", json=club_data, headers=self.headers)
+        assert first.status_code == 200, f"First create failed: {first.text}"
+        first_id = first.json()["id"]
+        self.created_club_id = first_id
+
+        second = client.post("/api/clubs", json=club_data, headers=self.headers)
+        assert second.status_code == 200, f"Second create returned {second.status_code}: {second.text}"
+        assert second.json()["id"] == first_id, "Idempotent create returned a different id"
+
+    def test_create_team_idempotent_in_same_division(self):
+        """POST /api/teams with a duplicate (name, division_id) returns the existing team."""
+        # Get/create a division + age group to test against.
+        divisions = client.get("/api/divisions", headers=self.headers).json()
+        assert divisions, "Need at least one division for this test"
+        division_id = divisions[0]["id"]
+        age_groups = client.get("/api/age-groups", headers=self.headers).json()
+        assert age_groups, "Need at least one age group for this test"
+        age_group_id = age_groups[0]["id"]
+
+        team_data = {
+            "name": "Test Idempotent Team",
+            "city": "Boston, MA",
+            "age_group_ids": [age_group_id],
+            "division_id": division_id,
+            "academy_team": False,
+        }
+
+        first = client.post("/api/teams", json=team_data, headers=self.headers)
+        assert first.status_code == 200, f"First team create failed: {first.text}"
+        first_body = first.json()
+        assert "team" in first_body, "Success response should include the team row"
+        first_id = first_body["team"]["id"]
+        self.created_team_ids.append(first_id)
+
+        second = client.post("/api/teams", json=team_data, headers=self.headers)
+        assert second.status_code == 200, f"Second team create returned {second.status_code}: {second.text}"
+        second_body = second.json()
+        assert "team" in second_body
+        assert second_body["team"]["id"] == first_id, "Idempotent team create returned a different id"
+        assert second_body.get("message") == "Team already exists"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes [SB-23](https://linear.app/silverbeer/issue/SB-23).

Previously, `POST /api/clubs` returned **409** with no recovery info on a duplicate-name insert, and `POST /api/teams` did the same plus returned only `{"message": "Team added successfully"}` on success — forcing every caller to follow up with a separate `team lookup`. Both behaviors broke the load-tournament-matches skill's re-run flow (caught today during the MLS NEXT Cup load when Metropolitan Oval, a pre-existing team, blew up the pipe).

## Approach

Keep the DB unique constraints (`clubs_name_unique`, `teams_name_division_unique`) as the source of truth. On the rare conflict path, look up the existing row (cheap, indexed) and return it with HTTP 200 instead of 409. **Happy path is unchanged** — zero extra SELECTs on the common case.

Lookups use exact (case-sensitive) `eq` matches to mirror the DB constraints (both are `UNIQUE` without `LOWER()` or CITEXT, so they're case-sensitive). Anything else risks returning the wrong row when two rows differ only by case — caught this in the first test run, fix included.

## Notable shape changes

- **`POST /api/teams`** now returns `{"message": "...", "team": {row}}` on both fresh creates and idempotent reuses. Eliminates the team-lookup round-trip the skill had to do after every create. Backward-compatible (existing callers only check for 200).
- **`add_team` DAO** returns `dict | None` (the created team row) instead of `bool`. Three tests updated to match.

## SKILL.md updates

Step 4's "Find the club first" defensive prefix is gone — the backend handles duplicates now, no caller-side dance needed. Step also notes that `team create`'s response includes the team row directly.

## Test plan

- [x] New: `test_create_club_idempotent_on_duplicate_name` — two POSTs with same name return the same id
- [x] New: `test_create_team_idempotent_in_same_division` — two POSTs with same `(name, division_id)` return the same id; response includes `team` row
- [x] Existing integration test updated for new `team` response key
- [x] Existing team_dao tests updated for new `add_team` return type

## Known pre-existing test issues (NOT introduced by this PR)

- `test_create_team_with_parent_club` and `test_create_club_and_link_team` fail on `parent_club_id` being None — the tests send a field the API doesn't recognize (`parent_club_id` vs `club_id`). Pre-existing bug.
- `tests/dao/test_team_dao.py` has shared module-scope fixtures and doesn't set `APP_ENV`, so its data isolation breaks when sequences drift (e.g. after a backup restore). Pre-existing, separate concern.

If you'd like, I'll file Linear tickets for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)