### PR TITLE
feat(tournaments): Standings view for group-stage tournaments (SB-29)

### DIFF
--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -1,6 +1,10 @@
 <template>
   <div
-    :class="viewMode === 'bracket' ? 'max-w-7xl mx-auto' : 'max-w-4xl mx-auto'"
+    :class="
+      viewMode === 'bracket' || viewMode === 'standings'
+        ? 'max-w-7xl mx-auto'
+        : 'max-w-4xl mx-auto'
+    "
   >
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-12">
@@ -85,9 +89,9 @@
                 </div>
                 <div>matches tracked</div>
               </div>
-              <!-- View toggle: only shown when the tournament has bracket rounds tagged -->
+              <!-- View toggle: List always shown; Bracket / Standings shown based on match round shape -->
               <div
-                v-if="hasBracketRounds"
+                v-if="hasBracketRounds || hasStandingsRounds"
                 class="inline-flex rounded-md border border-gray-300 bg-white p-0.5"
               >
                 <button
@@ -103,6 +107,7 @@
                   List
                 </button>
                 <button
+                  v-if="hasBracketRounds"
                   type="button"
                   @click="viewMode = 'bracket'"
                   :class="[
@@ -113,6 +118,19 @@
                   ]"
                 >
                   Bracket
+                </button>
+                <button
+                  v-if="hasStandingsRounds"
+                  type="button"
+                  @click="viewMode = 'standings'"
+                  :class="[
+                    'px-3 py-1 text-xs font-medium rounded transition-colors',
+                    viewMode === 'standings'
+                      ? 'bg-brand-600 text-white'
+                      : 'text-gray-600 hover:text-gray-900',
+                  ]"
+                >
+                  Standings
                 </button>
               </div>
             </div>
@@ -592,6 +610,61 @@
 
           <TournamentBracket :matches="bracketMatches" />
         </template>
+
+        <!-- ── Standings view ── -->
+        <template v-else-if="selected.matches && viewMode === 'standings'">
+          <!-- Selectors: age group + tournament group, reused pattern from Bracket -->
+          <div
+            class="mb-5 flex flex-col sm:flex-row sm:items-center sm:flex-wrap gap-3"
+          >
+            <div
+              v-if="standingsAgeGroups.length > 1"
+              class="flex flex-wrap items-center gap-2"
+            >
+              <span
+                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                >Age</span
+              >
+              <button
+                v-for="ag in standingsAgeGroups"
+                :key="`sag-${ag.id}`"
+                @click="standingsAgeGroupId = ag.id"
+                :class="[
+                  'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                  standingsAgeGroupId === ag.id
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-white border border-gray-300 text-gray-700 hover:border-indigo-400',
+                ]"
+              >
+                {{ ag.name }}
+              </button>
+            </div>
+            <div
+              v-if="standingsGroups.length > 1"
+              class="flex flex-wrap items-center gap-2"
+            >
+              <span
+                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                >Bracket</span
+              >
+              <button
+                v-for="g in standingsGroups"
+                :key="`sg-${g}`"
+                @click="standingsGroup = g"
+                :class="[
+                  'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                  standingsGroup === g
+                    ? 'bg-brand-600 text-white'
+                    : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+                ]"
+              >
+                {{ g }}
+              </button>
+            </div>
+          </div>
+
+          <TournamentStandings :matches="standingsMatches" />
+        </template>
       </div>
     </template>
   </div>
