### PR TITLE
feat(tournaments): pop match detail as modal overlay

### DIFF
--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -1,13 +1,45 @@
 <template>
-  <!-- Inline match detail: replaces the tournament page when a row is clicked. -->
-  <MatchDetailView
+  <!-- Match detail modal: overlays the tournament page when a row or bracket cell is clicked. -->
+  <div
     v-if="selectedMatchId"
-    :matchId="selectedMatchId"
-    @back="handleBackFromMatchDetail"
-  />
+    class="fixed inset-0 z-50 bg-black/60 overflow-y-auto"
+    @click.self="handleBackFromMatchDetail"
+  >
+    <div class="min-h-full flex items-start justify-center p-3 sm:p-6">
+      <div
+        class="relative w-full max-w-4xl bg-white rounded-lg shadow-2xl"
+        @click.stop
+      >
+        <button
+          type="button"
+          aria-label="Close match details"
+          class="absolute top-2 right-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+          @click="handleBackFromMatchDetail"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+        <MatchDetailView
+          :matchId="selectedMatchId"
+          @back="handleBackFromMatchDetail"
+        />
+      </div>
+    </div>
+  </div>
 
   <div
-    v-else
     :class="
       viewMode === 'bracket' || viewMode === 'standings'
         ? 'max-w-7xl mx-auto'
@@ -643,7 +675,10 @@
             </div>
           </div>
 
-          <TournamentBracket :matches="bracketMatches" />
+          <TournamentBracket
+            :matches="bracketMatches"
+            @match-click="viewMatch"
+          />
         </template>
 
         <!-- ── Standings view ── -->


### PR DESCRIPTION
## Summary
- Clicking a bracket cell now opens MatchDetailView as a modal on top of the bracket, instead of replacing the entire tournament page.
- Same modal behavior also applies to list/standings match rows (consistent UX across views).
- Backdrop click, close (×) button, and the in-component back button all dismiss the modal.

## Test plan
- [ ] Tournaments tab → 2026 MLS NEXT Cup → toggle Bracket view → click any matchup → modal opens with MatchDetailView, bracket visible behind
- [ ] Close via X button → returns to bracket
- [ ] Close via backdrop click → returns to bracket
- [ ] Close via in-component Back button → returns to bracket
- [ ] Same modal pop works from the List view (existing clickable rows)
- [ ] Same modal pop works from Standings (clickable group-stage rows)
- [ ] Mobile width — modal scrolls if MatchDetailView is taller than viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)