### PR TITLE
feat(support): SB-35 Phase 1 — email_threads schema + inbound webhook

### DIFF
--- a/backend/api/webhooks_email.py
+++ b/backend/api/webhooks_email.py
@@ -1,0 +1,233 @@
+"""
+Inbound email webhook (Resend Inbound → support@missingtable.com).
+
+Verifies the provider's Svix signature, fetches the full ReceivedEmail
+via the Resend API, runs the threading resolver, sanitizes any HTML,
+and persists the message. Idempotent on RFC 5322 Message-ID so
+provider retries are safe.
+
+SB-35 Phase 1. The admin API (Phase 2) and admin UI (Phase 3) consume
+the rows we land here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+import resend
+import structlog
+from fastapi import APIRouter, HTTPException, Request
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dao.email_messages_dao import EmailMessagesDAO
+from dao.email_threads_dao import EmailThreadsDAO
+from dao.match_dao import SupabaseConnection as DbConnectionHolder
+from services.email_inbound import (
+    WebhookVerificationError,
+    resolve_thread,
+    sanitize_html,
+    verify_webhook,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Inbound writes bypass RLS via the service-role connection — the webhook
+# can't authenticate as a user, and HMAC verification is the trust gate.
+_db_conn = DbConnectionHolder()
+_threads_dao = EmailThreadsDAO(_db_conn)
+_messages_dao = EmailMessagesDAO(_db_conn)
+
+router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
+
+_INBOUND_EVENT_TYPE = "email.received"
+
+
+def _strip_angle_brackets(value: str | None) -> str | None:
+    """RFC 5322 Message-IDs are wrapped in `<>`. Strip them for storage so
+    our equality lookups don't have to care about the wrapping."""
+    if not value:
+        return value
+    stripped = value.strip()
+    if stripped.startswith("<") and stripped.endswith(">"):
+        return stripped[1:-1]
+    return stripped
+
+
+def _header_lookup(headers: dict[str, str] | None, *names: str) -> str | None:
+    """Case-insensitive header lookup. Returns the first match."""
+    if not headers:
+        return None
+    lower = {k.lower(): v for k, v in headers.items()}
+    for name in names:
+        value = lower.get(name.lower())
+        if value:
+            return value
+    return None
+
+
+def _extract_display_name(from_header: str) -> tuple[str, str | None]:
+    """Parse a `"Jane Doe" <jane@example.com>` style From header into
+    (address, display_name). Falls back to (raw, None) on anything weird."""
+    raw = from_header.strip()
+    if "<" in raw and raw.endswith(">"):
+        name_part, _, addr_part = raw.rpartition("<")
+        name = name_part.strip().strip('"').strip() or None
+        return addr_part[:-1].strip(), name
+    return raw, None
+
+
+@router.post("/email/inbound")
+async def email_inbound(request: Request) -> dict[str, Any]:
+    """Receive an `email.received` event from Resend Inbound.
+
+    Returns 200 on:
+    - Successful ingest
+    - Unknown event type (we ignore quietly so Resend doesn't retry)
+    - Already-seen Message-ID (idempotent retry)
+
+    Returns 401 on signature mismatch.
+    Returns 500 on internal failure — Resend will retry.
+    """
+    raw_body = await request.body()
+    payload_str = raw_body.decode("utf-8")
+
+    # Forward only the headers the verifier needs — keeps logs cleaner.
+    svix_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower().startswith("svix-")
+    }
+
+    try:
+        verify_webhook(payload=payload_str, headers=svix_headers)
+    except WebhookVerificationError as e:
+        logger.warning("email_webhook_unauthorized", error=str(e))
+        raise HTTPException(status_code=401, detail="invalid webhook signature") from e
+
+    try:
+        event = json.loads(payload_str)
+    except json.JSONDecodeError as e:
+        logger.warning("email_webhook_bad_json", error=str(e))
+        raise HTTPException(status_code=400, detail="invalid JSON payload") from e
+
+    event_type = event.get("type")
+    if event_type != _INBOUND_EVENT_TYPE:
+        logger.info("email_webhook_ignored_event", event_type=event_type)
+        return {"status": "ignored", "event_type": event_type}
+
+    data = event.get("data") or {}
+    email_id = data.get("email_id") or data.get("id")
+    if not email_id:
+        # `event` is reserved by structlog — use a different key.
+        logger.warning("email_webhook_missing_email_id", payload=event)
+        raise HTTPException(status_code=400, detail="event.data.email_id missing")
+
+    received = _fetch_received_email(email_id)
+
+    raw_message_id = received.get("message_id")
+    message_id = _strip_angle_brackets(raw_message_id)
+    if not message_id:
+        logger.warning("email_webhook_missing_message_id", email_id=email_id)
+        raise HTTPException(status_code=400, detail="received email has no message_id")
+
+    # Idempotency: if we've seen this message_id already, Resend retried.
+    existing = _messages_dao.find_by_message_id(message_id)
+    if existing:
+        logger.info(
+            "email_webhook_duplicate",
+            message_id=message_id,
+            thread_id=existing["thread_id"],
+        )
+        return {
+            "status": "duplicate",
+            "message_id": message_id,
+            "thread_id": existing["thread_id"],
+        }
+
+    # ── Extract envelope fields ─────────────────────────────────────────────
+    headers = received.get("headers") or received.get("http_headers") or {}
+    in_reply_to = _strip_angle_brackets(_header_lookup(headers, "In-Reply-To"))
+    references = _header_lookup(headers, "References")
+
+    from_raw = received.get("from") or ""
+    from_email, from_name = _extract_display_name(from_raw)
+    to_list = received.get("to") or []
+    to_email = to_list[0] if to_list else ""
+
+    subject = received.get("subject") or "(no subject)"
+    body_text = received.get("text")
+    body_html_raw = received.get("html")
+    had_attachments = bool(received.get("attachments"))
+
+    # ── Resolve / create thread ─────────────────────────────────────────────
+    last_message_at_iso = received.get("created_at")
+    thread, created = resolve_thread(
+        _threads_dao,
+        _messages_dao,
+        subject=subject,
+        from_email=from_email,
+        from_name=from_name,
+        in_reply_to=in_reply_to,
+        last_message_at_iso=last_message_at_iso,
+    )
+
+    # ── Insert inbound message ──────────────────────────────────────────────
+    sanitized_html = sanitize_html(body_html_raw)
+    # raw_payload omits attachments — we don't want the base64 bodies in pg.
+    raw_for_storage = {k: v for k, v in received.items() if k != "attachments"}
+
+    _messages_dao.insert_inbound(
+        thread_id=thread["id"],
+        message_id=message_id,
+        from_email=from_email,
+        from_name=from_name,
+        to_email=to_email,
+        subject=subject,
+        in_reply_to=in_reply_to,
+        references=references,
+        body_text=body_text,
+        body_html=sanitized_html,
+        had_attachments=had_attachments,
+        raw_payload=raw_for_storage,
+    )
+
+    # ── Status transition for existing threads ──────────────────────────────
+    # New threads start at status='new' with unread_count=1 (create_for_inbound
+    # already set both), so only transition existing threads.
+    if not created:
+        _threads_dao.transition_on_inbound(
+            thread["id"], last_message_at=last_message_at_iso
+        )
+
+    logger.info(
+        "email_webhook_ingested",
+        thread_id=thread["id"],
+        case_number=thread["case_number"],
+        message_id=message_id,
+        created_new_thread=created,
+        had_attachments=had_attachments,
+    )
+    return {
+        "status": "accepted",
+        "thread_id": thread["id"],
+        "case_number": thread["case_number"],
+        "created_new_thread": created,
+    }
+
+
+def _fetch_received_email(email_id: str) -> dict[str, Any]:
+    """Fetch the full ReceivedEmail from the Resend API.
+
+    Returns the underlying dict (ReceivedEmail is a TypedDict). Raised
+    exceptions become 502 from the caller's perspective — Resend will
+    retry, which is the right behavior for transient upstream failures.
+    """
+    try:
+        return resend.Emails.Receiving.get(email_id)
+    except Exception as e:
+        logger.exception("email_webhook_fetch_failed", email_id=email_id)
+        raise HTTPException(status_code=502, detail=f"failed to fetch email {email_id}") from e

