### PR TITLE
fix(support): move support address to support@contact.missingtable.com

### DIFF
--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -11,7 +11,7 @@ import resend
 
 logger = logging.getLogger(__name__)
 
-SUPPORT_EMAIL = "support@missingtable.com"
+SUPPORT_EMAIL = "support@contact.missingtable.com"
 
 
 def _support_html_block() -> str:

--- a/frontend/src/__tests__/components/SupportEmailLink.spec.js
+++ b/frontend/src/__tests__/components/SupportEmailLink.spec.js
@@ -2,7 +2,7 @@
  * SupportEmailLink.vue Tests (SB-35)
  *
  * Renders the support address at runtime from JS constants so the literal
- * `support@missingtable.com` string never appears in template source. Also
+ * `support@contact.missingtable.com` string never appears in template source. Also
  * builds a properly-encoded mailto: href with optional subject + body.
  */
 
@@ -13,7 +13,7 @@ import SupportEmailLink from '@/components/SupportEmailLink.vue';
 describe('SupportEmailLink', () => {
   it('renders the support address as visible text by default', () => {
     const wrapper = mount(SupportEmailLink);
-    expect(wrapper.text()).toBe('support@missingtable.com');
+    expect(wrapper.text()).toBe('support@contact.missingtable.com');
   });
 
   it('uses displayText prop when provided instead of the raw address', () => {
@@ -26,7 +26,9 @@ describe('SupportEmailLink', () => {
   it('renders a mailto: href pointing at the support address', () => {
     const wrapper = mount(SupportEmailLink);
     const link = wrapper.find('a');
-    expect(link.attributes('href')).toBe('mailto:support@missingtable.com');
+    expect(link.attributes('href')).toBe(
+      'mailto:support@contact.missingtable.com'
+    );
   });
 
   it('appends an encoded subject param when subject prop is set', () => {
@@ -35,7 +37,7 @@ describe('SupportEmailLink', () => {
     });
     const href = wrapper.find('a').attributes('href');
     expect(href).toBe(
-      'mailto:support@missingtable.com?subject=%5BMT-42%5D%20Login%20trouble'
+      'mailto:support@contact.missingtable.com?subject=%5BMT-42%5D%20Login%20trouble'
     );
   });
 
@@ -53,7 +55,7 @@ describe('SupportEmailLink', () => {
     });
     const href = wrapper.find('a').attributes('href');
     expect(href).toBe(
-      'mailto:support@missingtable.com?subject=Hello&body=World'
+      'mailto:support@contact.missingtable.com?subject=Hello&body=World'
     );
   });
 });

--- a/frontend/src/components/SupportEmailLink.vue
+++ b/frontend/src/components/SupportEmailLink.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 });
 
 const SUPPORT_USER = 'support';
-const SUPPORT_DOMAIN = 'missingtable.com';
+const SUPPORT_DOMAIN = 'contact.missingtable.com';
 const address = `${SUPPORT_USER}@${SUPPORT_DOMAIN}`;
 
 const mailtoHref = computed(() => {


### PR DESCRIPTION
## Summary

Resend's free plan caps verified domains at 1. The existing slot is `contact.missingtable.com` (used for outbound transactional sends). Rather than upgrade to Pro or run a risky apex-domain swap, enable inbound on the existing subdomain and shift the advertised support address to match.

Changes:
- `SupportEmailLink.vue` builds `support@contact.missingtable.com` at runtime.
- `email_service.py` `SUPPORT_EMAIL` constant updated; the invite + invite-request approval emails now show the new address.
- Vitest expectations updated.

No webhook handler change needed — it stores whatever Resend forwards, regardless of subdomain.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run -- SupportEmailLink` — 6/6 pass
- [x] `ruff check services/email_service.py` — clean
- [ ] Manual: once Resend inbound is enabled on `contact.missingtable.com`, send an email to `support@contact.missingtable.com` and confirm it lands as a new thread

Linear: SB-35

🤖 Generated with [Claude Code](https://claude.com/claude-code)