### PR TITLE
feat(helm): wire EMAIL_INBOUND_WEBHOOK_SECRET on backend Deployment (SB-35)

### DIFF
--- a/helm/missing-table/templates/backend.yaml
+++ b/helm/missing-table/templates/backend.yaml
@@ -79,6 +79,15 @@ spec:
               name: {{ include "missing-table.fullname" . }}-secrets
               key: resend-api-key
               optional: true
+        # Resend Inbound webhook signing secret (Support Inbox, SB-35).
+        # Optional: pod starts even if absent; the webhook handler returns
+        # 401 to all callers until ESO populates it from AWS Secrets Manager.
+        - name: EMAIL_INBOUND_WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "missing-table.fullname" . }}-secrets
+              key: email-inbound-webhook-secret
+              optional: true
         # Telegram bot token for live-match notifications.
         # Optional: pod starts even if the key is absent; the dispatcher logs
         # a NotificationConfigError and skips telegram sends until the key

--- a/helm/missing-table/templates/secrets.yaml
+++ b/helm/missing-table/templates/secrets.yaml
@@ -34,6 +34,13 @@ stringData:
   telegram-bot-token: {{ .Values.secrets.telegramBotToken | quote }}
   {{- end }}
 
+  # Resend Inbound webhook signing secret - Support Inbox (SB-35).
+  # In prod populated by ESO from AWS Secrets Manager; same convention as
+  # telegram-bot-token above.
+  {{- if .Values.secrets.emailInboundWebhookSecret }}
+  email-inbound-webhook-secret: {{ .Values.secrets.emailInboundWebhookSecret | quote }}
+  {{- end }}
+
   # RabbitMQ connection (for match-scraper CronJob)
   {{- if .Values.rabbitmq }}
   rabbitmq-url: {{ printf "amqp://%s:%s@%s:%d//" .Values.rabbitmq.username .Values.rabbitmq.password .Values.rabbitmq.host (.Values.rabbitmq.port | int) | quote }} # pragma: allowlist secret

--- a/helm/missing-table/values-dev.yaml.example
+++ b/helm/missing-table/values-dev.yaml.example
@@ -28,6 +28,10 @@ secrets:
   # to disable telegram sends (discord is independent, per-club webhook).
   # telegramBotToken: "your-telegram-bot-token-here"
 
+  # Resend Inbound webhook signing secret — for the Support Inbox (SB-35).
+  # Leave empty/commented to keep the webhook returning 401 in dev.
+  # emailInboundWebhookSecret: "whsec_your-secret-here"
+
   # Grafana Cloud OTLP credentials (for frontend telemetry)
   # Get these from: Grafana Cloud -> Connections -> OTLP
   grafanaInstanceId: "your-grafana-instance-id"


### PR DESCRIPTION
## Summary

Adds the env var reference on the backend container so the inbound webhook handler can verify Resend's Svix signature in prod.

- **`templates/backend.yaml`**: new env var `EMAIL_INBOUND_WEBHOOK_SECRET` sourced from the `missing-table-secrets` K8s Secret, key `email-inbound-webhook-secret`. Marked `optional: true` — pod starts even before ESO populates the key. While unset, the webhook handler returns 401 to every call (fail-safe baked into `services/email_inbound.verify_webhook`).
- **`templates/secrets.yaml`**: parallel conditional for local dev where `values.secrets.emailInboundWebhookSecret` is set directly. Mirrors the `telegramBotToken` pattern.
- **`values-dev.yaml.example`**: example placeholder so dev users see how to set it locally.

Paired with [missingtable-platform-bootstrap#36](https://github.com/silverbeer/missingtable-platform-bootstrap/pull/36) (ExternalSecret extension that populates the K8s Secret key from AWS Secrets Manager in prod).

## Diff highlight

```yaml
# templates/backend.yaml
- name: EMAIL_INBOUND_WEBHOOK_SECRET
  valueFrom:
    secretKeyRef:
      name: {{ include "missing-table.fullname" . }}-secrets
      key: email-inbound-webhook-secret
      optional: true
```

## Rollout order

Either PR can land first:
- **If this merges first**: backend rolls with the env var unset; webhook returns 401 to all callers until platform-bootstrap#36 lands and ESO syncs the new key.
- **If platform-bootstrap#36 merges first**: K8s Secret gets the new key immediately, but the backend Deployment doesn't reference it yet, so the value sits unused until this PR lands and the pod is restarted by ArgoCD.

Best path: merge platform-bootstrap#36 first (so the Secret is ready), then this. Backend rollout on the next ArgoCD sync wires it up.

## Test plan

- [x] `helm lint helm/missing-table/` — clean
- [x] `helm template helm/missing-table/ | grep -A 6 EMAIL_INBOUND_WEBHOOK_SECRET` — renders the expected secretKeyRef
- [ ] After merge + AWS secret populated + ESO synced + backend rolled:
  ```
  kubectl -n missing-table exec deploy/missing-table-backend -- printenv EMAIL_INBOUND_WEBHOOK_SECRET | head -c 20
  # should print: whsec_xxxxxxxxxxx
  ```
- [ ] Send a test email to `support@contact.missingtable.com`; verify the Resend webhook log shows HTTP 200 and a new row lands in `email_threads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)