### PR TITLE
feat(tournaments): 32-team bracket view for MLS NEXT Cup (SB-27)

### DIFF
--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -1,0 +1,478 @@
+<template>
+  <div>
+    <!-- No matches in this bracket -->
+    <div v-if="r32Matches.length === 0" class="text-center py-10 text-gray-500">
+      No matches in this bracket yet.
+    </div>
+
+    <div v-else class="overflow-x-auto pb-4">
+      <div class="bracket-grid min-w-[1080px]">
+        <!-- Column headers -->
+        <div
+          v-for="(round, i) in ROUNDS"
+          :key="`hdr-${round.key}`"
+          :class="['bracket-header', `col-${i + 1}`]"
+        >
+          {{ round.label }}
+        </div>
+
+        <!-- R32 cells (16) -->
+        <div
+          v-for="(m, idx) in r32Matches"
+          :key="`r32-${m.id}`"
+          :class="['bracket-cell', `col-1`, `r32-${idx}`]"
+        >
+          <BracketCell :match="m" @click="$emit('match-click', m)" />
+        </div>
+
+        <!-- Placeholder cells for future rounds (no matches in DB yet) -->
+        <div
+          v-for="i in 8"
+          :key="`r16-${i}`"
+          :class="['bracket-cell', `col-2`, `r16-${i - 1}`]"
+        >
+          <BracketCell :match="null" />
+        </div>
+        <div
+          v-for="i in 4"
+          :key="`qf-${i}`"
+          :class="['bracket-cell', `col-3`, `qf-${i - 1}`]"
+        >
+          <BracketCell :match="null" />
+        </div>
+        <div
+          v-for="i in 2"
+          :key="`sf-${i}`"
+          :class="['bracket-cell', `col-4`, `sf-${i - 1}`]"
+        >
+          <BracketCell :match="null" />
+        </div>
+        <div :class="['bracket-cell', `col-5`, `final-0`]">
+          <BracketCell :match="null" :is-final="true" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, h } from 'vue';
+
+const props = defineProps({
+  matches: { type: Array, required: true },
+});
+
+defineEmits(['match-click']);
+
+const ROUNDS = [
+  { key: 'round_of_32', label: 'Round of 32' },
+  { key: 'round_of_16', label: 'Round of 16' },
+  { key: 'quarterfinal', label: 'Quarterfinals' },
+  { key: 'semifinal', label: 'Semifinals' },
+  { key: 'final', label: 'Final' },
+];
+
+// Stable display order: ascending id mirrors the source schedule order
+// (matches were loaded in that order). R32 pairs (M1+M2)→R16 #1, etc.
+const r32Matches = computed(() =>
+  [...props.matches]
+    .filter(m => m.tournament_round === 'round_of_32')
+    .sort((a, b) => a.id - b.id)
+);
+
+// ── Inline child component for match cells ──
+const BracketCell = {
+  props: {
+    match: { type: Object, default: null },
+    isFinal: { type: Boolean, default: false },
+  },
+  emits: ['click'],
+  setup(p, { emit }) {
+    const homeWinner = computed(() => isWinner(p.match, 'home'));
+    const awayWinner = computed(() => isWinner(p.match, 'away'));
+    const statusLabel = computed(() => {
+      if (!p.match) return null;
+      if (p.match.match_status === 'completed') return 'Final';
+      if (p.match.match_status === 'in_progress') return 'Live';
+      if (p.match.match_status === 'cancelled') return 'Cancelled';
+      return null;
+    });
+
+    return () => {
+      if (!p.match) {
+        return h(
+          'div',
+          {
+            class: [
+              'h-full rounded-md border border-dashed border-gray-200 bg-gray-50/50 flex items-center justify-center text-gray-300 text-xs',
+              p.isFinal ? 'px-3 py-2' : 'px-2 py-1.5',
+            ],
+          },
+          '—'
+        );
+      }
+      const live = p.match.match_status === 'in_progress';
+      return h(
+        'button',
+        {
+          type: 'button',
+          onClick: () => emit('click', p.match),
+          class: [
+            'w-full text-left rounded-md border bg-white px-2 py-1.5 shadow-sm hover:border-brand-400 transition-colors',
+            live ? 'border-brand-400 animate-pulse' : 'border-gray-200',
+          ],
+        },
+        [
+          // Row 1: home team
+          h(
+            'div',
+            {
+              class: [
+                'flex items-center justify-between gap-2 text-xs',
+                homeWinner.value
+                  ? 'font-bold text-gray-900'
+                  : p.match.match_status === 'completed'
+                    ? 'text-gray-400'
+                    : 'text-gray-800',
+              ],
+            },
+            [
+              h(
+                'span',
+                { class: 'truncate min-w-0' },
+                p.match.home_team?.name || 'TBD'
+              ),
+              h(
+                'span',
+                { class: 'font-mono tabular-nums shrink-0' },
+                scoreCell(p.match, 'home')
+              ),
+            ]
+          ),
+          // Row 2: away team
+          h(
+            'div',
+            {
+              class: [
+                'flex items-center justify-between gap-2 text-xs mt-0.5',
+                awayWinner.value
+                  ? 'font-bold text-gray-900'
+                  : p.match.match_status === 'completed'
+                    ? 'text-gray-400'
+                    : 'text-gray-800',
+              ],
+            },
+            [
+              h(
+                'span',
+                { class: 'truncate min-w-0' },
+                p.match.away_team?.name || 'TBD'
+              ),
+              h(
+                'span',
+                { class: 'font-mono tabular-nums shrink-0' },
+                scoreCell(p.match, 'away')
+              ),
+            ]
+          ),
+          // Row 3: meta (date + status)
+          h(
+            'div',
+            {
+              class:
+                'mt-1 flex items-center justify-between text-[10px] text-gray-400',
+            },
+            [
+              h('span', null, formatMatchDate(p.match.match_date)),
+              statusLabel.value
+                ? h(
+                    'span',
+                    {
+                      class: live
+                        ? 'text-brand-600 font-semibold'
+                        : statusLabel.value === 'Final'
+                          ? 'text-green-600 font-semibold'
+                          : statusLabel.value === 'Cancelled'
+                            ? 'text-red-500'
+                            : '',
+                    },
+                    statusLabel.value
+                  )
+                : null,
+            ]
+          ),
+        ]
+      );
+    };
+  },
+};
+
+// ── helpers ──
+
+function isWinner(match, side) {
+  if (!match || match.match_status !== 'completed') return false;
+  const h = match.home_score;
+  const a = match.away_score;
+  if (h == null || a == null) return false;
+  // PK shootout wins handled via penalty scores when regulation is tied.
+  if (h === a) {
+    const hp = match.home_penalty_score;
+    const ap = match.away_penalty_score;
+    if (hp == null || ap == null) return false;
+    return side === 'home' ? hp > ap : ap > hp;
+  }
+  return side === 'home' ? h > a : a > h;
+}
+
+function scoreCell(match, side) {
+  if (match.home_score == null || match.away_score == null) return 'TBD';
+  const base = side === 'home' ? match.home_score : match.away_score;
+  if (match.home_penalty_score != null && match.away_penalty_score != null) {
+    const pk =
+      side === 'home' ? match.home_penalty_score : match.away_penalty_score;
+    return `${base} (${pk})`;
+  }
+  return String(base);
+}
+
+function formatMatchDate(d) {
+  if (!d) return '';
+  return new Date(d + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+</script>
+
+<style scoped>
+/*
+ * Single-elimination 32-team bracket on a CSS grid.
+ *
+ * 32 row tracks let each round-cell span the right number of rows to
+ * center it vertically against its parent: R32 spans 2, R16 spans 4,
+ * QF spans 8, SF spans 16, Final spans 32. The connector lines are
+ * drawn with ::before/::after pseudo-elements on each cell.
+ */
+.bracket-grid {
+  display: grid;
+  grid-template-columns:
+    minmax(170px, 1fr) minmax(170px, 1fr) minmax(170px, 1fr)
+    minmax(170px, 1fr) minmax(170px, 1fr);
+  grid-template-rows: auto repeat(32, minmax(28px, 1fr));
+  gap: 0;
+  position: relative;
+}
+
+.bracket-header {
+  grid-row: 1;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgb(107 114 128);
+  text-align: center;
+  padding-bottom: 0.5rem;
+}
+.col-1 {
+  grid-column: 1;
+}
+.col-2 {
+  grid-column: 2;
+}
+.col-3 {
+  grid-column: 3;
+}
+.col-4 {
+  grid-column: 4;
+}
+.col-5 {
+  grid-column: 5;
+}
+
+.bracket-cell {
+  position: relative;
+  padding: 4px 12px 4px 4px;
+  display: flex;
+  align-items: center;
+}
+.col-2.bracket-cell,
+.col-3.bracket-cell,
+.col-4.bracket-cell,
+.col-5.bracket-cell {
+  padding-left: 12px;
+}
+
+.bracket-cell > * {
+  width: 100%;
+}
+
+/* R32: rows 2..33 in pairs of 2 */
+.r32-0 {
+  grid-row: 2 / span 2;
+}
+.r32-1 {
+  grid-row: 4 / span 2;
+}
+.r32-2 {
+  grid-row: 6 / span 2;
+}
+.r32-3 {
+  grid-row: 8 / span 2;
+}
+.r32-4 {
+  grid-row: 10 / span 2;
+}
+.r32-5 {
+  grid-row: 12 / span 2;
+}
+.r32-6 {
+  grid-row: 14 / span 2;
+}
+.r32-7 {
+  grid-row: 16 / span 2;
+}
+.r32-8 {
+  grid-row: 18 / span 2;
+}
+.r32-9 {
+  grid-row: 20 / span 2;
+}
+.r32-10 {
+  grid-row: 22 / span 2;
+}
+.r32-11 {
+  grid-row: 24 / span 2;
+}
+.r32-12 {
+  grid-row: 26 / span 2;
+}
+.r32-13 {
+  grid-row: 28 / span 2;
+}
+.r32-14 {
+  grid-row: 30 / span 2;
+}
+.r32-15 {
+  grid-row: 32 / span 2;
+}
+
+/* R16: each spans 4 rows, centered between its two R32 parents */
+.r16-0 {
+  grid-row: 2 / span 4;
+}
+.r16-1 {
+  grid-row: 6 / span 4;
+}
+.r16-2 {
+  grid-row: 10 / span 4;
+}
+.r16-3 {
+  grid-row: 14 / span 4;
+}
+.r16-4 {
+  grid-row: 18 / span 4;
+}
+.r16-5 {
+  grid-row: 22 / span 4;
+}
+.r16-6 {
+  grid-row: 26 / span 4;
+}
+.r16-7 {
+  grid-row: 30 / span 4;
+}
+
+/* QF: each spans 8 rows */
+.qf-0 {
+  grid-row: 2 / span 8;
+}
+.qf-1 {
+  grid-row: 10 / span 8;
+}
+.qf-2 {
+  grid-row: 18 / span 8;
+}
+.qf-3 {
+  grid-row: 26 / span 8;
+}
+
+/* SF: each spans 16 rows */
+.sf-0 {
+  grid-row: 2 / span 16;
+}
+.sf-1 {
+  grid-row: 18 / span 16;
+}
+
+/* Final spans all 32 */
+.final-0 {
+  grid-row: 2 / span 32;
+}
+
+/* Connector lines.
+ * For each cell, draw a short horizontal line going right toward the
+ * next round, and a vertical line joining sibling pairs.
+ *
+ * Layout reference:
+ *   cell ─┐
+ *         │ vertical
+ *   cell ─┘
+ *         ── horizontal (drawn from the next column's left edge)
+ */
+.bracket-cell::after {
+  /* Short horizontal line going right from this cell's right edge.
+   * This is the "lead-out" line common to every cell except Final. */
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 12px;
+  height: 1px;
+  background: rgb(209 213 219);
+}
+.col-5.bracket-cell::after {
+  display: none;
+}
+
+/*
+ * Vertical "bridge" that joins two sibling cells: drawn on the top
+ * cell of each pair, extending downward to the bottom cell's midpoint.
+ *   For R32→R16: pair = (2k, 2k+1). Top cells: r32-0,2,4,...,14.
+ *   For R16→QF: top cells: r16-0,2,4,6.
+ *   For QF→SF: top cells: qf-0, qf-2.
+ *   For SF→Final: top cell: sf-0.
+ * Height of the bridge = vertical distance between paired-cell midpoints
+ * = (rows-per-cell) × row-height. Since each pair sits in 2 × span rows,
+ * the bridge spans exactly `span` rows downward (= 100% of cell height).
+ */
+.r32-0::before,
+.r32-2::before,
+.r32-4::before,
+.r32-6::before,
+.r32-8::before,
+.r32-10::before,
+.r32-12::before,
+.r32-14::before,
+.r16-0::before,
+.r16-2::before,
+.r16-4::before,
+.r16-6::before,
+.qf-0::before,
+.qf-2::before,
+.sf-0::before {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 1px;
+  height: 100%;
+  background: rgb(209 213 219);
+}
+
+/* Mobile: keep the bracket usable; rely on the outer overflow-x scroll. */
+@media (max-width: 768px) {
+  .bracket-grid {
+    grid-template-rows: auto repeat(32, minmax(34px, auto));
+  }
+}
+</style>

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="max-w-4xl mx-auto">
+  <div
+    :class="viewMode === 'bracket' ? 'max-w-7xl mx-auto' : 'max-w-4xl mx-auto'"
+  >
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-12">
       <div
@@ -76,11 +78,43 @@
                 {{ selected.description }}
               </p>
             </div>
-            <div class="text-right text-sm text-gray-500">
-              <div class="text-2xl font-bold text-gray-800">
-                {{ selected.matches?.length ?? 0 }}
+            <div class="flex flex-col items-end gap-3">
+              <div class="text-right text-sm text-gray-500">
+                <div class="text-2xl font-bold text-gray-800">
+                  {{ selected.matches?.length ?? 0 }}
+                </div>
+                <div>matches tracked</div>
               </div>
-              <div>matches tracked</div>
+              <!-- View toggle: only shown when the tournament has bracket rounds tagged -->
+              <div
+                v-if="hasBracketRounds"
+                class="inline-flex rounded-md border border-gray-300 bg-white p-0.5"
+              >
+                <button
+                  type="button"
+                  @click="viewMode = 'list'"
+                  :class="[
+                    'px-3 py-1 text-xs font-medium rounded transition-colors',
+                    viewMode === 'list'
+                      ? 'bg-brand-600 text-white'
+                      : 'text-gray-600 hover:text-gray-900',
+                  ]"
+                >
+                  List
+                </button>
+                <button
+                  type="button"
+                  @click="viewMode = 'bracket'"
+                  :class="[
+                    'px-3 py-1 text-xs font-medium rounded transition-colors',
+                    viewMode === 'bracket'
+                      ? 'bg-brand-600 text-white'
+                      : 'text-gray-600 hover:text-gray-900',
+                  ]"
+                >
+                  Bracket
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -92,7 +126,7 @@
           ></div>
         </div>
 
