### PR TITLE
feat(support): add support@ discoverability to invite + registration + user menu

### DIFF
--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -11,6 +11,23 @@ import resend
 
 logger = logging.getLogger(__name__)
 
+SUPPORT_EMAIL = "support@missingtable.com"
+
+
+def _support_html_block() -> str:
+    """Inline support line for invite-flow HTML emails."""
+    return (
+        '<p style="color: #6b7280; font-size: 13px; margin-top: 16px;">'
+        "Need help? Contact us at "
+        f'<a href="mailto:{SUPPORT_EMAIL}" style="color: #2563eb;">{SUPPORT_EMAIL}</a>.'
+        "</p>"
+    )
+
+
+def _support_text_block() -> str:
+    """Inline support line for invite-flow plain-text emails."""
+    return f"Need help? Contact us at {SUPPORT_EMAIL}.\n\n"
+
 
 class EmailService:
     """Thin wrapper around the Resend SDK for sending transactional emails."""
@@ -188,6 +205,7 @@ class EmailService:
       Or paste this code on the signup page: <strong>{invite_code}</strong>
     </p>
     {expiry_html}
+    {_support_html_block()}
     <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
     <p style="color: #9ca3af; font-size: 12px;">Missing Table · missingtable.com</p>
   </div>
@@ -202,6 +220,7 @@ class EmailService:
             f"{redemption_url}\n\n"
             f"Or paste this code on the signup page: {invite_code}\n\n"
             f"{expiry_text}"
+            f"{_support_text_block()}"
             "— Missing Table"
         )
 
@@ -258,9 +277,7 @@ class EmailService:
       We'll send you a separate invite link shortly so you can finish
       setting up your account. Keep an eye on this inbox.
     </p>
-    <p style="color: #6b7280; font-size: 13px;">
-      Questions in the meantime? Just reply to this email.
-    </p>
+    {_support_html_block()}
     <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
     <p style="color: #9ca3af; font-size: 12px;">Missing Table · missingtable.com</p>
   </div>
@@ -274,7 +291,7 @@ class EmailService:
             "approved.\n\n"
             "We'll send you a separate invite link shortly so you can "
             "finish setting up your account. Keep an eye on this inbox.\n\n"
-            "Questions in the meantime? Just reply to this email.\n\n"
+            f"{_support_text_block()}"
             "— Missing Table"
         )
 

