### PR TITLE
fix(ig-share-card): SVG torn edge in PNG + solid MATCH PREVIEW + polish

### DIFF
--- a/frontend/src/components/ig/IgSplit.vue
+++ b/frontend/src/components/ig/IgSplit.vue
@@ -286,13 +286,12 @@ export default {
   font-style: italic;
   transform: skewX(-4deg);
   transform-origin: left center;
-  text-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
-  /* Tiny gradient on the type for extra polish. */
-  background: linear-gradient(180deg, #ffffff 0%, #cbd5e1 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
+  /* Solid white + layered shadow for depth. Avoid background-clip:text;
+     html2canvas renders that as transparent in the downloaded PNG. */
+  color: #ffffff;
+  text-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.25),
+    0 6px 24px rgba(0, 0, 0, 0.55);
 }
 
 .matchup {


### PR DESCRIPTION
## Summary
Two follow-ups to #363, bundled because they touch the same component:

### 1. Torn edge now renders in the downloaded PNG (SVG-based fix)
html2canvas does not honor \`clip-path: polygon()\`, so the diagonal torn-paper boundary shipped in #363 was **invisible in the Copy-to-Clipboard / Download PNG output**. Rewrite IgSplit so the panel + footer shapes are drawn as inline SVG \`<path>\`s (html2canvas captures SVG reliably) with text/crests stacked on top as a separate transparent layer.

### 2. MATCH PREVIEW visible in the PNG
The gradient-text technique (\`background-clip: text\` + transparent fill) rendered in the live preview but came out as transparent in the captured PNG. Swap to solid white + a two-layer drop-shadow.

### Bundled polish
- **U14 chip**: asymmetric padding compensates for the trailing letter-spacing so the label sits optically centered in the box.
- **VS / Score**: switched to Impact italic with a 6° skew + red accent for a sharper, broadcast-style look.
- **Matchup row**: bigger gap (28px), bigger crests (128px), more vertical breathing room between crest and team name.
- **Footer band**: dedicated 92px-tall row pinned to the bottom with centered content and slightly larger row gap.

## Test plan
- [ ] Match → Instagram → Brand Split → preview shows torn diagonal edge with red footer
- [ ] **Copy to clipboard** → paste anywhere → torn edge is visible (no straight cut)
- [ ] **Download PNG** → torn edge AND MATCH PREVIEW text are both visible
- [ ] U14/U15/U16/U17/U19 chips look centered
- [ ] VS and Score have the new italic-skew look
- [ ] Other templates (Photo Overlay, Tournament Round, Stadium) unaffected
- [ ] Photo gets cropped/positioned correctly on the right half

🤖 Generated with [Claude Code](https://claude.com/claude-code)