-        <template v-else-if="selected.matches">
+        <template v-else-if="selected.matches && viewMode === 'list'">
           <!-- Age group filter -->
           <div
             v-if="availableAgeGroups.length > 1"
@@ -503,15 +537,71 @@
             </div>
           </div>
         </template>
+
+        <!-- ── Bracket view ── -->
+        <template v-else-if="selected.matches && viewMode === 'bracket'">
+          <!-- Selectors: age group + bracket group -->
+          <div
+            class="mb-5 flex flex-col sm:flex-row sm:items-center sm:flex-wrap gap-3"
+          >
+            <div
+              v-if="bracketAgeGroups.length > 0"
+              class="flex flex-wrap items-center gap-2"
+            >
+              <span
+                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                >Age</span
+              >
+              <button
+                v-for="ag in bracketAgeGroups"
+                :key="`bag-${ag.id}`"
+                @click="bracketAgeGroupId = ag.id"
+                :class="[
+                  'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                  bracketAgeGroupId === ag.id
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-white border border-gray-300 text-gray-700 hover:border-indigo-400',
+                ]"
+              >
+                {{ ag.name }}
+              </button>
+            </div>
+            <div
+              v-if="bracketGroups.length > 1"
+              class="flex flex-wrap items-center gap-2"
+            >
+              <span
+                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                >Bracket</span
+              >
+              <button
+                v-for="g in bracketGroups"
+                :key="`bg-${g}`"
+                @click="bracketGroup = g"
+                :class="[
+                  'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                  bracketGroup === g
+                    ? 'bg-brand-600 text-white'
+                    : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+                ]"
+              >
+                {{ g }}
+              </button>
+            </div>
+          </div>
+
+          <TournamentBracket :matches="bracketMatches" />
+        </template>
       </div>
     </template>
   </div>
 </template>
 
 <script>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