--- a/frontend/src/__tests__/components/SupportEmailLink.spec.js
+++ b/frontend/src/__tests__/components/SupportEmailLink.spec.js
@@ -1,0 +1,59 @@
+/**
+ * SupportEmailLink.vue Tests (SB-35)
+ *
+ * Renders the support address at runtime from JS constants so the literal
+ * `support@missingtable.com` string never appears in template source. Also
+ * builds a properly-encoded mailto: href with optional subject + body.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SupportEmailLink from '@/components/SupportEmailLink.vue';
+
+describe('SupportEmailLink', () => {
+  it('renders the support address as visible text by default', () => {
+    const wrapper = mount(SupportEmailLink);
+    expect(wrapper.text()).toBe('support@missingtable.com');
+  });
+
+  it('uses displayText prop when provided instead of the raw address', () => {
+    const wrapper = mount(SupportEmailLink, {
+      props: { displayText: 'Contact support' },
+    });
+    expect(wrapper.text()).toBe('Contact support');
+  });
+
+  it('renders a mailto: href pointing at the support address', () => {
+    const wrapper = mount(SupportEmailLink);
+    const link = wrapper.find('a');
+    expect(link.attributes('href')).toBe('mailto:support@missingtable.com');
+  });
+
+  it('appends an encoded subject param when subject prop is set', () => {
+    const wrapper = mount(SupportEmailLink, {
+      props: { subject: '[MT-42] Login trouble' },
+    });
+    const href = wrapper.find('a').attributes('href');
+    expect(href).toBe(
+      'mailto:support@missingtable.com?subject=%5BMT-42%5D%20Login%20trouble'
+    );
+  });
+
+  it('appends an encoded body param when body prop is set', () => {
+    const wrapper = mount(SupportEmailLink, {
+      props: { body: 'Hi support team,\n\nI need help.' },
+    });
+    const href = wrapper.find('a').attributes('href');
+    expect(href).toContain('body=Hi%20support%20team%2C%0A%0AI%20need%20help.');
+  });
+
+  it('combines subject and body with & separator', () => {
+    const wrapper = mount(SupportEmailLink, {
+      props: { subject: 'Hello', body: 'World' },
+    });
+    const href = wrapper.find('a').attributes('href');
+    expect(href).toBe(
+      'mailto:support@missingtable.com?subject=Hello&body=World'
+    );
+  });
+});

--- a/frontend/src/components/AuthNav.vue
+++ b/frontend/src/components/AuthNav.vue
@@ -45,6 +45,14 @@
             class="dropdown-menu"
             data-testid="dropdown-menu"
           >
+            <SupportEmailLink
+              :subject="supportSubject"
+              :body="supportBody"
+              display-text="Contact support"
+              class="dropdown-item support-item"
+              data-testid="support-link"
+            />
+            <div class="dropdown-divider"></div>
             <button
               @click="handleLogout"
               class="dropdown-item logout-item"
@@ -79,9 +87,11 @@
 <script>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useAuthStore } from '@/stores/auth';
+import SupportEmailLink from '@/components/SupportEmailLink.vue';
 
 export default {
   name: 'AuthNav',
+  components: { SupportEmailLink },
   emits: ['show-login', 'logout'],
   setup(props, { emit }) {
     const authStore = useAuthStore();
@@ -178,6 +188,19 @@ export default {
       document.removeEventListener('click', handleClickOutside);
     });
 
+    const supportSubject = computed(() => {
+      const email = authStore.state.profile?.email;
+      return email ? `[Account: ${email}] Help request` : 'Help request';
+    });
+    const supportBody = computed(() => {
+      const lines = ['Hi support team,', '', 'I need help with my account.'];
+      const profile = authStore.state.profile;
+      if (profile?.email) lines.push('', `Account email: ${profile.email}`);
+      if (profile?.display_name)
+        lines.push(`Display name: ${profile.display_name}`);
+      return lines.join('\n');
+    });
+
     return {
       authStore,
       showDropdown,
@@ -187,6 +210,8 @@ export default {
       hideDropdown,
       showLogin,
       handleLogout,
+      supportSubject,
+      supportBody,
     };
   },
 };
@@ -387,6 +412,26 @@ export default {
 
 .logout-item:hover {
   background-color: #fef2f2;
+}
+
+.support-item {
+  color: #374151;
+  font-weight: 500;
+}
+
+.support-item:hover {
+  background-color: #f8fafc;
+}
+
+/* Override SupportEmailLink's default underlined-link styling when used
+   as a dropdown row. */
+:deep(.support-item.support-email-link) {
+  text-decoration: none;
+  color: #374151;
+}
+
+:deep(.support-item.support-email-link:hover) {
+  color: #111827;
 }
 
 .login-btn {

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -89,7 +89,15 @@
           class="error-message"
           data-testid="error-message"
         >
-          {{ authStore.state.error }}
+          <span>{{ authStore.state.error }}</span>
+          <p v-if="showInviteSignup" class="error-support-line">
+            Stuck? Email
+            <SupportEmailLink
+              :subject="supportSubjectForError"
+              :body="supportBodyForError"
+            />
+            and we'll help.
+          </p>
         </div>
 
         <div class="form-actions">
@@ -208,6 +216,17 @@
             Login
           </button>
         </p>
+        <p
+          v-if="showInviteSignup"
+          class="support-line"
+          data-testid="invite-support-line"
+        >
+          Need help with your invite? Contact
+          <SupportEmailLink
+            :subject="supportSubjectForInvite"
+            :body="supportBodyForInvite"
+          />.
+        </p>
       </div>
 
       <!-- Role Selection (after successful signup) -->
@@ -259,12 +278,14 @@
 </template>
 
 <script>
-import { ref, reactive, onMounted, nextTick, watch } from 'vue';
+import { ref, reactive, computed, onMounted, nextTick, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
+import SupportEmailLink from '@/components/SupportEmailLink.vue';
 
 export default {
   name: 'LoginForm',
+  components: { SupportEmailLink },
   emits: ['login-success', 'show-forgot-password'],
   setup(props, { emit }) {
     const authStore = useAuthStore();
@@ -451,6 +472,28 @@ export default {
       }
     });
 
+    const supportSubjectForInvite = computed(() =>
+      form.inviteCode
+        ? `Help with invite code ${form.inviteCode}`
+        : 'Help with my Missing Table invite'
+    );
+    const supportBodyForInvite = computed(() => {
+      const lines = ['Hi support team,', '', 'I need help with my invite.'];
+      if (form.inviteCode) lines.push('', `Invite code: ${form.inviteCode}`);
+      if (form.email) lines.push(`Email on invite: ${form.email}`);
+      return lines.join('\n');
+    });
+    const supportSubjectForError = computed(
+      () => supportSubjectForInvite.value
+    );
+    const supportBodyForError = computed(() => {
+      const lines = ['Hi support team,', '', 'I hit an error during signup:'];
+      if (authStore.state.error) lines.push('', authStore.state.error);
+      if (form.inviteCode) lines.push('', `Invite code: ${form.inviteCode}`);
+      if (form.email) lines.push(`Email on invite: ${form.email}`);
+      return lines.join('\n');
+    });
+
     return {
       authStore,
       isSignup,
@@ -470,6 +513,10 @@ export default {
       handleGoogleLogin,
       handleGoogleSignUp,
       completeProfile,
+      supportSubjectForInvite,
+      supportBodyForInvite,
+      supportSubjectForError,
+      supportBodyForError,
     };
   },
 };
@@ -558,6 +605,18 @@ export default {
   border-radius: 6px;
   margin-bottom: 1rem;
   font-size: 0.875rem;
+}
+
+.error-support-line {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #7f1d1d;
+}
+
+.support-line {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #64748b;
 }
 
 .form-actions {

--- a/frontend/src/components/SupportEmailLink.vue
+++ b/frontend/src/components/SupportEmailLink.vue
@@ -1,0 +1,53 @@
+<template>
+  <a
+    :href="mailtoHref"
+    class="support-email-link"
+    data-testid="support-email-link"
+  >
+    {{ displayText || address }}
+  </a>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  subject: {
+    type: String,
+    default: '',
+  },
+  body: {
+    type: String,
+    default: '',
+  },
+  displayText: {
+    type: String,
+    default: '',
+  },
+});
+
+const SUPPORT_USER = 'support';
+const SUPPORT_DOMAIN = 'missingtable.com';
+const address = `${SUPPORT_USER}@${SUPPORT_DOMAIN}`;
+
+const mailtoHref = computed(() => {
+  const params = [];
+  if (props.subject)
+    params.push(`subject=${encodeURIComponent(props.subject)}`);
+  if (props.body) params.push(`body=${encodeURIComponent(props.body)}`);
+  const query = params.length ? `?${params.join('&')}` : '';
+  return `mailto:${address}${query}`;
+});
+</script>
+
+<style scoped>
+.support-email-link {
+  color: #2563eb;
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.support-email-link:hover {
+  color: #1d4ed8;
+}
+</style>


### PR DESCRIPTION
## Summary

First slice of [SB-35 — Support Inbox](https://linear.app/silverbeer/issue/SB-35/support-inbox-inbound-email-replies-via-supportmissingtablecom). Makes `support@missingtable.com` discoverable to the audiences that need it, **without** exposing it on the public marketing surface (anti-spam).

- New `<SupportEmailLink />` component — single source of truth, builds the `mailto:` href at runtime from JS constants so no literal `support@missingtable.com` string ever appears in template source. Accepts optional `subject` / `body` for pre-filled mail clients.
- Invite email (HTML + text) and invite-request-approval email now include a "Need help? Contact support@…" line.
- `LoginForm.vue` shows the support link in the invite-signup flow, plus a more prominent prompt next to error messages — the highest-bounce moment for stuck invitees. Subject/body pre-filled with invite code + email for admin context.
- `AuthNav.vue` user dropdown gains a "Contact support" entry, with subject pre-filled as `[Account: jane@example.com] Help request` so admins know who's writing.

Deliberately NOT touched: public marketing pages, login page (pre-auth), anywhere indexable. Per the SB-35 design, the address stays gated behind the invite token or session.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — all 260 tests pass (6 new for SupportEmailLink)
- [x] `uv run ruff check services/email_service.py` — clean
- [x] Sanity-checked rendered HTML + text blocks via Python import
- [ ] Manual: trigger an invite from the admin panel against a real Resend send, confirm the new support line lands in inbox
- [ ] Manual: load the invite-signup page in browser, confirm support link is visible in both the form footer and the error message when an invalid code is entered
- [ ] Manual: log in, open user dropdown, click Contact support, confirm mail client opens with `[Account: ...]` subject

Linear: SB-35

🤖 Generated with [Claude Code](https://claude.com/claude-code)