--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ from api.channel_requests import router as channel_requests_router
 from api.club_notifications import router as club_notifications_router
 from api.invite_requests import router as invite_requests_router
 from api.invites import router as invites_router
+from api.webhooks_email import router as webhooks_email_router
 from auth import (
     AuthManager,
     get_current_user_required,
@@ -257,6 +258,7 @@ app.include_router(invites_router)
 app.include_router(invite_requests_router)
 app.include_router(channel_requests_router)
 app.include_router(club_notifications_router)
+app.include_router(webhooks_email_router)
 
 # Version endpoint
 import contextlib

--- a/backend/dao/email_messages_dao.py
+++ b/backend/dao/email_messages_dao.py
@@ -1,0 +1,113 @@
+"""
+EmailMessagesDAO — individual messages in support-inbox threads (SB-35).
+
+Phase 1 surface (webhook ingest): insert_inbound, find_by_message_id,
+find_thread_id_by_in_reply_to. Phase 2 (admin API) will add list_by_thread
+and insert_outbound for admin replies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from dao.base_dao import BaseDAO, invalidates_cache
+
+logger = structlog.get_logger()
+
+EMAIL_MESSAGES_CACHE_PATTERN = "mt:dao:email_messages:*"
+
+
+class EmailMessagesDAO(BaseDAO):
+    """Data access for the email_messages table."""
+
+    # ── reads ────────────────────────────────────────────────────────────────
+
+    def find_by_message_id(self, message_id: str) -> dict[str, Any] | None:
+        """Look up a message by its RFC 5322 Message-ID (angle brackets stripped).
+
+        Used for webhook idempotency: if the same provider event arrives twice
+        (e.g. Resend retry), the second insert hits the unique constraint —
+        but we check first so we can return 200 cleanly without an exception.
+        """
+        response = (
+            self.client.table("email_messages")
+            .select("*")
+            .eq("message_id", message_id)
+            .limit(1)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    def find_thread_id_by_in_reply_to(self, in_reply_to: str) -> str | None:
+        """Resolve the thread an inbound reply belongs to via the In-Reply-To
+        header. Returns the thread_id of the referenced message, or None if
+        we don't recognize the referenced Message-ID.
+
+        This is the first tier of the threading resolver. Falls back to
+        case-number-in-subject and then subject+sender if this misses.
+        """
+        response = (
+            self.client.table("email_messages")
+            .select("thread_id")
+            .eq("message_id", in_reply_to)
+            .limit(1)
+            .execute()
+        )
+        return response.data[0]["thread_id"] if response.data else None
+
+    # ── writes ───────────────────────────────────────────────────────────────
+
+    @invalidates_cache(EMAIL_MESSAGES_CACHE_PATTERN)
+    def insert_inbound(
+        self,
+        *,
+        thread_id: str,
+        message_id: str,
+        from_email: str,
+        to_email: str,
+        subject: str,
+        in_reply_to: str | None = None,
+        references: str | None = None,
+        from_name: str | None = None,
+        body_text: str | None = None,
+        body_html: str | None = None,
+        had_attachments: bool = False,
+        raw_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Insert a new inbound message row.
+
+        Caller is responsible for sanitizing body_html (we never insert raw
+        webhook HTML — bleach is applied upstream in the inbound service).
+
+        Raises if the unique constraint on message_id fires; the webhook
+        handler checks find_by_message_id first to make ingest idempotent.
+        """
+        payload: dict[str, Any] = {
+            "thread_id": thread_id,
+            "direction": "inbound",
+            "message_id": message_id,
+            "from_email": from_email,
+            "to_email": to_email,
+            "subject": subject,
+            "in_reply_to": in_reply_to,
+            "references": references,
+            "from_name": from_name,
+            "body_text": body_text,
+            "body_html": body_html,
+            "had_attachments": had_attachments,
+            "raw_payload": raw_payload,
+        }
+        response = self.client.table("email_messages").insert(payload).execute()
+        if not response.data:
+            raise RuntimeError("email_messages insert returned no data")
+        row = response.data[0]
+        logger.info(
+            "email_message_inserted",
+            message_id=message_id,
+            thread_id=thread_id,
+            direction="inbound",
+            had_attachments=had_attachments,
+        )
+        return row

--- a/backend/dao/email_threads_dao.py
+++ b/backend/dao/email_threads_dao.py
@@ -1,0 +1,169 @@
+"""
+EmailThreadsDAO — support-inbox conversations (SB-35).
+
+Phase 1 surface (webhook ingest): create_for_inbound, transition_on_inbound,
+get_by_id, get_by_case_number. Phase 2 (admin API) will add listing,
+status overrides, and outbound-reply transitions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from dao.base_dao import BaseDAO, invalidates_cache
+
+logger = structlog.get_logger()
+
+EMAIL_THREADS_CACHE_PATTERN = "mt:dao:email_threads:*"
+
+
+class EmailThreadsDAO(BaseDAO):
+    """Data access for the email_threads table."""
+
+    # ── reads ────────────────────────────────────────────────────────────────
+
+    def get_thread_by_id(self, thread_id: str) -> dict[str, Any] | None:
+        """Fetch a thread by UUID. Returns None if not found.
+
+        Named `get_thread_by_id` (rather than `get_by_id`) so the typed UUID
+        argument doesn't collide with BaseDAO.get_by_id(table, record_id).
+        """
+        response = (
+            self.client.table("email_threads")
+            .select("*")
+            .eq("id", thread_id)
+            .limit(1)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    def find_recent_by_participant(
+        self,
+        participant_email: str,
+        *,
+        since_iso: str,
+    ) -> list[dict[str, Any]]:
+        """Recent threads from a participant, newest first.
+
+        Used by the threading resolver's third-tier fallback: when neither
+        In-Reply-To nor a case-number-in-subject matches, look for a recent
+        thread from the same sender and merge by normalized subject upstream.
+
+        Args:
+            participant_email: external party's address (case-insensitive match)
+            since_iso: ISO timestamp lower bound (e.g. now - 30 days)
+        """
+        response = (
+            self.client.table("email_threads")
+            .select("*")
+            .ilike("participant_email", participant_email)
+            .gte("last_message_at", since_iso)
+            .order("last_message_at", desc=True)
+            .limit(20)
+            .execute()
+        )
+        return response.data or []
+
+    def get_by_case_number(self, case_number: int) -> dict[str, Any] | None:
+        """Fetch a thread by its MT-{n} case number. Returns None if not found.
+
+        Used by the threading resolver (fallback when In-Reply-To is missing
+        but the inbound subject contains `[MT-{n}]`) and by the admin UI for
+        deep-linking by case number.
+        """
+        response = (
+            self.client.table("email_threads")
+            .select("*")
+            .eq("case_number", case_number)
+            .limit(1)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    # ── writes ───────────────────────────────────────────────────────────────
+
+    @invalidates_cache(EMAIL_THREADS_CACHE_PATTERN)
+    def create_for_inbound(
+        self,
+        *,
+        subject: str,
+        participant_email: str,
+        participant_name: str | None = None,
+        last_message_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert a new thread for an inbound email that didn't match any
+        existing thread. case_number is assigned automatically from the
+        sequence; status starts as 'new'; unread_count is set to 1 since
+        this insert always pairs with an inbound message.
+
+        Args:
+            subject: subject line of the first inbound message
+            participant_email: the external party (sender of the inbound)
+            participant_name: optional display name from From header
+            last_message_at: optional ISO timestamp; defaults to now() in db
+
+        Returns:
+            The inserted row (including assigned id and case_number).
+        """
+        payload: dict[str, Any] = {
+            "subject": subject,
+            "participant_email": participant_email,
+            "participant_name": participant_name,
+            "status": "new",
+            "unread_count": 1,
+        }
+        if last_message_at:
+            payload["last_message_at"] = last_message_at
+
+        response = self.client.table("email_threads").insert(payload).execute()
+        if not response.data:
+            raise RuntimeError("email_threads insert returned no data")
+        row = response.data[0]
+        logger.info(
+            "email_thread_created",
+            thread_id=row["id"],
+            case_number=row["case_number"],
+            participant_email=participant_email,
+        )
+        return row
+
+    @invalidates_cache(EMAIL_THREADS_CACHE_PATTERN)
+    def transition_on_inbound(
+        self,
+        thread_id: str,
+        *,
+        last_message_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        """An inbound message just landed on an existing thread.
+
+        Side effects:
+        - status: 'new' / 'awaiting_admin' / 'resolved' → 'awaiting_admin'
+          (reopens 'resolved' threads on user reply).
+        - status: 'spam' → unchanged (silently absorb).
+        - unread_count += 1
+        - last_message_at = max(existing, last_message_at)
+        """
+        current = self.get_thread_by_id(thread_id)
+        if not current:
+            return None
+
+        next_status = current["status"]
+        if next_status != "spam":
+            next_status = "awaiting_admin"
+
+        updates: dict[str, Any] = {
+            "status": next_status,
+            "unread_count": (current.get("unread_count") or 0) + 1,
+        }
+        if last_message_at:
+            updates["last_message_at"] = last_message_at
+
+        response = (
+            self.client.table("email_threads")
+            .update(updates)
+            .eq("id", thread_id)
+            .execute()
+        )
+        return response.data[0] if response.data else None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "email-validator>=2.3.0",
     "debugpy>=1.8.17",
     "resend>=2.0.0",
+    "bleach>=6.2.0",
     "telegram-notify",
     "discord-notify",
 ]

--- a/backend/services/email_inbound.py
+++ b/backend/services/email_inbound.py
@@ -1,0 +1,241 @@
+"""
+Inbound-email primitives for the Support Inbox (SB-35 Phase 1).
+
+Pure-ish helpers consumed by the inbound webhook handler:
+- verify_webhook  — wraps resend.Webhooks.verify with env-driven secret + typed errors
+- sanitize_html   — bleach allowlist; never store raw provider HTML
+- parse_case_number_from_subject — `[MT-{n}]` extractor for threading fallback
+- normalize_subject — strips Re:/Fwd: + case-number tokens for fuzzy match
+- resolve_thread  — 4-tier threading resolver (creates a new thread if no match)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import bleach
+import resend
+import structlog
+
+if TYPE_CHECKING:
+    from dao.email_messages_dao import EmailMessagesDAO
+    from dao.email_threads_dao import EmailThreadsDAO
+
+logger = structlog.get_logger()
+
+
+class WebhookVerificationError(Exception):
+    """Raised when the inbound webhook signature can't be verified."""
+
+
+# ── HMAC verification ────────────────────────────────────────────────────────
+
+
+def verify_webhook(*, payload: str, headers: dict[str, str]) -> None:
+    """Verify a Resend inbound webhook using its Svix-based signature.
+
+    Loads the secret from EMAIL_INBOUND_WEBHOOK_SECRET. The payload must be
+    the raw request body string (not parsed JSON) — Svix is sensitive to
+    even whitespace differences.
+
+    Raises WebhookVerificationError on any failure (missing secret,
+    missing headers, bad signature). The webhook handler should catch
+    this and return 401.
+    """
+    secret = os.getenv("EMAIL_INBOUND_WEBHOOK_SECRET")
+    if not secret:
+        raise WebhookVerificationError(
+            "EMAIL_INBOUND_WEBHOOK_SECRET is not configured"
+        )
+
+    required = {"svix-id", "svix-timestamp", "svix-signature"}
+    missing = required - {k.lower() for k in headers}
+    if missing:
+        raise WebhookVerificationError(
+            f"Missing required webhook header(s): {sorted(missing)}"
+        )
+
+    try:
+        resend.Webhooks.verify(
+            resend.VerifyWebhookOptions(
+                payload=payload,
+                headers=headers,
+                webhook_secret=secret,
+            )
+        )
+    except Exception as e:
+        raise WebhookVerificationError(f"Signature verification failed: {e}") from e
+
+
+# ── HTML sanitization ────────────────────────────────────────────────────────
+
+# Conservative allowlist for displayed email content. We don't trust the
+# inbound payload, so we strip everything not in this set. Bleach also
+# rejects javascript: hrefs by default given the protocol allowlist below.
+_ALLOWED_TAGS = frozenset({
+    "a", "b", "blockquote", "br", "code", "div", "em", "hr",
+    "i", "li", "ol", "p", "pre", "span", "strong", "u", "ul",
+})
+_ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title"],
+    "span": ["class"],
+    "div": ["class"],
+}
+_ALLOWED_PROTOCOLS = frozenset({"http", "https", "mailto"})
+
+
+def sanitize_html(raw: str | None) -> str | None:
+    """Sanitize untrusted inbound HTML with a conservative allowlist.
+
+    Returns None for None input (so we can pass it through). Strips
+    disallowed tags rather than escaping them — we never want raw HTML
+    rendered into the admin UI.
+    """
+    if raw is None:
+        return None
+    return bleach.clean(
+        raw,
+        tags=_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRIBUTES,
+        protocols=_ALLOWED_PROTOCOLS,
+        strip=True,
+    )
+
+
+# ── Case-number / subject parsing ────────────────────────────────────────────
+
+# Matches `[MT-1234]` (any leading/trailing space) and captures the digits.
+# Case-insensitive on "MT". Doesn't match `MT-1234` without brackets — we
+# always render the case number bracketed in outbound subjects, and we
+# don't want to false-match other patterns in subjects.
+_CASE_RE = re.compile(r"\[\s*MT-(\d+)\s*\]", re.IGNORECASE)
+
+# Strips Re:/Fwd:/Fw: prefixes, possibly chained ("Re: Re: Re:"). Match
+# at the start, repeat. Case-insensitive, optional surrounding whitespace.
+_REPLY_PREFIX_RE = re.compile(r"^\s*(?:re|fwd?|fw)\s*:\s*", re.IGNORECASE)
+
+
+def parse_case_number_from_subject(subject: str | None) -> int | None:
+    """Return the integer case number embedded as `[MT-{n}]`, or None."""
+    if not subject:
+        return None
+    m = _CASE_RE.search(subject)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_subject(subject: str | None) -> str:
+    """Subject form used for fuzzy thread matching.
+
+    - strips chained Re:/Fwd: prefixes
+    - removes any [MT-{n}] token
+    - collapses internal whitespace
+    - lowercases
+    """
+    if not subject:
+        return ""
+    s = _CASE_RE.sub("", subject)
+    while True:
+        new = _REPLY_PREFIX_RE.sub("", s)
+        if new == s:
+            break
+        s = new
+    return " ".join(s.split()).lower()
+
+
+# ── Threading resolver ───────────────────────────────────────────────────────
+
+# Window for the fuzzy fallback. Anything older and we'd rather start a
+# new thread than risk merging unrelated conversations.
+_FALLBACK_WINDOW = timedelta(days=30)
+
+
+def resolve_thread(
+    threads_dao: EmailThreadsDAO,
+    messages_dao: EmailMessagesDAO,
+    *,
+    subject: str,
+    from_email: str,
+    from_name: str | None,
+    in_reply_to: str | None,
+    last_message_at_iso: str | None = None,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """Resolve the email_threads row this inbound message belongs to.
+
+    Returns (thread_row, created), where `created` is True if a new thread
+    was inserted.
+
+    Fallback chain (in order):
+    1. `In-Reply-To` matches a known message_id → reuse its thread
+    2. `[MT-{n}]` in subject → reuse the matching thread by case_number
+    3. Same participant + same normalized subject within the last 30 days
+       → reuse the most recent matching thread
+    4. Nothing matched → create a new thread (assigns a fresh case number)
+    """
+    # 1) In-Reply-To
+    if in_reply_to:
+        thread_id = messages_dao.find_thread_id_by_in_reply_to(in_reply_to)
+        if thread_id:
+            existing = threads_dao.get_thread_by_id(thread_id)
+            if existing:
+                logger.info(
+                    "email_thread_resolved",
+                    via="in_reply_to",
+                    thread_id=existing["id"],
+                    case_number=existing["case_number"],
+                )
+                return existing, False
+
+    # 2) [MT-{n}] in subject
+    case_number = parse_case_number_from_subject(subject)
+    if case_number is not None:
+        existing = threads_dao.get_by_case_number(case_number)
+        if existing:
+            logger.info(
+                "email_thread_resolved",
+                via="case_number",
+                thread_id=existing["id"],
+                case_number=existing["case_number"],
+            )
+            return existing, False
+
+    # 3) Recent participant + same normalized subject
+    normalized = normalize_subject(subject)
+    if normalized:
+        since = (now or datetime.now(UTC)) - _FALLBACK_WINDOW
+        candidates = threads_dao.find_recent_by_participant(
+            from_email,
+            since_iso=since.isoformat(),
+        )
+        for candidate in candidates:
+            if normalize_subject(candidate.get("subject")) == normalized:
+                logger.info(
+                    "email_thread_resolved",
+                    via="participant_subject",
+                    thread_id=candidate["id"],
+                    case_number=candidate["case_number"],
+                )
+                return candidate, False
+
+    # 4) New thread
+    created = threads_dao.create_for_inbound(
+        subject=subject or "(no subject)",
+        participant_email=from_email,
+        participant_name=from_name,
+        last_message_at=last_message_at_iso,
+    )
+    logger.info(
+        "email_thread_resolved",
+        via="new",
+        thread_id=created["id"],
+        case_number=created["case_number"],
+    )
+    return created, True

--- a/backend/tests/unit/test_email_inbound.py
+++ b/backend/tests/unit/test_email_inbound.py
@@ -1,0 +1,430 @@
+"""Unit tests for the inbound-email primitives (SB-35 Phase 1).
+
+Covers:
+- pure helpers in services/email_inbound (sanitizer, subject parsers, verifier)
+- resolve_thread with mock DAOs for all 4 fallback branches
+- POST /api/webhooks/email/inbound endpoint with verify + resend SDK + DAOs mocked
+
+No database. Integration tests against real Supabase land later.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("EMAIL_INBOUND_WEBHOOK_SECRET", raising=False)
+    yield
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+
+
+class TestParseCaseNumber:
+    def test_basic_bracketed(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject("[MT-42] Question") == 42
+
+    def test_with_reply_prefix(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject("Re: [MT-1042] My team") == 1042
+
+    def test_lowercase_mt(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject("[mt-7] x") == 7
+
+    def test_extra_whitespace(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject("[ MT-9 ] thing") == 9
+
+    def test_unbracketed_returns_none(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject("MT-99 in the wild") is None
+
+    def test_none_input(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject(None) is None
+
+    def test_empty_string(self):
+        from services.email_inbound import parse_case_number_from_subject
+        assert parse_case_number_from_subject("") is None
+
+
+class TestNormalizeSubject:
+    def test_strips_chained_reply_prefixes(self):
+        from services.email_inbound import normalize_subject
+        assert normalize_subject("Re: Re: RE:  Hello world") == "hello world"
+
+    def test_strips_fwd_variants(self):
+        from services.email_inbound import normalize_subject
+        assert normalize_subject("Fwd: Fw: Fwd:  Hello") == "hello"
+
+    def test_strips_case_number_token(self):
+        from services.email_inbound import normalize_subject
+        assert normalize_subject("Re: [MT-42] My Question") == "my question"
+
+    def test_collapses_whitespace(self):
+        from services.email_inbound import normalize_subject
+        assert normalize_subject("  Hello    world  ") == "hello world"
+
+    def test_none_returns_empty(self):
+        from services.email_inbound import normalize_subject
+        assert normalize_subject(None) == ""
+
+
+class TestSanitizeHtml:
+    def test_strips_script_tag(self):
+        from services.email_inbound import sanitize_html
+        # bleach strips tag but keeps inner text — that text is harmless
+        # since no <script> tag reaches the rendered DOM.
+        assert sanitize_html("<script>alert(1)</script><p>ok</p>") == "alert(1)<p>ok</p>"
+
+    def test_keeps_allowed_tags(self):
+        from services.email_inbound import sanitize_html
+        result = sanitize_html("<p><strong>Hi</strong> <em>there</em></p>")
+        assert result == "<p><strong>Hi</strong> <em>there</em></p>"
+
+    def test_strips_javascript_href(self):
+        from services.email_inbound import sanitize_html
+        assert sanitize_html('<a href="javascript:alert(1)">x</a>') == "<a>x</a>"
+
+    def test_preserves_https_href(self):
+        from services.email_inbound import sanitize_html
+        assert (
+            sanitize_html('<a href="https://example.com">x</a>')
+            == '<a href="https://example.com">x</a>'
+        )
+
+    def test_preserves_mailto(self):
+        from services.email_inbound import sanitize_html
+        assert (
+            sanitize_html('<a href="mailto:a@b.com">a</a>')
+            == '<a href="mailto:a@b.com">a</a>'
+        )
+
+    def test_strips_img_tag(self):
+        # Not on our allowlist — should be removed (inner text kept, but img has none)
+        from services.email_inbound import sanitize_html
+        assert sanitize_html('<img src="x.png" alt="x">') == ""
+
+    def test_none_passthrough(self):
+        from services.email_inbound import sanitize_html
+        assert sanitize_html(None) is None
+
+
+class TestVerifyWebhook:
+    def test_missing_secret_raises(self):
+        from services.email_inbound import WebhookVerificationError, verify_webhook
+        with pytest.raises(WebhookVerificationError, match="not configured"):
+            verify_webhook(payload="{}", headers={})
+
+    def test_missing_headers_raises(self, monkeypatch):
+        from services.email_inbound import WebhookVerificationError, verify_webhook
+        monkeypatch.setenv("EMAIL_INBOUND_WEBHOOK_SECRET", "whsec_test")
+        with pytest.raises(WebhookVerificationError, match="Missing required webhook header"):
+            verify_webhook(payload="{}", headers={"svix-id": "x"})
+
+    def test_bad_signature_raises(self, monkeypatch):
+        from services.email_inbound import WebhookVerificationError, verify_webhook
+        monkeypatch.setenv("EMAIL_INBOUND_WEBHOOK_SECRET", "whsec_dGVzdA==")
+        with pytest.raises(WebhookVerificationError):
+            verify_webhook(
+                payload="{}",
+                headers={
+                    "svix-id": "msg_test",
+                    "svix-timestamp": "1700000000",
+                    "svix-signature": "v1,not-a-real-signature",
+                },
+            )
+
+
+# ── resolve_thread ───────────────────────────────────────────────────────────
+
+
+def _make_threads_dao(*, by_case_number=None, by_id=None, recent=None, created=None):
+    dao = MagicMock()
+    dao.get_by_case_number.return_value = by_case_number
+    dao.get_thread_by_id.return_value = by_id
+    dao.find_recent_by_participant.return_value = recent or []
+    dao.create_for_inbound.return_value = created or {
+        "id": "new-uuid",
+        "case_number": 99,
+        "subject": "",
+        "status": "new",
+    }
+    return dao
+
+
+def _make_messages_dao(*, thread_id_for_in_reply_to=None):
+    dao = MagicMock()
+    dao.find_thread_id_by_in_reply_to.return_value = thread_id_for_in_reply_to
+    return dao
+
+
+class TestResolveThread:
+    def test_in_reply_to_match_returns_existing_thread(self):
+        from services.email_inbound import resolve_thread
+        target = {"id": "t1", "case_number": 10, "subject": "Original", "status": "awaiting_user"}
+        threads = _make_threads_dao(by_id=target)
+        messages = _make_messages_dao(thread_id_for_in_reply_to="t1")
+
+        thread, created = resolve_thread(
+            threads, messages,
+            subject="Re: Original",
+            from_email="x@y.com",
+            from_name=None,
+            in_reply_to="msg-abc",
+        )
+        assert thread is target
+        assert created is False
+        threads.create_for_inbound.assert_not_called()
+
+    def test_case_number_match_when_in_reply_to_missing(self):
+        from services.email_inbound import resolve_thread
+        target = {"id": "t2", "case_number": 42, "subject": "Old", "status": "resolved"}
+        threads = _make_threads_dao(by_case_number=target)
+        messages = _make_messages_dao(thread_id_for_in_reply_to=None)
+
+        thread, created = resolve_thread(
+            threads, messages,
+            subject="Re: [MT-42] Old",
+            from_email="x@y.com",
+            from_name=None,
+            in_reply_to=None,
+        )
+        assert thread is target
+        assert created is False
+        threads.create_for_inbound.assert_not_called()
+
+    def test_case_number_in_subject_overrides_unrelated_in_reply_to(self):
+        # If In-Reply-To points at a deleted/unknown message, we should fall
+        # through to the [MT-{n}] subject token rather than start a new thread.
+        from services.email_inbound import resolve_thread
+        target = {"id": "t3", "case_number": 7, "subject": "Old", "status": "new"}
+        threads = _make_threads_dao(by_case_number=target)
+        messages = _make_messages_dao(thread_id_for_in_reply_to=None)  # unknown
+
+        thread, _created = resolve_thread(
+            threads, messages,
+            subject="Re: [MT-7] Old",
+            from_email="x@y.com",
+            from_name=None,
+            in_reply_to="msg-unknown",
+        )
+        assert thread is target
+
+    def test_participant_subject_fallback(self):
+        from services.email_inbound import resolve_thread
+        target = {"id": "t4", "case_number": 5, "subject": "Hello world", "status": "awaiting_user"}
+        # No In-Reply-To, no [MT-] in subject — must match by participant + subject
+        threads = _make_threads_dao(recent=[target])
+        messages = _make_messages_dao()
+
+        thread, created = resolve_thread(
+            threads, messages,
+            subject="Re: Hello world",
+            from_email="x@y.com",
+            from_name=None,
+            in_reply_to=None,
+        )
+        assert thread is target
+        assert created is False
+        threads.create_for_inbound.assert_not_called()
+
+    def test_creates_new_thread_when_no_match(self):
+        from services.email_inbound import resolve_thread
+        threads = _make_threads_dao(
+            created={"id": "fresh", "case_number": 101, "subject": "Brand new", "status": "new"}
+        )
+        messages = _make_messages_dao()
+
+        thread, created = resolve_thread(
+            threads, messages,
+            subject="Brand new",
+            from_email="x@y.com",
+            from_name="X Y",
+            in_reply_to=None,
+        )
+        assert created is True
+        assert thread["case_number"] == 101
+        threads.create_for_inbound.assert_called_once()
+
+
+# ── webhook endpoint ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def webhook_client(monkeypatch):
+    """A fresh FastAPI app with only the email-inbound router mounted, so
+    we don't pull in the full backend (auth middleware, Supabase, etc.)
+    just to exercise this one endpoint."""
+    monkeypatch.setenv("EMAIL_INBOUND_WEBHOOK_SECRET", "whsec_test")
+    from api import webhooks_email
+    app = FastAPI()
+    app.include_router(webhooks_email.router)
+    return TestClient(app), webhooks_email
+
+
+class TestWebhookEndpoint:
+    def test_signature_rejected(self, webhook_client):
+        client, _ = webhook_client
+        with patch(
+            "api.webhooks_email.verify_webhook",
+            side_effect=__import__("services.email_inbound", fromlist=["WebhookVerificationError"])
+                .WebhookVerificationError("bad sig"),
+        ):
+            resp = client.post(
+                "/api/webhooks/email/inbound",
+                content=b"{}",
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 401
+
+    def test_unknown_event_type_returns_ignored(self, webhook_client):
+        client, _ = webhook_client
+        with patch("api.webhooks_email.verify_webhook"):
+            resp = client.post(
+                "/api/webhooks/email/inbound",
+                content=json.dumps({"type": "email.delivered", "data": {}}).encode(),
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+
+    def test_missing_email_id_returns_400(self, webhook_client):
+        client, _ = webhook_client
+        with patch("api.webhooks_email.verify_webhook"):
+            resp = client.post(
+                "/api/webhooks/email/inbound",
+                content=json.dumps({"type": "email.received", "data": {}}).encode(),
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 400
+
+    def test_happy_path_new_thread(self, webhook_client):
+        client, module = webhook_client
+        received_email = {
+            "from": '"Jane Doe" <jane@example.com>',
+            "to": ["support@missingtable.com"],
+            "subject": "Help with my invite",
+            "message_id": "<msg-001@example.com>",
+            "html": "<p>Hi support</p>",
+            "text": "Hi support",
+            "headers": {},
+            "attachments": [],
+            "created_at": "2026-05-23T12:00:00Z",
+        }
+        new_thread = {
+            "id": "thread-uuid",
+            "case_number": 1,
+            "subject": "Help with my invite",
+            "status": "new",
+        }
+
+        with (
+            patch("api.webhooks_email.verify_webhook"),
+            patch("api.webhooks_email.resend.Emails.Receiving.get", return_value=received_email),
+            patch.object(module._messages_dao, "find_by_message_id", return_value=None),
+            patch.object(module._messages_dao, "insert_inbound") as insert,
+            patch("api.webhooks_email.resolve_thread", return_value=(new_thread, True)) as resolver,
+            patch.object(module._threads_dao, "transition_on_inbound") as transition,
+        ):
+            resp = client.post(
+                "/api/webhooks/email/inbound",
+                content=json.dumps(
+                    {"type": "email.received", "data": {"email_id": "em-123"}}
+                ).encode(),
+                headers={"content-type": "application/json"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "accepted"
+        assert body["case_number"] == 1
+        assert body["created_new_thread"] is True
+
+        # message_id stored without angle brackets
+        insert_kwargs = insert.call_args.kwargs
+        assert insert_kwargs["message_id"] == "msg-001@example.com"
+        assert insert_kwargs["from_email"] == "jane@example.com"
+        assert insert_kwargs["from_name"] == "Jane Doe"
+        assert insert_kwargs["had_attachments"] is False
+
+        # New thread → no transition (create_for_inbound already set status='new')
+        transition.assert_not_called()
+        resolver.assert_called_once()
+
+    def test_idempotent_duplicate_message_id(self, webhook_client):
+        client, module = webhook_client
+        existing = {"id": "msg-row", "thread_id": "thread-uuid", "message_id": "msg-001@example.com"}
+        received_email = {
+            "from": "jane@example.com",
+            "to": ["support@missingtable.com"],
+            "subject": "Help",
+            "message_id": "<msg-001@example.com>",
+            "html": None,
+            "text": "Hi",
+            "headers": {},
+            "attachments": [],
+            "created_at": "2026-05-23T12:00:00Z",
+        }
+
+        with (
+            patch("api.webhooks_email.verify_webhook"),
+            patch("api.webhooks_email.resend.Emails.Receiving.get", return_value=received_email),
+            patch.object(module._messages_dao, "find_by_message_id", return_value=existing),
+            patch.object(module._messages_dao, "insert_inbound") as insert,
+        ):
+            resp = client.post(
+                "/api/webhooks/email/inbound",
+                content=json.dumps(
+                    {"type": "email.received", "data": {"email_id": "em-123"}}
+                ).encode(),
+                headers={"content-type": "application/json"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "duplicate"
+        insert.assert_not_called()
+
+    def test_attachments_flag_set_but_attachments_not_stored(self, webhook_client):
+        client, module = webhook_client
+        received_email = {
+            "from": "jane@example.com",
+            "to": ["support@missingtable.com"],
+            "subject": "Help",
+            "message_id": "<msg-att@example.com>",
+            "html": "<p>see attached</p>",
+            "text": "see attached",
+            "headers": {},
+            "attachments": [{"filename": "secret.pdf", "content": "BIGBASE64..."}],
+            "created_at": "2026-05-23T12:00:00Z",
+        }
+        new_thread = {"id": "t", "case_number": 2, "subject": "Help", "status": "new"}
+
+        with (
+            patch("api.webhooks_email.verify_webhook"),
+            patch("api.webhooks_email.resend.Emails.Receiving.get", return_value=received_email),
+            patch.object(module._messages_dao, "find_by_message_id", return_value=None),
+            patch.object(module._messages_dao, "insert_inbound") as insert,
+            patch("api.webhooks_email.resolve_thread", return_value=(new_thread, True)),
+        ):
+            client.post(
+                "/api/webhooks/email/inbound",
+                content=json.dumps(
+                    {"type": "email.received", "data": {"email_id": "em-att"}}
+                ).encode(),
+                headers={"content-type": "application/json"},
+            )
+
+        insert_kwargs = insert.call_args.kwargs
+        assert insert_kwargs["had_attachments"] is True
+        # raw_payload must not include the attachment bodies
+        assert "attachments" not in insert_kwargs["raw_payload"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -352,6 +352,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2071,6 +2083,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "bleach" },
     { name = "boto3" },
     { name = "celery" },
     { name = "crewai" },
@@ -2164,6 +2177,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.18.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "bleach", specifier = ">=6.2.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "celery", specifier = ">=5.5.3" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.6.4" },
@@ -5024,6 +5038,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/29/061ec845fb58521848f3739e466efd8250b4b7b98c1b6c5bf4d40b419b7e/webcolors-24.11.1.tar.gz", hash = "sha256:ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6", size = 45064, upload-time = "2024-11-11T07:43:24.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/e8/c0e05e4684d13459f93d312077a9a2efbe04d59c393bc2b8802248c908d4/webcolors-24.11.1-py3-none-any.whl", hash = "sha256:515291393b4cdf0eb19c155749a096f779f7d909f7cceea072791cb9095b92e9", size = 14934, upload-time = "2024-11-11T07:43:22.529Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]

--- a/supabase-local/migrations/20260523000000_add_email_inbox.sql
+++ b/supabase-local/migrations/20260523000000_add_email_inbox.sql
@@ -1,0 +1,109 @@
+-- Migration: Support Inbox (SB-35 Phase 1)
+-- Description: Tables for inbound + outbound email threads tied to support@missingtable.com.
+--              Inbound webhook (Resend Inbound) writes to these; admin UI (Phase 2/3) reads.
+-- Date: 2026-05-23
+-- Related: SB-35
+
+-- Ensure moddatetime extension is available for the updated_at trigger.
+CREATE EXTENSION IF NOT EXISTS moddatetime SCHEMA extensions;
+
+-- ----------------------------------------------------------------------------
+-- 1) Case-number sequence — every thread gets a monotonically-increasing
+--    integer rendered as "MT-{n}" in the UI and subject lines.
+-- ----------------------------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS public.email_thread_case_seq START 1;
+
+-- ----------------------------------------------------------------------------
+-- 2) email_threads — one row per conversation with an external participant.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.email_threads (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    case_number integer NOT NULL UNIQUE DEFAULT nextval('public.email_thread_case_seq'),
+    subject text NOT NULL,
+    participant_email text NOT NULL,
+    participant_name text,
+    status text NOT NULL DEFAULT 'new',
+    last_message_at timestamptz NOT NULL DEFAULT now(),
+    unread_count integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT email_threads_status_check
+        CHECK (status IN ('new', 'awaiting_admin', 'awaiting_user', 'resolved', 'spam'))
+);
+
+ALTER SEQUENCE public.email_thread_case_seq OWNED BY public.email_threads.case_number;
+
+COMMENT ON TABLE public.email_threads IS 'Support-inbox threads keyed by case_number (MT-{n}). Auto-transitions via status enum.';
+COMMENT ON COLUMN public.email_threads.case_number IS 'Sequential MT case number, rendered as "MT-{case_number}" and embedded in outbound subjects as a threading fallback.';
+COMMENT ON COLUMN public.email_threads.status IS 'Lifecycle: new (first inbound) → awaiting_admin (user replied) → awaiting_user (admin replied) → resolved | spam (manual).';
+
+CREATE INDEX IF NOT EXISTS idx_email_threads_status_last_message
+    ON public.email_threads (status, last_message_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_threads_case_number
+    ON public.email_threads (case_number);
+CREATE INDEX IF NOT EXISTS idx_email_threads_participant_email
+    ON public.email_threads (participant_email);
+
+DROP TRIGGER IF EXISTS handle_updated_at ON public.email_threads;
+CREATE TRIGGER handle_updated_at
+    BEFORE UPDATE ON public.email_threads
+    FOR EACH ROW
+    EXECUTE PROCEDURE extensions.moddatetime(updated_at);
+
+-- ----------------------------------------------------------------------------
+-- 3) email_messages — one row per inbound or outbound message in a thread.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.email_messages (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    thread_id uuid NOT NULL REFERENCES public.email_threads(id) ON DELETE CASCADE,
+    direction text NOT NULL,
+    message_id text NOT NULL UNIQUE,
+    in_reply_to text,
+    "references" text,
+    from_email text NOT NULL,
+    from_name text,
+    to_email text NOT NULL,
+    subject text NOT NULL,
+    body_text text,
+    body_html text,
+    had_attachments boolean NOT NULL DEFAULT false,
+    raw_payload jsonb,
+    sent_by_user_id uuid REFERENCES public.user_profiles(id),
+    read_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT email_messages_direction_check
+        CHECK (direction IN ('inbound', 'outbound'))
+);
+
+COMMENT ON TABLE public.email_messages IS 'Individual inbound and outbound messages in support threads. message_id is the RFC 5322 Message-ID (angle brackets stripped) and is unique for idempotent webhook ingest.';
+COMMENT ON COLUMN public.email_messages.had_attachments IS 'True when the inbound payload included attachments; the attachments themselves are dropped (not stored). UI surfaces a "reply via your email client to see attachments" notice.';
+COMMENT ON COLUMN public.email_messages.body_html IS 'Sanitized HTML body (bleach allowlist). Never store unsanitized HTML from the inbound webhook.';
+COMMENT ON COLUMN public.email_messages.raw_payload IS 'Full provider payload (Resend ReceivedEmail) for debugging. May be cleared after a retention window.';
+
+CREATE INDEX IF NOT EXISTS idx_email_messages_thread_created
+    ON public.email_messages (thread_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_email_messages_message_id
+    ON public.email_messages (message_id);
+CREATE INDEX IF NOT EXISTS idx_email_messages_in_reply_to
+    ON public.email_messages (in_reply_to)
+    WHERE in_reply_to IS NOT NULL;
+
+-- ----------------------------------------------------------------------------
+-- 4) Row-level security — admin-only for now. Phase 2 admin API uses the
+--    service role for inserts/updates and goes through these policies for
+--    admin-user reads via the standard auth path.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.email_threads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.email_messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS email_threads_admin_all ON public.email_threads;
+CREATE POLICY email_threads_admin_all
+    ON public.email_threads
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());
+
+DROP POLICY IF EXISTS email_messages_admin_all ON public.email_messages;
+CREATE POLICY email_messages_admin_all
+    ON public.email_messages
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());


### PR DESCRIPTION
## Summary

First slice of [SB-35 — Support Inbox](https://linear.app/silverbeer/issue/SB-35/support-inbox-inbound-email-replies-via-supportmissingtablecom) **after** discoverability (#375). Lands the schema, DAOs, primitives, and webhook endpoint that the admin API (Phase 2) and admin UI (Phase 3) will sit on top of. **Resend Inbound dashboard config + DNS for `support.missingtable.com` are still external steps you'll need to do — see "Before this is live" below.**

## What's in this PR

### Schema (`supabase-local/migrations/20260523000000_add_email_inbox.sql`)
- `email_thread_case_seq` drives `MT-{n}` case numbering — embedded as `[MT-{n}]` in outbound subjects and used as a threading fallback when RFC 5322 headers get stripped.
- `email_threads` with status enum (`new` / `awaiting_admin` / `awaiting_user` / `resolved` / `spam`), unread_count, `updated_at` trigger.
- `email_messages` with **unique `message_id`** for idempotent ingest, `in_reply_to`, sanitized `body_html`, `had_attachments` flag (attachments themselves are dropped, not stored), `raw_payload` jsonb for debugging.
- Admin-only RLS via `public.is_admin()`. Indexes on hot paths.

### DAOs
- `EmailThreadsDAO` — `get_thread_by_id`, `get_by_case_number`, `find_recent_by_participant`, `create_for_inbound`, `transition_on_inbound` (reopens `resolved` threads on user reply; `spam` is sticky).
- `EmailMessagesDAO` — `find_by_message_id`, `find_thread_id_by_in_reply_to`, `insert_inbound`.
- Both follow the existing `BaseDAO` + `@invalidates_cache` pattern.

### Inbound primitives (`backend/services/email_inbound.py`)
- `verify_webhook` — wraps `resend.Webhooks.verify` (Svix) with typed `WebhookVerificationError`.
- `sanitize_html` — bleach allowlist; conservative tag set; protocols limited to `http`, `https`, `mailto`. Strips `<script>`, neutralizes `javascript:` hrefs.
- `parse_case_number_from_subject` + `normalize_subject` for threading.
- `resolve_thread` — 4-tier resolver: In-Reply-To → `[MT-{n}]` subject token → recent participant + normalized subject (30-day window) → new thread.

### Webhook endpoint (`POST /api/webhooks/email/inbound`)
1. Verifies Svix signature against `EMAIL_INBOUND_WEBHOOK_SECRET` → **401** on bad signature.
2. Ignores non-`email.received` events with **200** (so Resend doesn't retry).
3. Fetches full `ReceivedEmail` via `resend.Emails.Receiving.get(email_id)`.
4. **Idempotent** on RFC 5322 Message-ID — retries return `200 duplicate`.
5. Resolves the thread, sanitizes HTML, drops attachment bodies (`had_attachments` flag is set but base64 bodies are stripped from `raw_payload`).
6. Inserts message + transitions thread status.
7. Uses the service-role Supabase client to bypass RLS — HMAC is the trust gate.

### Tests (`tests/unit/test_email_inbound.py`)
**33 passing**, no DB required:
- All four `resolve_thread` branches against mock DAOs.
- Sanitizer behavior (script stripping, `javascript:` neutralization, allowlist).
- Case-number / subject parsers (chained `Re:`, bracket variants, edge cases).
- Webhook endpoint flows: 401 / 400 / 200-ignored / 200-accepted / 200-duplicate.
- Verifies attachments aren't stored and `from_name` is parsed out of `"Name" <addr>` style headers.

## Before this is live (external steps for you)

1. **Resend Inbound dashboard**: register `support.missingtable.com`, generate the webhook signing secret, point the webhook at `https://api.missingtable.com/api/webhooks/email/inbound`.
2. **DNS**: add the MX records Resend gives you for `support.missingtable.com` (keeps the apex domain mail untouched).
3. **Secrets**: add `EMAIL_INBOUND_WEBHOOK_SECRET` to AWS Secrets Manager and wire it through External Secrets → Kubernetes Secret. (The existing `RESEND_API_KEY` already covers the outbound fetch the webhook uses.)

Until step 3 is in place, the endpoint will return 401 for all calls — by design.

## Test plan

- [x] `ruff check` clean across all changed files.
- [x] `pytest tests/unit/test_email_inbound.py` — 33/33 pass.
- [x] Migration applied against the local Supabase — tables, sequence, FK cascade, and RLS policy all verified directly.
- [ ] **Manual (after deploy + DNS)**: send a test email to `support@missingtable.com`, confirm a new `MT-1` thread lands in the DB with the message attached.
- [ ] **Manual**: reply to an MT-sent transactional email; confirm the inbound message threads under the original by `In-Reply-To`.

## What's next (out of scope for this PR)

- **Phase 2**: admin API endpoints (`/api/admin/emails/threads`, reply, mark resolved/spam).
- **Phase 3**: admin UI inbox + reply composer.

Linear: SB-35

🤖 Generated with [Claude Code](https://claude.com/claude-code)