+import TournamentBracket from './TournamentBracket.vue';
 
 const KNOCKOUT_ROUNDS = new Set([
   'round_of_32',
@@ -519,6 +609,14 @@ const KNOCKOUT_ROUNDS = new Set([
   'quarterfinal',
   'semifinal',
   'third_place',
+  'final',
+]);
+
+const BRACKET_ROUNDS = new Set([
+  'round_of_32',
+  'round_of_16',
+  'quarterfinal',
+  'semifinal',
   'final',
 ]);
 
@@ -534,6 +632,7 @@ const ROUND_LABELS = {
 
 export default {
   name: 'TournamentMatchCenter',
+  components: { TournamentBracket },
   setup() {
     const authStore = useAuthStore();
 
@@ -547,6 +646,11 @@ export default {
 
     const teamFilter = ref('');
     const ageGroupFilter = ref(null);
+
+    // ── view mode + bracket selectors ──
+    const viewMode = ref('list'); // 'list' | 'bracket'
+    const bracketAgeGroupId = ref(null);
+    const bracketGroup = ref(null);
 
     // ── helpers ──
 
@@ -668,6 +772,90 @@ export default {
       )
     );
 
+    // ── bracket-mode computed state ──
+
+    // True when the selected tournament has at least one match tagged with
+    // a single-elimination bracket round (drives the List|Bracket toggle).
+    const hasBracketRounds = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      return matches.some(m => BRACKET_ROUNDS.has(m.tournament_round));
+    });
+
+    const bracketAgeGroups = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      const seen = new Map();
+      for (const m of matches) {
+        if (m.age_group && BRACKET_ROUNDS.has(m.tournament_round)) {
+          seen.set(m.age_group.id, m.age_group);
+        }
+      }
+      return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+    });
+
+    const bracketGroups = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      const groups = new Set();
+      for (const m of matches) {
+        if (
+          BRACKET_ROUNDS.has(m.tournament_round) &&
+          (bracketAgeGroupId.value == null ||
+            m.age_group?.id === bracketAgeGroupId.value) &&
+          m.tournament_group
+        ) {
+          groups.add(m.tournament_group);
+        }
+      }
+      // Stable order: Championship first if present, then alphabetical.
+      const arr = [...groups];
+      arr.sort((a, b) => {
+        if (a === 'Championship') return -1;
+        if (b === 'Championship') return 1;
+        return a.localeCompare(b);
+      });
+      return arr;
+    });
+
+    const bracketMatches = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      return matches.filter(
+        m =>
+          BRACKET_ROUNDS.has(m.tournament_round) &&
+          (bracketAgeGroupId.value == null ||
+            m.age_group?.id === bracketAgeGroupId.value) &&
+          (bracketGroup.value == null ||
+            m.tournament_group === bracketGroup.value)
+      );
+    });
+
+    // Seed defaults when a tournament loads or its match set changes.
+    watch(
+      () => selected.value?.matches,
+      () => {
+        if (!hasBracketRounds.value) return;
+        if (
+          bracketAgeGroupId.value == null &&
+          bracketAgeGroups.value.length > 0
+        ) {
+          bracketAgeGroupId.value = bracketAgeGroups.value[0].id;
+        }
+        if (bracketGroup.value == null && bracketGroups.value.length > 0) {
+          bracketGroup.value = bracketGroups.value[0];
+        }
+      },
+      { immediate: true }
+    );
+
+    // If user changes age group and the prior bracket group isn't available
+    // for the new age group, fall back to the first available.
+    watch(bracketAgeGroupId, () => {
+      if (
+        bracketGroup.value != null &&
+        !bracketGroups.value.includes(bracketGroup.value)
+      ) {
+        bracketGroup.value = bracketGroups.value[0] ?? null;
+      }
+    });
+
     onMounted(fetchTournaments);
 
     return {
@@ -688,6 +876,13 @@ export default {
       formatMatchDate,
       roundLabel,
       selectTournament,
+      viewMode,
+      hasBracketRounds,
+      bracketAgeGroups,
+      bracketAgeGroupId,
+      bracketGroups,
+      bracketGroup,
+      bracketMatches,
     };
   },
 };