@@ -602,6 +675,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 import TournamentBracket from './TournamentBracket.vue';
+import TournamentStandings from './TournamentStandings.vue';
 
 const KNOCKOUT_ROUNDS = new Set([
   'round_of_32',
@@ -632,7 +706,7 @@ const ROUND_LABELS = {
 
 export default {
   name: 'TournamentMatchCenter',
-  components: { TournamentBracket },
+  components: { TournamentBracket, TournamentStandings },
   setup() {
     const authStore = useAuthStore();
 
@@ -647,10 +721,12 @@ export default {
     const teamFilter = ref('');
     const ageGroupFilter = ref(null);
 
-    // ── view mode + bracket selectors ──
-    const viewMode = ref('list'); // 'list' | 'bracket'
+    // ── view mode + bracket / standings selectors ──
+    const viewMode = ref('list'); // 'list' | 'bracket' | 'standings'
     const bracketAgeGroupId = ref(null);
     const bracketGroup = ref(null);
+    const standingsAgeGroupId = ref(null);
+    const standingsGroup = ref(null);
 
     // ── helpers ──
 
@@ -856,6 +932,87 @@ export default {
       }
     });
 
+    // ── standings-mode computed state ──
+    // Same pattern as bracket-mode, but keyed off group_stage matches
+    // grouped by `tournament_group` (e.g. 'U14 Boys Diamond Bracket A').
+
+    const hasStandingsRounds = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      return matches.some(
+        m => m.tournament_round === 'group_stage' && m.tournament_group
+      );
+    });
+
+    const standingsAgeGroups = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      const seen = new Map();
+      for (const m of matches) {
+        if (
+          m.age_group &&
+          m.tournament_round === 'group_stage' &&
+          m.tournament_group
+        ) {
+          seen.set(m.age_group.id, m.age_group);
+        }
+      }
+      return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+    });
+
+    const standingsGroups = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      const groups = new Set();
+      for (const m of matches) {
+        if (
+          m.tournament_round === 'group_stage' &&
+          m.tournament_group &&
+          (standingsAgeGroupId.value == null ||
+            m.age_group?.id === standingsAgeGroupId.value)
+        ) {
+          groups.add(m.tournament_group);
+        }
+      }
+      return [...groups].sort((a, b) => a.localeCompare(b));
+    });
+
+    const standingsMatches = computed(() => {
+      const matches = selected.value?.matches ?? [];
+      return matches.filter(
+        m =>
+          m.tournament_round === 'group_stage' &&
+          m.tournament_group &&
+          (standingsAgeGroupId.value == null ||
+            m.age_group?.id === standingsAgeGroupId.value) &&
+          (standingsGroup.value == null ||
+            m.tournament_group === standingsGroup.value)
+      );
+    });
+
+    watch(
+      () => selected.value?.matches,
+      () => {
+        if (!hasStandingsRounds.value) return;
+        if (
+          standingsAgeGroupId.value == null &&
+          standingsAgeGroups.value.length > 0
+        ) {
+          standingsAgeGroupId.value = standingsAgeGroups.value[0].id;
+        }
+        if (standingsGroup.value == null && standingsGroups.value.length > 0) {
+          standingsGroup.value = standingsGroups.value[0];
+        }
+      },
+      { immediate: true }
+    );
+
+    watch(standingsAgeGroupId, () => {
+      if (
+        standingsGroup.value != null &&
+        !standingsGroups.value.includes(standingsGroup.value)
+      ) {
+        standingsGroup.value = standingsGroups.value[0] ?? null;
+      }
+    });
+
     onMounted(fetchTournaments);
 
     return {
@@ -883,6 +1040,12 @@ export default {
       bracketGroups,
       bracketGroup,
       bracketMatches,
+      hasStandingsRounds,
+      standingsAgeGroups,
+      standingsAgeGroupId,
+      standingsGroups,
+      standingsGroup,
+      standingsMatches,
     };
   },
 };

