### PR TITLE
feat(tournaments): show kickoff time alongside match date

### DIFF
--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -270,6 +270,11 @@
                       formatMatchDate(match.match_date)
                     }}</span>
                     <span
+                      v-if="match.scheduled_kickoff"
+                      class="text-xs text-gray-400"
+                      >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
+                    >
+                    <span
                       v-if="match.age_group"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
@@ -308,7 +313,10 @@
                   <div
                     class="hidden sm:block w-24 shrink-0 text-xs text-gray-400"
                   >
-                    {{ formatMatchDate(match.match_date) }}
+                    <div>{{ formatMatchDate(match.match_date) }}</div>
+                    <div v-if="match.scheduled_kickoff" class="text-gray-500">
+                      {{ formatKickoffTime(match.scheduled_kickoff) }}
+                    </div>
                   </div>
                   <div class="hidden sm:flex gap-1 shrink-0">
                     <span
@@ -396,6 +404,11 @@
                       formatMatchDate(match.match_date)
                     }}</span>
                     <span
+                      v-if="match.scheduled_kickoff"
+                      class="text-xs text-gray-400"
+                      >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
+                    >
+                    <span
                       v-if="match.age_group"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
@@ -434,7 +447,10 @@
                   <div
                     class="hidden sm:block w-24 shrink-0 text-xs text-gray-400"
                   >
-                    {{ formatMatchDate(match.match_date) }}
+                    <div>{{ formatMatchDate(match.match_date) }}</div>
+                    <div v-if="match.scheduled_kickoff" class="text-gray-500">
+                      {{ formatKickoffTime(match.scheduled_kickoff) }}
+                    </div>
                   </div>
                   <div class="hidden sm:flex gap-1 shrink-0">
                     <span
@@ -527,6 +543,11 @@
                       formatMatchDate(match.match_date)
                     }}</span>
                     <span
+                      v-if="match.scheduled_kickoff"
+                      class="text-xs text-gray-400"
+                      >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
+                    >
+                    <span
                       v-if="match.age_group"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
@@ -560,7 +581,10 @@
                   <div
                     class="hidden sm:block w-24 shrink-0 text-xs text-gray-400"
                   >
-                    {{ formatMatchDate(match.match_date) }}
+                    <div>{{ formatMatchDate(match.match_date) }}</div>
+                    <div v-if="match.scheduled_kickoff" class="text-gray-500">
+                      {{ formatKickoffTime(match.scheduled_kickoff) }}
+                    </div>
                   </div>
                   <div class="hidden sm:flex gap-1 shrink-0">
                     <span
@@ -827,6 +851,15 @@ export default {
             weekday: 'short',
             month: 'short',
             day: 'numeric',
+          })
+        : '';
+
+    const formatKickoffTime = iso =>
+      iso
+        ? new Date(iso).toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
           })
         : '';
 
@@ -1113,6 +1146,7 @@ export default {
       untaggedMatches,
       formatDate,
       formatMatchDate,
+      formatKickoffTime,
       roundLabel,
       selectTournament,
       viewMode,


### PR DESCRIPTION
## Summary

The tournament view (Tournaments → tournament detail → match list) only showed the date for each match, so users couldn't see which match was kicking off when. Adds the scheduled kickoff time next to / under the date in all three section variants (group stage, knockout, untagged) and on both mobile and desktop layouts.

- **Mobile**: inline in the meta tag row as `Sat, May 23 · 8:00 AM`.
- **Desktop**: stacked under the date in the left date column.

Only rendered when `scheduled_kickoff` is present, so matches without a kickoff time stay clean.

`scheduled_kickoff` is already returned by the tournament endpoint ([backend/dao/tournament_dao.py:160](https://github.com/silverbeer/missing-table/blob/main/backend/dao/tournament_dao.py#L160)), so no backend change needed.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 260/260 pass
- [ ] Manual: open Tournaments → 2026 IFA Memorial Day Cup, confirm kickoff times appear next to / under dates in the match list (desktop + mobile widths)
- [ ] Manual: verify a match without a kickoff time still renders cleanly (date only, no stray "·" separator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)