### PR TITLE
feat(ig-share-card): SVG-based torn edge in PNG + matchup/footer polish

### DIFF
--- a/frontend/src/components/ig/IgSplit.vue
+++ b/frontend/src/components/ig/IgSplit.vue
@@ -1,8 +1,10 @@
 <template>
   <!--
-    Brand Split template (SB-32). Left = solid navy brand panel with big
+    Brand Split template (SB-32). Left = navy brand panel with big
     wordmark + crests + date. Right = photo. Inspired by MLS Next Pro
-    match-preview cards.
+    match-preview cards. The boundary between the two halves is rendered
+    as an SVG `<path>` (not CSS clip-path) so html2canvas captures the
+    torn-paper effect reliably in the downloaded PNG.
   -->
   <div
     ref="root"
@@ -11,8 +13,55 @@
     data-template="split"
     :data-mode="mode"
   >
-    <!-- Brand panel — clip-path gives the right edge a torn-paper look. -->
-    <div class="panel" :style="{ clipPath: tornClipPath }">
+    <!-- Photo layer (full bleed, behind everything). background-image,
+         not <img>, so html2canvas honors cover cropping. -->
+    <div
+      v-if="photoSrc"
+      class="photo"
+      data-testid="ig-photo"
+      :style="{ backgroundImage: `url(${photoSrc})` }"
+    ></div>
+    <div v-else class="photo-fallback" data-testid="ig-photo-fallback"></div>
+
+    <!-- SVG-rendered panel + footer shapes. html2canvas handles SVG
+         paths reliably; CSS clip-path does NOT survive the capture. -->
+    <svg
+      class="panel-svg"
+      viewBox="0 0 1080 1080"
+      preserveAspectRatio="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient
+          id="ig-split-grad"
+          x1="0"
+          y1="0"
+          x2="0"
+          y2="1080"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0%" stop-color="#0f172a" />
+          <stop offset="100%" stop-color="#0a1224" />
+        </linearGradient>
+        <radialGradient
+          id="ig-split-glow"
+          cx="0"
+          cy="0"
+          r="540"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0%" stop-color="rgba(220, 38, 38, 0.18)" />
+          <stop offset="100%" stop-color="rgba(220, 38, 38, 0)" />
+        </radialGradient>
+      </defs>
+      <path :d="panelPath" fill="url(#ig-split-grad)" />
+      <path :d="panelPath" fill="url(#ig-split-glow)" />
+      <path :d="footerPath" fill="#dc2626" />
+    </svg>
+
+    <!-- Panel content sits on top of the SVG fills. No background. -->
+    <div class="panel-content">
       <div class="panel-top">
         <div class="panel-top-row">
           <div class="panel-top-text">
@@ -101,16 +150,6 @@
         </div>
       </div>
     </div>
-
-    <!-- Photo layer (full bleed, behind panel). background-image, not <img>,
-         so html2canvas honors cover cropping. -->
-    <div
-      v-if="photoSrc"
-      class="photo"
-      data-testid="ig-photo"
-      :style="{ backgroundImage: `url(${photoSrc})` }"
-    ></div>
-    <div v-else class="photo-fallback" data-testid="ig-photo-fallback"></div>
   </div>
 </template>
 
@@ -118,6 +157,12 @@
 import { computed, ref, toRefs } from 'vue';
 import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
