### PR TITLE
feat(leaderboard): mark as Beta (stats real, 2025-2026 incomplete)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -346,6 +346,13 @@
             >
               <span v-if="tab.isLive" class="live-dot"></span>
               {{ tab.name }}
+              <span
+                v-if="tab.isBeta"
+                class="beta-badge"
+                data-testid="beta-badge"
+                aria-label="Beta feature"
+                >Beta</span
+              >
             </button>
           </nav>
           <!-- Standings -->
@@ -597,7 +604,12 @@ export default {
       { id: 'table', name: 'Table', requiresAuth: true },
       { id: 'scores', name: 'Matches', requiresAuth: true },
       { id: 'match-center', name: 'Tournaments', requiresAuth: true },
-      { id: 'leaderboard', name: 'Leaderboard', requiresAuth: true },
+      {
+        id: 'leaderboard',
+        name: 'Leaderboard',
+        requiresAuth: true,
+        isBeta: true,
+      },
       { id: 'qop', name: 'QoP', requiresAuth: true },
       {
         id: 'add-match',
@@ -1050,6 +1062,21 @@ export default {
   50% {
     opacity: 0.5;
   }
+}
+
+.beta-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #92400e;
+  background-color: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-radius: 9999px;
+  vertical-align: middle;
 }
 
 .live-tab-content {

--- a/frontend/src/components/GoalsLeaderboard.vue
+++ b/frontend/src/components/GoalsLeaderboard.vue
@@ -1,5 +1,35 @@
 <template>
   <div>
+    <!-- Beta notice -->
+    <div
+      v-if="!betaNoticeDismissed"
+      class="beta-notice"
+      data-testid="leaderboard-beta-notice"
+      role="status"
+    >
+      <div class="beta-notice-body">
+        <p>
+          <strong>Leaderboard is in beta.</strong>
+          Stats shown here are real, but our coverage of the 2025-2026 season is
+          still incomplete — some matches and goal data are missing. We're
+          targeting a full launch for the 2026-2027 season. Spot something off?
+          <SupportEmailLink
+            subject="[Leaderboard beta] Feedback"
+            :body="supportBody"
+          />.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="beta-notice-dismiss"
+        @click="dismissBetaNotice"
+        aria-label="Dismiss beta notice"
+        data-testid="leaderboard-beta-dismiss"
+      >
+        ×
+      </button>
+    </div>
+
     <!-- Filters Section -->
     <div class="mb-6 space-y-4">
       <!-- Age Group Links -->
@@ -257,9 +287,13 @@
 import { ref, onMounted, watch } from 'vue';
 import { useAuthStore } from '../stores/auth';
 import { getApiBaseUrl } from '../config/api';
+import SupportEmailLink from '@/components/SupportEmailLink.vue';
+
+const BETA_NOTICE_DISMISS_KEY = 'leaderboard-beta-notice-dismissed';
 
 export default {
   name: 'GoalsLeaderboard',
+  components: { SupportEmailLink },
   setup() {
     const authStore = useAuthStore();
     const leaderboardData = ref([]);
@@ -473,6 +507,26 @@ export default {
       fetchLeaderboardData();
     });
 
+    const betaNoticeDismissed = ref(
+      typeof window !== 'undefined' &&
+        window.sessionStorage?.getItem(BETA_NOTICE_DISMISS_KEY) === '1'
+    );
+    const dismissBetaNotice = () => {
+      betaNoticeDismissed.value = true;
+      try {
+        window.sessionStorage?.setItem(BETA_NOTICE_DISMISS_KEY, '1');
+      } catch {
+        // sessionStorage can throw in privacy modes — fine to swallow,
+        // the ref already updated for this session.
+      }
+    };
+    const supportBody = [
+      'Hi support team,',
+      '',
+      'I have feedback or a report about the Leaderboard beta:',
+      '',
+    ].join('\n');
+
     return {
       leaderboardData,
       ageGroups,
@@ -490,7 +544,59 @@ export default {
       formatPlayerName,
       error,
       loading,
+      betaNoticeDismissed,
+      dismissBetaNotice,
+      supportBody,
     };
   },
 };
 </script>
+
+<style scoped>
+.beta-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  padding: 0.875rem 1rem;
+  background-color: #fffbeb;
+  border: 1px solid #fcd34d;
+  border-radius: 8px;
+  color: #78350f;
+}
+
+.beta-notice-body {
+  flex: 1;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.beta-notice-body p {
+  margin: 0;
+}
+
+.beta-notice-body strong {
+  font-weight: 700;
+}
+
+.beta-notice-dismiss {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: #92400e;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.beta-notice-dismiss:hover {
+  background-color: #fef3c7;
+}
+</style>


### PR DESCRIPTION
## Summary

Resolves [SB-36](https://linear.app/silverbeer/issue/SB-36/mark-leaderboard-tab-as-beta-stats-real-but-incomplete-for-2025-2026). Sets explicit expectations that Leaderboard is still being tested.

- **Tab badge**: small amber "Beta" pill next to the Leaderboard tab label in the main nav. Renders via a generic `isBeta: true` flag on the tab definition so the pattern can be reused if other tabs go through beta in the future.
- **In-page notice**: amber callout at the top of `GoalsLeaderboard.vue` explaining stats are real but 2025-2026 coverage is incomplete, with a 2026-2027 launch target and a feedback link via `<SupportEmailLink />` (subject pre-filled with `[Leaderboard beta] Feedback`). Dismissible per session via sessionStorage.

Note: mobile uses the same horizontal-scrolling tab bar (no separate `<select>`), so the desktop and mobile experiences both get the badge via the single tab render.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 260/260 pass
- [ ] Manual: open the Leaderboard tab, confirm "Beta" pill is visible next to the label and the amber notice appears at the top
- [ ] Manual: dismiss the notice, refresh the tab — should reappear (session-only); switch to another tab and back without refreshing — should stay dismissed
- [ ] Manual: click the "Contact support" link in the notice and confirm the mail client opens with the `[Leaderboard beta] Feedback` subject

## Future cleanup

When 2026-2027 launches and coverage is complete, removing this is two small deletions:
- Drop `isBeta: true` from the leaderboard entry in `App.vue:600`
- Drop the `<!-- Beta notice -->` block, the `betaNoticeDismissed`/`dismissBetaNotice` setup, and the `<style scoped>` rules from `GoalsLeaderboard.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)