### PR DESCRIPTION
## Summary

- Adds `TournamentBracket.vue` — a 32-team single-elimination tree (R32 → R16 → QF → SF → Final) rendered on a CSS grid with pseudo-element connector lines.
- Wires a **List | Bracket** view toggle into `TournamentMatchCenter.vue`, shown only when the selected tournament has matches tagged with a bracket round.
- Adds age-group and bracket selectors (U13/U14 × Championship/Premier) above the tree, driven by `tournament_group` on match rows.
- Future-round cells render as `—` placeholders until those matches are created. Completed-match winners are bolded; losers dimmed.
- One-shot DB backfill: set `tournament_group` on the 64 existing tournament_id=1 matches that were loaded before the loader started writing that field. (Source: `scripts/mlsnext-cup/sched/*.json`.)

Linear: https://linear.app/silverbeer/issue/SB-27

## What is _not_ in this PR (per SB-27 scope)

- `PlayoffBracket.vue` (IFA-style, QF-starting, backed by `playoff_bracket_slots`) is untouched.
- No logos in cells. The tournament detail endpoint doesn't yet return club logo URLs, and the local club-logos bucket is broken (SB-21). Logos are a follow-up.
- No live-pulse / live-mode wiring (no live data feed yet), no standings inside the bracket, no predictions, no dark mode / team-color cells.