+
+// Card height in SVG userSpace units (matches viewBox + .ig-share-card px).
+const CARD_HEIGHT = 1080;
+// Height of the red footer band (px).
+const FOOTER_HEIGHT = 92;
+const FOOTER_TOP = CARD_HEIGHT - FOOTER_HEIGHT;
 
 export default {
   name: 'IgSplit',
@@ -140,38 +185,70 @@ export default {
       props.photoIsCrossOrigin ? 'anonymous' : null
     );
 
-    // Torn-paper clip-path for the panel's right edge. The base x lerps
-    // from `topX` to `bottomX` so the tear leans diagonally (panel is
-    // wider at the top, narrower at the bottom). Deterministic
-    // pseudo-random jaggies along the way. clip-path: polygon() because
-    // html2canvas handles it more reliably than masks.
-    const tornClipPath = computed(() => {
+    // Torn-paper edge points (deterministic). The base x lerps from
+    // `topX` (wider at top) to `bottomX` (narrower at bottom), so the
+    // tear leans diagonally. Pseudo-random jaggies (sin-based hash)
+    // produce the same shape on every render.
+    const tornEdgePoints = computed(() => {
       const topX = 600;
       const bottomX = 480;
-      const height = 1080;
       const hash = n => {
         const s = Math.sin(n) * 43758.5453;
         return s - Math.floor(s);
       };
-      const points = ['0px 0px', `${topX}px 0px`];
+      const points = [[topX, 0]];
       let y = 0;
       let i = 1;
-      while (y < height) {
+      while (y < CARD_HEIGHT) {
         const step = 16 + hash(i * 7) * 22;
-        y = Math.min(y + step, height);
-        if (y >= height) break;
-        const baseX = topX + ((bottomX - topX) * y) / height;
+        y = Math.min(y + step, CARD_HEIGHT);
+        if (y >= CARD_HEIGHT) break;
+        const baseX = topX + ((bottomX - topX) * y) / CARD_HEIGHT;
         let xOffset = (hash(i * 13) - 0.5) * 28;
         if (hash(i * 17) > 0.72) {
           xOffset += (hash(i * 23) - 0.4) * 52;
         }
-        const x = baseX + xOffset;
-        points.push(`${x.toFixed(1)}px ${y.toFixed(1)}px`);
+        points.push([baseX + xOffset, y]);
         i++;
       }
-      points.push(`${bottomX}px ${height}px`);
-      points.push(`0px ${height}px`);
-      return `polygon(${points.join(', ')})`;
+      points.push([bottomX, CARD_HEIGHT]);
+      return points;
+    });
+
+    const panelPath = computed(() => {
+      const pts = tornEdgePoints.value;
+      const parts = ['M 0 0'];
+      for (const [x, y] of pts) {
+        parts.push(`L ${x.toFixed(1)} ${y.toFixed(1)}`);
+      }
+      parts.push(`L 0 ${CARD_HEIGHT}`);
+      parts.push('Z');
+      return parts.join(' ');
+    });
+
+    // Footer band: red strip at the bottom, bounded by the torn edge
+    // (so it doesn't overrun into the photo half).
+    const footerPath = computed(() => {
+      const pts = tornEdgePoints.value;
+      for (let idx = 0; idx < pts.length - 1; idx++) {
+        const [x1, y1] = pts[idx];
+        const [x2, y2] = pts[idx + 1];
+        if (y1 <= FOOTER_TOP && y2 >= FOOTER_TOP) {
+          const t = y2 === y1 ? 0 : (FOOTER_TOP - y1) / (y2 - y1);
+          const startX = x1 + (x2 - x1) * t;
+          const parts = [
+            `M 0 ${FOOTER_TOP}`,
+            `L ${startX.toFixed(1)} ${FOOTER_TOP}`,
+          ];
+          for (let j = idx + 1; j < pts.length; j++) {
+            parts.push(`L ${pts[j][0].toFixed(1)} ${pts[j][1].toFixed(1)}`);
+          }
+          parts.push(`L 0 ${CARD_HEIGHT}`);
+          parts.push('Z');
+          return parts.join(' ');
+        }
+      }
+      return '';
     });
 
     return {
@@ -179,7 +256,8 @@ export default {
       ...data,
       photoCrossOrigin,
       tagline: IG_SHARE_TAGLINE,
-      tornClipPath,
+      panelPath,
+      footerPath,
     };
   },
 };
@@ -199,21 +277,58 @@ export default {
   isolation: isolate;
 }
 
-.panel {
+.photo,
+.photo-fallback {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+}
+
+.photo {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.photo-fallback {
+  background:
+    radial-gradient(
+      circle at 30% 30%,
+      rgba(59, 130, 246, 0.4),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 70% 70%,
+      rgba(239, 68, 68, 0.35),
+      transparent 55%
+    ),
+    linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
+}
+
+.panel-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.panel-content {
   position: absolute;
   top: 0;
   left: 0;
-  width: 620px;
+  width: 580px;
   height: 100%;
-  z-index: 2;
+  z-index: 3;
   /* Right padding clears the diagonal torn-edge (top ~600, bottom ~480)
-     so content stays inside the visible polygon at every y. */
-  padding: 56px 140px 48px 48px;
+     so content stays within the visible polygon at every y. The bottom
+     padding is 0 because the footer-band is absolutely positioned. */
+  padding: 56px 140px 0 48px;
   display: flex;
   flex-direction: column;
-  background:
-    radial-gradient(circle at 0% 0%, rgba(220, 38, 38, 0.18), transparent 55%),
-    linear-gradient(180deg, #0f172a 0%, #0a1224 100%);
 }
 
 .panel-top {
@@ -258,18 +373,20 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 12px;
+  gap: 16px;
 }
 
 .hero-eyebrow {
   display: inline-block;
   align-self: flex-start;
-  padding: 8px 18px;
+  /* Asymmetric padding compensates for the trailing letter-spacing so
+     the label (e.g. "U14") looks optically centered inside the chip. */
+  padding: 8px 12px 8px 20px;
   background: #dc2626;
   color: #ffffff;
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 800;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   border-radius: 4px;
 }
 
@@ -286,8 +403,6 @@ export default {
   font-style: italic;
   transform: skewX(-4deg);
   transform-origin: left center;
-  /* Solid white + layered shadow for depth. Avoid background-clip:text;
-     html2canvas renders that as transparent in the downloaded PNG. */
   color: #ffffff;
   text-shadow:
     0 2px 0 rgba(0, 0, 0, 0.25),
@@ -296,25 +411,26 @@ export default {
 
 .matchup {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  margin-top: 32px;
+  gap: 28px;
+  margin-top: 48px;
   margin-bottom: 32px;
+  padding-right: 12px;
 }
 
 .crest-block {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 18px;
   flex: 1;
   min-width: 0;
 }
 
 .crest {
-  width: 120px;
-  height: 120px;
+  width: 128px;
+  height: 128px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -340,9 +456,9 @@ export default {
 }
 
 .team-name {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 700;
-  line-height: 1.15;
+  line-height: 1.2;
   text-align: center;
   word-break: break-word;
   max-width: 100%;
@@ -353,34 +469,54 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 80px;
+  min-width: 84px;
+  /* Match the crest height so VS sits aligned with the badges. */
+  height: 128px;
 }
 
 .vs {
-  font-size: 56px;
+  font-family:
+    Impact, 'Haettenschweiler', 'Arial Narrow Bold', 'Bebas Neue', 'Oswald',
+    sans-serif;
+  font-style: italic;
+  font-size: 78px;
   font-weight: 900;
-  letter-spacing: 0.04em;
-  color: rgba(255, 255, 255, 0.92);
+  letter-spacing: -0.02em;
+  color: #dc2626;
+  text-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.3),
+    0 6px 18px rgba(0, 0, 0, 0.55);
+  transform: skewX(-6deg);
+  line-height: 1;
 }
 
 .score {
-  font-size: 56px;
+  font-family:
+    Impact, 'Haettenschweiler', 'Arial Narrow Bold', 'Bebas Neue', 'Oswald',
+    sans-serif;
+  font-style: italic;
+  font-size: 72px;
   font-weight: 900;
   font-variant-numeric: tabular-nums;
   color: #ffffff;
   white-space: nowrap;
+  text-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.3),
+    0 6px 18px rgba(0, 0, 0, 0.55);
+  transform: skewX(-6deg);
 }
 
 .footer-band {
-  background: #dc2626;
-  /* Negative margins cancel the panel's padding so the band reaches
-     the panel's edges (left + right + bottom). The clip-path then
-     trims the band's right side along the torn edge. */
-  margin: 0 -140px -48px -48px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 92px;
   padding: 18px 140px 18px 48px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  justify-content: center;
+  gap: 8px;
   color: #ffffff;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -403,39 +539,9 @@ export default {
 
 .footer-tagline {
   text-align: center;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   letter-spacing: 0.04em;
   color: rgba(255, 255, 255, 0.95);
-}
-
-.photo,
-.photo-fallback {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.photo {
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
-.photo-fallback {
-  background:
-    radial-gradient(
-      circle at 30% 30%,
-      rgba(59, 130, 246, 0.4),
-      transparent 55%
-    ),
-    radial-gradient(
-      circle at 70% 70%,
-      rgba(239, 68, 68, 0.35),
-      transparent 55%
-    ),
-    linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
 }
 </style>


### PR DESCRIPTION
## Summary
Followup to #363 and #364. Two missed fixes from the earlier PR (it was squash-merged before the second commit landed):

### 1. Torn edge now renders in the downloaded PNG (SVG-based)
html2canvas does not honor \`clip-path: polygon()\`, so the diagonal torn-paper boundary shipped in #363 is invisible in the Copy-to-Clipboard / Download PNG output (you only see it in the live preview). Rewrite IgSplit so the panel + footer shapes are drawn as inline SVG \`<path>\`s with text/crests stacked on top as a transparent content layer. html2canvas captures SVG reliably.

### 2. Bundled polish (per design feedback)
- **U14 chip**: asymmetric padding compensates for trailing letter-spacing so the label looks optically centered.
- **VS / Score**: Impact italic with 6° skew + red accent for a broadcast-style look.
- **Matchup row**: bigger gap (28px), bigger crests (128px), more vertical breathing between crest and team name.
- **Footer band**: dedicated 92px-tall row pinned to bottom with centered content and slightly larger row gap.

## Test plan
- [ ] Match → Instagram → Brand Split → preview shows torn diagonal edge with red footer
- [ ] **Copy to clipboard** → torn edge is visible in the pasted image (no straight cut)
- [ ] **Download PNG** → torn edge AND MATCH PREVIEW text are both visible
- [ ] U14/U15/U16/U17/U19 chips look centered
- [ ] VS and Score have the new italic-skew look
- [ ] Other templates (Photo Overlay, Tournament Round, Stadium) unaffected
- [ ] Photo gets cropped/positioned correctly on the right half

🤖 Generated with [Claude Code](https://claude.com/claude-code)