--- a/frontend/src/components/TournamentStandings.vue
+++ b/frontend/src/components/TournamentStandings.vue
@@ -1,0 +1,287 @@
+<template>
+  <div>
+    <!-- No matches -->
+    <div
+      v-if="bracketTeams.length === 0"
+      class="text-center py-10 text-gray-500"
+    >
+      No group-stage matches in this bracket yet.
+    </div>
+
+    <template v-else>
+      <!-- Standings table -->
+      <div
+        class="overflow-x-auto bg-white rounded-lg border border-gray-200 mb-6"
+      >
+        <table class="min-w-full text-sm">
+          <thead class="bg-gray-50 text-gray-600">
+            <tr>
+              <th class="px-2 py-2 w-8 text-center font-semibold">#</th>
+              <th class="px-3 py-2 text-left font-semibold">Team</th>
+              <th
+                v-for="col in STAT_COLS"
+                :key="col.key"
+                class="px-2 py-2 text-center font-semibold w-12"
+              >
+                {{ col.label }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, idx) in standings"
+              :key="row.team.id"
+              :class="[
+                idx === 0 ? 'bg-brand-50/50' : 'hover:bg-gray-50',
+                'border-t border-gray-100',
+              ]"
+            >
+              <td class="px-2 py-2 text-center text-gray-500 tabular-nums">
+                {{ idx + 1 }}
+              </td>
+              <td
+                :class="[
+                  'px-3 py-2 truncate',
+                  idx === 0 ? 'font-semibold text-gray-900' : 'text-gray-800',
+                ]"
+              >
+                {{ row.team.name }}
+              </td>
+              <td
+                v-for="col in STAT_COLS"
+                :key="col.key"
+                :class="[
+                  'px-2 py-2 text-center tabular-nums',
+                  col.key === 'pts'
+                    ? 'font-bold text-gray-900'
+                    : 'text-gray-700',
+                ]"
+              >
+                {{ formatStat(row, col.key) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Head-to-head cross-table -->
+      <div>
+        <h3
+          class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2"
+        >
+          Head-to-head
+        </h3>
+        <div class="overflow-x-auto bg-white rounded-lg border border-gray-200">
+          <table class="min-w-full text-sm">
+            <thead class="bg-gray-50 text-gray-600">
+              <tr>
+                <th
+                  class="px-3 py-2 text-left font-semibold sticky left-0 bg-gray-50 z-10"
+                  style="min-width: 180px"
+                ></th>
+                <th
+                  v-for="team in bracketTeams"
+                  :key="`hdr-${team.id}`"
+                  class="px-3 py-2 text-center font-semibold"
+                  style="min-width: 110px"
+                >
+                  {{ team.name }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="rowTeam in bracketTeams"
+                :key="`row-${rowTeam.id}`"
+                class="border-t border-gray-100"
+              >
+                <td
+                  class="px-3 py-2 font-medium text-gray-800 sticky left-0 bg-white z-10"
+                >
+                  {{ rowTeam.name }}
+                </td>
+                <td
+                  v-for="colTeam in bracketTeams"
+                  :key="`cell-${rowTeam.id}-${colTeam.id}`"
+                  :class="[
+                    'px-3 py-2 text-center tabular-nums',
+                    rowTeam.id === colTeam.id
+                      ? 'bg-gray-100 text-gray-300'
+                      : 'text-gray-700',
+                  ]"
+                >
+                  <span v-if="rowTeam.id === colTeam.id">—</span>
+                  <span v-else>{{ h2hCell(rowTeam.id, colTeam.id) }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  // Pre-filtered: only matches we want to include in the standings
+  // (age group + tournament_group + group_stage round, filter happens
+  // upstream so this component stays small and pure).
+  matches: { type: Array, required: true },
+});
+
+// Columns shown in the standings table, in order.
+const STAT_COLS = [
+  { key: 'mp', label: 'MP' },
+  { key: 'w', label: 'W' },
+  { key: 'd', label: 'D' },
+  { key: 'l', label: 'L' },
+  { key: 'gf', label: 'GF' },
+  { key: 'ga', label: 'GA' },
+  { key: 'gd', label: 'GD' },
+  { key: 'pts', label: 'PTS' },
+];
+
+// Unique teams that appear in this match set, sorted by name. Used as
+// both the row and column axis of the head-to-head cross-table.
+const bracketTeams = computed(() => {
+  const seen = new Map();
+  for (const m of props.matches) {
+    if (m.home_team && !seen.has(m.home_team.id)) {
+      seen.set(m.home_team.id, m.home_team);
+    }
+    if (m.away_team && !seen.has(m.away_team.id)) {
+      seen.set(m.away_team.id, m.away_team);
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+});
+
+// One completed match (or null) keyed by `${rowId}_${colId}` so the
+// cross-table can look it up in O(1) per cell. The row team is the
+// "perspective" team — the cell shows the score from the row team's
+// point of view (i.e. row-team-goals first).
+const completedByPair = computed(() => {
+  const map = new Map();
+  for (const m of props.matches) {
+    if (m.match_status !== 'completed') continue;
+    if (m.home_score == null || m.away_score == null) continue;
+    map.set(`${m.home_team.id}_${m.away_team.id}`, m);
+  }
+  return map;
+});
+
+// Format a cross-table cell from the row team's perspective.
+function h2hCell(rowId, colId) {
+  const homeMatch = completedByPair.value.get(`${rowId}_${colId}`);
+  if (homeMatch) {
+    return formatScore(homeMatch.home_score, homeMatch.away_score, homeMatch);
+  }
+  const awayMatch = completedByPair.value.get(`${colId}_${rowId}`);
+  if (awayMatch) {
+    return formatScore(awayMatch.away_score, awayMatch.home_score, awayMatch);
+  }
+  return '-';
+}
+
+function formatScore(forGoals, againstGoals, match) {
+  // Penalty-shootout suffix when present.
+  if (
+    match.home_penalty_score != null &&
+    match.away_penalty_score != null &&
+    forGoals === againstGoals
+  ) {
+    const isHomePerspective = match.home_score === forGoals;
+    const pkFor = isHomePerspective
+      ? match.home_penalty_score
+      : match.away_penalty_score;
+    const pkAgainst = isHomePerspective
+      ? match.away_penalty_score
+      : match.home_penalty_score;
+    return `${forGoals}-${againstGoals} (${pkFor}-${pkAgainst} PK)`;
+  }
+  return `${forGoals}-${againstGoals}`;
+}
+
+// Per-team standings rows. PK shootout wins count as wins; PK goals are
+// excluded from GF/GA (regulation only).
+const standings = computed(() => {
+  const rows = new Map();
+  for (const team of bracketTeams.value) {
+    rows.set(team.id, {
+      team,
+      mp: 0,
+      w: 0,
+      d: 0,
+      l: 0,
+      gf: 0,
+      ga: 0,
+      gd: 0,
+      pts: 0,
+    });
+  }
+
+  for (const m of props.matches) {
+    if (m.match_status !== 'completed') continue;
+    if (m.home_score == null || m.away_score == null) continue;
+
+    const home = rows.get(m.home_team?.id);
+    const away = rows.get(m.away_team?.id);
+    if (!home || !away) continue;
+
+    home.mp += 1;
+    away.mp += 1;
+    home.gf += m.home_score;
+    home.ga += m.away_score;
+    away.gf += m.away_score;
+    away.ga += m.home_score;
+
+    let homeWin = m.home_score > m.away_score;
+    let awayWin = m.away_score > m.home_score;
+    if (
+      !homeWin &&
+      !awayWin &&
+      m.home_penalty_score != null &&
+      m.away_penalty_score != null
+    ) {
+      homeWin = m.home_penalty_score > m.away_penalty_score;
+      awayWin = m.away_penalty_score > m.home_penalty_score;
+    }
+
+    if (homeWin) {
+      home.w += 1;
+      home.pts += 3;
+      away.l += 1;
+    } else if (awayWin) {
+      away.w += 1;
+      away.pts += 3;
+      home.l += 1;
+    } else {
+      home.d += 1;
+      away.d += 1;
+      home.pts += 1;
+      away.pts += 1;
+    }
+  }
+
+  for (const r of rows.values()) {
+    r.gd = r.gf - r.ga;
+  }
+
+  return [...rows.values()].sort((a, b) => {
+    if (b.pts !== a.pts) return b.pts - a.pts;
+    if (b.gd !== a.gd) return b.gd - a.gd;
+    if (b.gf !== a.gf) return b.gf - a.gf;
+    return a.team.name.localeCompare(b.team.name);
+  });
+});
+
+function formatStat(row, key) {
+  if (key === 'gd') {
+    return row.gd > 0 ? `+${row.gd}` : String(row.gd);
+  }
+  return row[key];
+}
+</script>


### PR DESCRIPTION
## Summary

- Adds `TournamentStandings.vue` — standings table + head-to-head cross-table for tournaments with `group_stage` matches grouped by `tournament_group`. Both views computed on the frontend from the existing tournament match list — no schema changes, no new endpoints.
- Wires Standings into the existing tournament header toggle, alongside List and Bracket. Each option appears only when applicable to the tournament's match shape: every tournament gets **List**; **Bracket** shows when there's any `round_of_*` / `final` match (SB-27 path); **Standings** shows when there's any `group_stage` match with a non-null `tournament_group`.
- 2026 IFA MEMORIAL DAY CUP → **List + Standings**. 2026 MLS NEXT Cup → **List + Bracket** (unchanged).

Linear: https://linear.app/silverbeer/issue/SB-29

## Standings rules

- Sort: PTS desc → GD desc → GF desc → team name asc (alphabetical fallback so the order is deterministic for the all-zeros pre-tournament state).
- PK shootout wins count as W and add 3 PTS.
- PK goals are excluded from GF / GA (regulation only).
- Cross-table cells show the score from the row team's perspective. PK shootouts get a `(4-3 PK)` suffix when present.
- Diagonal cells render em-dash. Unplayed pairs render `-`.

## Test plan

- [ ] Tournaments → 2026 IFA MEMORIAL DAY CUP → see a **List | Standings** toggle (no Bracket because no R32/R16 matches).
- [ ] Tournaments → 2026 MLS NEXT Cup → see a **List | Bracket** toggle (no Standings because no group_stage matches) — no regression.
- [ ] Other tournaments with neither match shape → no toggle at all (also no regression).
- [ ] Click Standings → standings table (all zeros, 5 teams sorted alphabetically) + head-to-head grid (`-` everywhere except diagonals).
- [ ] In Admin, mark one match completed with a score (e.g. IFA 2-1 over A.C. Connecticut) → reload → IFA jumps to top of the standings table with `MP=1, W=1, GF=2, GA=1, GD=+1, PTS=3`, and the cross-table cell shows `2-1` from IFA's row, `1-2` from A.C. Connecticut's row.
- [ ] Enter a draw with a PK shootout → loser's regulation score is reflected in GF/GA but PK score is not; winner gets 3 PTS; cross-table shows `2-2 (4-3 PK)`.
- [ ] Mobile: cross-table scrolls horizontally; standings stays readable.
- [ ] No regression on List view or SB-27 Bracket view.

## Out of scope

- Inline result entry from the Standings page (existing admin match-edit flow handles this).
- Backend-computed standings endpoint (compute on the fly each render is fine for v1; can move server-side later if the view gets reused).
- Tiebreaker beyond GD/GF (head-to-head record, away goals etc. — extend the comparator if/when needed).
- Live-pulse highlighting for in-progress matches inside the cross-table (same scope deferral as SB-27 v1).

## Notes for reviewer

- I did **not** visually verify in a browser session — please eyeball the standings layout, sticky-left column on the cross-table, and mobile scroll. Lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)