### PR TITLE
feat(tournaments): make List-view rows clickable + 'Preview' link (SB-30)

### DIFF
--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -1,5 +1,13 @@
 <template>
+  <!-- Inline match detail: replaces the tournament page when a row is clicked. -->
+  <MatchDetailView
+    v-if="selectedMatchId"
+    :matchId="selectedMatchId"
+    @back="handleBackFromMatchDetail"
+  />
+
   <div
+    v-else
     :class="
       viewMode === 'bracket' || viewMode === 'standings'
         ? 'max-w-7xl mx-auto'
@@ -220,7 +228,8 @@
               <div
                 v-for="match in groupStageMatches"
                 :key="match.id"
-                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-gray-300 transition-colors"
+                @click="viewMatch(match)"
+                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
               >
                 <!-- Mobile meta row -->
                 <div class="flex items-center justify-between mb-1.5 sm:hidden">
@@ -255,7 +264,11 @@
                       class="text-xs text-red-500"
                       >Cancelled</span
                     >
-                    <span v-else class="text-xs text-gray-400">Scheduled</span>
+                    <span
+                      v-else
+                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      >Preview</span
+                    >
                   </div>
                 </div>
                 <!-- Main row -->
@@ -319,7 +332,11 @@
                       class="text-xs text-red-500"
                       >Cancelled</span
                     >
-                    <span v-else class="text-xs text-gray-400">Scheduled</span>
+                    <span
+                      v-else
+                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      >Preview</span
+                    >
                   </div>
                 </div>
               </div>
@@ -337,7 +354,8 @@
               <div
                 v-for="match in knockoutMatches"
                 :key="match.id"
-                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-gray-300 transition-colors"
+                @click="viewMatch(match)"
+                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
               >
                 <!-- Mobile meta row -->
                 <div class="flex items-center justify-between mb-1.5 sm:hidden">
@@ -372,7 +390,11 @@
                       class="text-xs text-red-500"
                       >Cancelled</span
                     >
-                    <span v-else class="text-xs text-gray-400">Scheduled</span>
+                    <span
+                      v-else
+                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      >Preview</span
+                    >
                   </div>
                 </div>
                 <!-- Main row -->
@@ -441,7 +463,11 @@
                       class="text-xs text-red-500"
                       >Cancelled</span
                     >
-                    <span v-else class="text-xs text-gray-400">Scheduled</span>
+                    <span
+                      v-else
+                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      >Preview</span
+                    >
                   </div>
                 </div>
               </div>
@@ -459,7 +485,8 @@
               <div
                 v-for="match in untaggedMatches"
                 :key="match.id"
-                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-gray-300 transition-colors"
+                @click="viewMatch(match)"
+                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
               >
                 <!-- Mobile meta row -->
                 <div class="flex items-center justify-between mb-1.5 sm:hidden">
@@ -489,7 +516,11 @@
                       class="text-xs text-red-500"
                       >Cancelled</span
                     >
-                    <span v-else class="text-xs text-gray-400">Scheduled</span>
+                    <span
+                      v-else
+                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      >Preview</span
+                    >
                   </div>
                 </div>
                 <!-- Main row -->
@@ -548,7 +579,11 @@
                       class="text-xs text-red-500"
                       >Cancelled</span
                     >
-                    <span v-else class="text-xs text-gray-400">Scheduled</span>
+                    <span
+                      v-else
+                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      >Preview</span
+                    >
                   </div>
                 </div>
               </div>
@@ -676,6 +711,7 @@ import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 import TournamentBracket from './TournamentBracket.vue';
 import TournamentStandings from './TournamentStandings.vue';
+import MatchDetailView from './MatchDetailView.vue';
 
 const KNOCKOUT_ROUNDS = new Set([
   'round_of_32',
@@ -706,7 +742,7 @@ const ROUND_LABELS = {
 
 export default {
   name: 'TournamentMatchCenter',
-  components: { TournamentBracket, TournamentStandings },
+  components: { TournamentBracket, TournamentStandings, MatchDetailView },
   setup() {
     const authStore = useAuthStore();
 
@@ -727,6 +763,17 @@ export default {
     const bracketGroup = ref(null);
     const standingsAgeGroupId = ref(null);
     const standingsGroup = ref(null);
+
+    // ── inline match detail (preview) navigation ──
+    // When set, MatchDetailView replaces the tournament page (same pattern
+    // as MatchesView). Back button clears it.
+    const selectedMatchId = ref(null);
+    const viewMatch = match => {
+      selectedMatchId.value = match.id;
+    };
+    const handleBackFromMatchDetail = () => {
+      selectedMatchId.value = null;
+    };
 
     // ── helpers ──
 
@@ -1046,6 +1093,9 @@ export default {
       standingsGroups,
       standingsGroup,
       standingsMatches,
+      selectedMatchId,
+      viewMatch,
+      handleBackFromMatchDetail,
     };
   },
 };


### PR DESCRIPTION
## Summary

Replaces the dead-gray `Scheduled` badge in the Tournament List view with a clickable **Preview** link, and makes the whole match row clickable. Clicking opens `MatchDetailView` inline (same swap pattern as `MatchesView`); the detail view's back button restores the tournament page with the same selected tournament + view mode.

Linear: https://linear.app/silverbeer/issue/SB-30

## Changes

- `TournamentMatchCenter.vue` imports `MatchDetailView` and adds an inline-swap (`selectedMatchId` ref, `viewMatch`, `handleBackFromMatchDetail`).
- Three match-row sections (group_stage, knockout, untagged) all get `@click="viewMatch(match)"`, brand-hover styling, and `cursor-pointer`.
- All six `Scheduled` labels (mobile + desktop × 3 sections) become `Preview`, brand-color, hover underline.
- `Final` / `Live` / `Cancelled` status badges left unchanged — they're informative status hints; the row click still navigates.

No backend changes — `MatchDetailView` self-fetches by `matchId`.

## Test plan

- [ ] Tournaments → 2026 IFA MEMORIAL DAY CUP → List → each row has hover state + cursor pointer.
- [ ] Right-hand label on scheduled matches reads **Preview** in brand color, not **Scheduled**.
- [ ] Click row OR Preview label → MatchDetailView opens in place of the tournament list.
- [ ] Back from detail → tournament list reappears with same tournament + view mode selected.
- [ ] Completed/Live/Cancelled matches still show their status badge; row clicks still navigate.
- [ ] No regression on Bracket view (SB-27) or Standings view (SB-29).

## Notes for reviewer

- I did **not** visually verify in a browser session — please eyeball hover, link styling, and back-button restore. Lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)