### PR TITLE
feat(admin-invites): surface recipient email in the invites table

### DIFF
--- a/frontend/src/components/admin/AdminInvites.vue
+++ b/frontend/src/components/admin/AdminInvites.vue
@@ -144,6 +144,10 @@
             data-testid="invite-email-input"
             class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
+          <p class="text-xs text-gray-500 mt-1">
+            If provided, the invite link will be auto-emailed to this address
+            once the invite is created.
+          </p>
         </div>
 
         <!-- Note (Optional) -->
@@ -378,6 +382,11 @@
               <th
                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
               >
+                Email Sent To
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
                 Status
               </th>
               <th
@@ -428,6 +437,33 @@
                 <template v-else>
                   {{ invite.teams?.name }} - {{ invite.age_groups?.name }}
                 </template>
+              </td>
+              <td
+                class="px-6 py-4 whitespace-nowrap text-sm"
+                data-testid="invite-email-cell"
+              >
+                <span
+                  v-if="invite.email"
+                  :title="`Invite email auto-sent to ${invite.email}`"
+                  class="inline-flex items-center gap-1 text-gray-700"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-3.5 h-3.5 text-green-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M3 8l9 6 9-6M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    />
+                  </svg>
+                  {{ invite.email }}
+                </span>
+                <span v-else class="text-gray-300">—</span>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <span


### PR DESCRIPTION
## Summary
After creating an invite with an email address, there was no way to tell from the Existing Invites table who it had been sent to or whether the auto-email even fired. The data (\`invite.email\`) was already stored — just not displayed.

## What changes
- **New "Email Sent To" column** between Club/Team and Status. Shows the recipient address with a small envelope icon. Hover tooltip says "Invite email auto-sent to <addr>". Renders an em-dash when no email was supplied at create time.
- **Hint under the Email input** on the create form so admins know that filling it in triggers a send.

## Why this is the right scope
- No backend change — \`/api/invites/my-invites\` already returns the email field (\`select("*", …)\` on invitations).
- No new column to the invitations schema needed.
- Keeps the "did we email?" signal as a proxy for "is invite.email non-null" — same logic as the auto-send in #369. Old invitations created before #369 will show the email if one was supplied at creation time; the proxy is "good-enough" for now. A precise \`email_sent_at\` timestamp + a way to manually re-send the invite-code email is a natural follow-up.

## Test plan
- [ ] Create an invite WITH an email → row appears with envelope + address, tooltip shows "auto-sent to …"
- [ ] Create an invite WITHOUT an email → row shows em-dash
- [ ] Existing invites that were created before #369 → if they had an email, address shows (with the same tooltip wording even though no email was actually sent at the time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)