## Test plan

- [ ] Open `Tournaments → 2026 MLS NEXT Cup` in the existing flat list view → renders unchanged (no regression).
- [ ] A **List | Bracket** toggle appears in the tournament header. Switching to **Bracket** renders the 5-column tree with connector lines.
- [ ] Switching age group between U13 ↔ U14 swaps the bracket without a page reload.
- [ ] Switching bracket between Championship ↔ Premier shows the corresponding 16-match R32 column.
- [ ] R32 cells show scheduled matches with `TBD` scores; date row populated.
- [ ] R16 / QF / SF / Final cells render `—` placeholders (no matches yet in DB).
- [ ] Mobile viewport: the bracket scrolls horizontally inside its container; selectors stack above the tree.
- [ ] Open the IFA-style `PlayoffBracket.vue` view elsewhere in the app — unchanged.

## Acceptance criteria (from SB-27)

- [x] Toggle appears when matches have `tournament_round` set
- [x] 5-round tree with connector lines on Bracket
- [x] Age-group / bracket selector switches update tree without full reload
- [x] Scheduled = TBD, completed = scores with winner bold
- [x] TBD-vs-TBD future cells render as `—`
- [x] Mobile: horizontal scroll, legible cells
- [x] No regression on flat-list Tournament view
- [x] No regression on `PlayoffBracket.vue`

## Notes for reviewer

- I did **not** visually exercise the bracket in a browser session — please eyeball the layout, connector alignment, and mobile-scroll behavior. Lint is clean.
- R32 cells are ordered by ascending `match_id`, which mirrors the source-schedule order so paired-cell-vs-paired-cell alignment is consistent with the scrape data; no parent/child match relationship is stored in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)