### PR TITLE
feat(invite-requests): email requester when admin approves

### DIFF
--- a/backend/api/invite_requests.py
+++ b/backend/api/invite_requests.py
@@ -20,6 +20,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from auth import get_current_user_required
 from dao.match_dao import SupabaseConnection as DbConnectionHolder
+from services.email_service import EmailService
 
 # Initialize database connection with service role for admin operations
 supabase_url = os.getenv("SUPABASE_URL", "")
@@ -266,14 +267,36 @@ async def update_invite_request_status(
 
         result = service_client.table("invite_requests").update(update_data).eq("id", request_id).execute()
 
-        if result.data:
-            return {
-                "success": True,
-                "message": f"Invite request {status_update.status}",
-                "request": result.data[0],
-            }
-        else:
+        if not result.data:
             raise HTTPException(status_code=500, detail="Failed to update invite request")
+
+        updated_request = result.data[0]
+
+        # On approval, send a heads-up email to the requester. The actual
+        # invitation (with a redemption code) is still created by the admin
+        # via the Create Invite UI; this email closes the "nothing happened"
+        # UX gap so the requester knows their request was seen. Email
+        # failures are logged but never fail the API call.
+        email_sent = False
+        if status_update.status == "approved":
+            try:
+                email_service = EmailService()
+                email_sent = email_service.send_invite_request_approval(
+                    to_email=updated_request["email"],
+                    name=updated_request["name"],
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to send invite-request approval email",
+                    extra={"request_id": request_id},
+                )
+
+        return {
+            "success": True,
+            "message": f"Invite request {status_update.status}",
+            "request": updated_request,
+            "email_sent": email_sent,
+        }
 
     except HTTPException:
         raise

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -89,3 +89,74 @@ class EmailService:
         except Exception as e:
             logger.error(f"Failed to send password reset email: {e}")
             return False
+
+    def send_invite_request_approval(self, to_email: str, name: str) -> bool:
+        """
+        Notify a requester that their join request was approved.
+
+        The actual invitation (with a redemption code) is still created
+        manually by an admin via the existing Create Invite UI; this
+        email is a heads-up so the requester knows their request was
+        seen and accepted.
+
+        Args:
+            to_email: Recipient email address
+            name: Requester's name (for personalisation)
+
+        Returns:
+            True on success, False on failure
+        """
+        html_body = f"""
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Your Missing Table request was approved</title>
+</head>
+<body style="font-family: Arial, sans-serif; background: #f3f4f6; padding: 32px;">
+  <div style="max-width: 480px; margin: 0 auto; background: #fff; border-radius: 8px; padding: 32px;">
+    <h2 style="color: #16a34a;">You're approved! 🎉</h2>
+    <p>Hi <strong>{name}</strong>,</p>
+    <p>Good news — your request to join Missing Table has been approved.</p>
+    <p>
+      We'll send you a separate invite link shortly so you can finish
+      setting up your account. Keep an eye on this inbox.
+    </p>
+    <p style="color: #6b7280; font-size: 13px;">
+      Questions in the meantime? Just reply to this email.
+    </p>
+    <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
+    <p style="color: #9ca3af; font-size: 12px;">Missing Table · missingtable.com</p>
+  </div>
+</body>
+</html>
+"""
+
+        text_body = (
+            f"Hi {name},\n\n"
+            "Good news — your request to join Missing Table has been "
+            "approved.\n\n"
+            "We'll send you a separate invite link shortly so you can "
+            "finish setting up your account. Keep an eye on this inbox.\n\n"
+            "Questions in the meantime? Just reply to this email.\n\n"
+            "— Missing Table"
+        )
+
+        try:
+            resend.Emails.send(
+                {
+                    "from": self.from_address,
+                    "to": [to_email],
+                    "subject": "Your Missing Table request was approved",
+                    "html": html_body,
+                    "text": text_body,
+                }
+            )
+            logger.info(
+                "invite_request_approval_email_sent",
+                extra={"recipient": to_email[:3] + "***"},
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to send invite-request approval email: {e}")
+            return False


### PR DESCRIPTION
## Summary
When an admin approves an invite-request, the requester now receives a heads-up email so they know their request was seen. Closes the silent-approval UX gap raised on Slack.

**Scope is intentionally tight.** Today this is a *notification* email only — it tells the requester "you're approved, expect an invite link shortly." Admins still create the actual invitation (with redemption code) via the existing Create Invite UI.

**Why not fully auto-create the invitation here?** The \`invitations\` table requires an \`invite_type\` (\`club_manager\` / \`club_fan\` / \`team_manager\` / \`team_player\` / \`team_fan\`) plus a target (\`club_id\` or \`team_id\` + \`age_group_id\`). The \`invite_requests\` table doesn't capture any of those today — \`team\` is just free text. To close the loop end-to-end the admin needs to pick those at approval time, which means extending both the approval payload and the admin UI. A clean follow-up.

## How it works
- \`PUT /api/invite-requests/{id}/status\` with \`{ "status": "approved" }\` triggers a Resend email via the existing \`EmailService\`.
- New method: \`EmailService.send_invite_request_approval(to_email, name)\` — mirrors the existing password-reset email pattern.
- Email send failures are logged but never fail the approval API call.
- The approval response now includes \`email_sent: bool\` so the UI can surface a confirmation later.

## Test plan
- [ ] Local: log in as admin, submit a public invite request via the join form, approve it, verify Resend log shows the email
- [ ] Prod (post-merge): approve a real pending request, requester gets the email at the address on file
- [ ] Reject a request → no email sent
- [ ] If Resend is misconfigured (e.g. RESEND_API_KEY missing), approval still succeeds and \`email_sent: false\` is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)