### PR TITLE
feat(email): Reply-To header on transactional emails

### DIFF
--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -22,6 +22,26 @@ class EmailService:
         resend.api_key = api_key
         self.from_address = os.getenv("RESEND_FROM_ADDRESS", "noreply@contact.missingtable.com")
         self.app_base_url = os.getenv("APP_BASE_URL", "https://missingtable.com")
+        # Optional. If set, every outgoing email includes a Reply-To header
+        # pointing at this address so user replies route to a monitored
+        # inbox instead of the noreply@ from-address.
+        self.reply_to = os.getenv("RESEND_REPLY_TO") or None
+
+    def _build_send_payload(
+        self, to_email: str, subject: str, html: str, text: str
+    ) -> dict:
+        """Common Resend payload with optional Reply-To."""
+        payload = {
+            "from": self.from_address,
+            "to": [to_email],
+            "subject": subject,
+            "html": html,
+            "text": text,
+        }
+        if self.reply_to:
+            # Resend expects a list of strings here.
+            payload["reply_to"] = [self.reply_to]
+        return payload
 
     def send_password_reset(self, to_email: str, reset_token: str, username: str) -> bool:
         """
@@ -76,13 +96,12 @@ class EmailService:
 
         try:
             resend.Emails.send(
-                {
-                    "from": self.from_address,
-                    "to": [to_email],
-                    "subject": "Reset your Missing Table password",
-                    "html": html_body,
-                    "text": text_body,
-                }
+                self._build_send_payload(
+                    to_email=to_email,
+                    subject="Reset your Missing Table password",
+                    html=html_body,
+                    text=text_body,
+                )
             )
             logger.info("password_reset_email_sent", extra={"recipient": to_email[:3] + "***"})
             return True
@@ -188,13 +207,12 @@ class EmailService:
 
         try:
             resend.Emails.send(
-                {
-                    "from": self.from_address,
-                    "to": [to_email],
-                    "subject": subject,
-                    "html": html_body,
-                    "text": text_body,
-                }
+                self._build_send_payload(
+                    to_email=to_email,
+                    subject=subject,
+                    html=html_body,
+                    text=text_body,
+                )
             )
             logger.info(
                 "invitation_email_sent",
@@ -262,13 +280,12 @@ class EmailService:
 
         try:
             resend.Emails.send(
-                {
-                    "from": self.from_address,
-                    "to": [to_email],
-                    "subject": "Your Missing Table request was approved",
-                    "html": html_body,
-                    "text": text_body,
-                }
+                self._build_send_payload(
+                    to_email=to_email,
+                    subject="Your Missing Table request was approved",
+                    html=html_body,
+                    text=text_body,
+                )
             )
             logger.info(
                 "invite_request_approval_email_sent",

--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -25,6 +25,11 @@ backend:
     appBaseUrl: "https://missingtable.com"
     extra:
       CACHE_ENABLED: "true"
+      # When set, every transactional email (password reset, invite,
+      # request approval) includes this Reply-To header so user replies
+      # land in a monitored inbox instead of the noreply@ from-address.
+      # Change this to whatever inbox you actually read.
+      RESEND_REPLY_TO: "support@missingtable.com"
 
 # Live-match notifications (explicit override — defaults to true in values.yaml)
 # The TELEGRAM_BOT_TOKEN key inside the ESO-managed missing-table-secrets must


### PR DESCRIPTION
## Summary
Users replying to the \`noreply@contact.missingtable.com\` from-address had their replies go into a black hole — no inbox is monitoring it, and most mail clients warn against replying anyway.

This PR adds an optional \`RESEND_REPLY_TO\` env var. When set, every outgoing transactional email carries a \`Reply-To\` header so user replies land in a real support inbox while the verified-sender from-address stays as-is for Resend.

## How it works
- New \`EmailService._build_send_payload()\` centralises the Resend payload + tacks on \`reply_to: [self.reply_to]\` when the env var is set.
- All three send methods (\`send_password_reset\`, \`send_invitation\`, \`send_invite_request_approval\`) route through it. Consistent behavior across all templates.
- If \`RESEND_REPLY_TO\` is unset, nothing changes — payload omits the header.

## Configuration
\`helm/values-prod.yaml\` seeds \`RESEND_REPLY_TO\` with \`support@missingtable.com\`. **Two options for what to actually use:**
1. **Use \`support@missingtable.com\`** — set up Gmail / Cloudflare Email Routing to forward replies to your personal inbox. Most professional-looking.
2. **Use your personal email directly** — change the value in this PR before merge, replies land in your inbox immediately. Simpler, slightly leaks the address.

## Test plan
- [ ] Merge + deploy → admin creates a club_fan invitation for a test address
- [ ] Recipient receives the email, taps Reply → composer pre-fills the configured \`reply_to\` address (not the noreply@)
- [ ] Send a real reply → it actually reaches that inbox
- [ ] Same for password-reset and approval-notification emails
- [ ] Unset the env var → emails still send, no Reply-To header

🤖 Generated with [Claude Code](https://claude.com/claude-code)