### PR TITLE
fix(matches): include tournament-only teams in Edit Match dropdown

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2068,6 +2068,17 @@ async def get_teams(
         # Get teams based on filters
         if match_type_id and age_group_id:
             teams = team_dao.get_teams_by_match_type_and_age_group(match_type_id, age_group_id, division_id=division_id)
+            # Tournament opponents (created via get_or_create_opponent_team)
+            # have only a team_mappings row for the age group and no
+            # team_match_types row, so the strict filter above skips them.
+            # For Tournament match edits, union them in.
+            if for_match_edit:
+                match_type = match_type_dao.get_match_type_by_id(match_type_id)
+                if match_type and (match_type.get("name") or "").lower() == "tournament":
+                    extra = team_dao.get_teams_by_age_group_mapping(age_group_id)
+                    seen = {t["id"] for t in teams}
+                    teams = teams + [t for t in extra if t["id"] not in seen]
+                    teams.sort(key=lambda t: (t.get("name") or "").lower())
         elif club_id:
             teams = team_dao.get_club_teams(club_id)
         else:

--- a/backend/dao/team_dao.py
+++ b/backend/dao/team_dao.py
@@ -168,6 +168,64 @@ class TeamDAO(BaseDAO):
 
         return teams
 
+    @dao_cache("teams:by_age_group_mapping:{age_group_id}")
+    def get_teams_by_age_group_mapping(self, age_group_id: int) -> list[dict]:
+        """Get every team that has a team_mappings row for this age group.
+
+        This is the lookup used for tournament match editing: tournament-only
+        opponents (created via get_or_create_opponent_team) have a
+        team_mappings row for the age group but no team_match_types row, so
+        the stricter get_teams_by_match_type_and_age_group filter excludes
+        them. Use this to widen the candidate set when editing a tournament
+        match.
+        """
+        mapping_response = (
+            self.client.table("team_mappings")
+            .select("team_id")
+            .eq("age_group_id", age_group_id)
+            .execute()
+        )
+        team_ids = list({r["team_id"] for r in mapping_response.data})
+        if not team_ids:
+            return []
+
+        response = (
+            self.client.table("teams")
+            .select("""
+                *,
+                team_mappings (
+                    age_groups (
+                        id,
+                        name
+                    ),
+                    divisions (
+                        id,
+                        name
+                    )
+                )
+            """)
+            .in_("id", team_ids)
+            .order("name")
+            .execute()
+        )
+
+        teams = []
+        for team in response.data:
+            age_groups = []
+            divisions_by_age_group = {}
+            if "team_mappings" in team:
+                for tag in team["team_mappings"]:
+                    if tag.get("age_groups"):
+                        age_group = tag["age_groups"]
+                        age_groups.append(age_group)
+                        if tag.get("divisions"):
+                            divisions_by_age_group[age_group["id"]] = tag["divisions"]
+            team["age_groups"] = age_groups
+            team["divisions_by_age_group"] = divisions_by_age_group
+            teams.append(team)
+
+        return teams
+
     @dao_cache("teams:by_name:{name}")
     def get_team_by_name(self, name: str) -> dict | None:
         """Get a team by name (case-insensitive exact match).


### PR DESCRIPTION
## Summary

**Hotfix** — admins cannot score Tournament matches against tournament-only opponents (e.g. SUSA FC ACADEMY) because those teams are missing from the Home/Away team dropdowns in the Edit Match modal.

## Root cause

Tournament opponents are created via `tournament_dao.get_or_create_opponent_team()` ([backend/dao/tournament_dao.py:334+](https://github.com/silverbeer/missing-table/blob/main/backend/dao/tournament_dao.py#L334)) as lightweight teams with:
- `league_id`, `division_id`, `club_id` all `null`
- A single `team_mappings` row for the age group
- **No `team_match_types` row** — by design, so they don't pollute league standings

But the dropdown's team filter, `get_teams_by_match_type_and_age_group()` ([backend/dao/team_dao.py:88](https://github.com/silverbeer/missing-table/blob/main/backend/dao/team_dao.py#L88)), queries `team_match_types` first. Any team without a matching row is silently dropped from the result. So tournament opponents never appear in Tournament match-edit dropdowns.

## Fix

- New DAO method `team_dao.get_teams_by_age_group_mapping(age_group_id)` returns every team that has a `team_mappings` row for the age group (the broader candidate set).
- API handler `/api/teams` ([backend/app.py:2069](https://github.com/silverbeer/missing-table/blob/main/backend/app.py#L2069)) detects when it's a Tournament match edit (`for_match_edit=true` + match type name `"tournament"`) and unions those teams in with the strict-filter result.
- Non-tournament match types (League/Playoff/Friendly) keep their current behavior — dropdowns there stay scoped to teams with explicit `team_match_types` registration.

## Test plan

- [x] `ruff check` — clean
- [x] Backend imports cleanly with the new code path
- [ ] **Manual (please verify)**: open the Edit Match modal for a U14 Tournament match (match ID 3053 from the repro screenshots), confirm SUSA FC ACADEMY now appears in the Home Team and Away Team dropdowns
- [ ] **Manual**: open Edit Match for a U14 League match, confirm the team list is unchanged (no tournament-only teams should bleed in)
- [ ] **Manual**: edit the SUSA match, set a score, save, confirm it persists

## Notes

- Doesn't backfill any data — purely a query change.
- The DAO method has its own cache key (`teams:by_age_group_mapping:{age_group_id}`) so it doesn't conflict with the existing match-type-scoped cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)