### PR TITLE
fix(support): use short header keys when calling resend.Webhooks.verify (SB-35)

### DIFF
--- a/backend/services/email_inbound.py
+++ b/backend/services/email_inbound.py
@@ -52,17 +52,27 @@ def verify_webhook(*, payload: str, headers: dict[str, str]) -> None:
         )
 
     required = {"svix-id", "svix-timestamp", "svix-signature"}
-    missing = required - {k.lower() for k in headers}
+    lowered = {k.lower(): v for k, v in headers.items()}
+    missing = required - lowered.keys()
     if missing:
         raise WebhookVerificationError(
             f"Missing required webhook header(s): {sorted(missing)}"
         )
 
+    # Resend's WebhookHeaders TypedDict uses the short keys `id`/`timestamp`/
+    # `signature` (the `svix-` prefix is stripped). The field-level docstring
+    # says "The svix-id header value" but the field is named just `id`, so
+    # we must remap before calling verify — passing the prefixed HTTP-header
+    # names through results in "svix-id header is required" failures.
     try:
         resend.Webhooks.verify(
             resend.VerifyWebhookOptions(
                 payload=payload,
-                headers=headers,
+                headers={
+                    "id": lowered["svix-id"],
+                    "timestamp": lowered["svix-timestamp"],
+                    "signature": lowered["svix-signature"],
+                },
                 webhook_secret=secret,
             )
         )

--- a/backend/tests/unit/test_email_inbound.py
+++ b/backend/tests/unit/test_email_inbound.py
@@ -144,6 +144,40 @@ class TestVerifyWebhook:
                 },
             )
 
+    def test_passes_short_keys_to_svix_verify(self, monkeypatch):
+        """Regression: Resend's WebhookHeaders TypedDict uses short keys
+        ('id', 'timestamp', 'signature'), not the HTTP header names. Earlier
+        code passed the prefixed names through and got 'svix-id header is
+        required' failures in prod. Lock that mapping in."""
+        from unittest.mock import patch
+
+        from services.email_inbound import verify_webhook
+        monkeypatch.setenv("EMAIL_INBOUND_WEBHOOK_SECRET", "whsec_test")
+
+        with patch("services.email_inbound.resend.Webhooks.verify") as mock_verify:
+            verify_webhook(
+                payload='{"hello": "world"}',
+                headers={
+                    "Svix-Id": "msg_xyz",
+                    "Svix-Timestamp": "1700000000",
+                    "Svix-Signature": "v1,abc",
+                    # Extra noise headers that should be dropped:
+                    "content-type": "application/json",
+                    "x-trace": "trace-123",
+                },
+            )
+
+        mock_verify.assert_called_once()
+        options = mock_verify.call_args.args[0]
+        # Short keys, not prefixed.
+        assert options["headers"] == {
+            "id": "msg_xyz",
+            "timestamp": "1700000000",
+            "signature": "v1,abc",
+        }
+        assert options["payload"] == '{"hello": "world"}'
+        assert options["webhook_secret"] == "whsec_test"
+
 
 # ── resolve_thread ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Live prod debugging caught this. Inbound webhook calls from Resend were returning 401 with the SDK error `Signature verification failed: svix-id header is required` — even though the `svix-*` headers were clearly present in the request and our pre-check accepted them.

## Root cause

Resend's `WebhookHeaders` TypedDict (in `resend.webhooks._webhook`) keys signatures by **short names** — `id`, `timestamp`, `signature` — even though each field's docstring describes it as "The svix-id header value" etc. The `svix-` prefix is stripped in their type. Svix's verify implementation does `headers.get("id")` / `.get("timestamp")` / `.get("signature")`.

We were passing the full HTTP header dict straight through with keys `svix-id` / `svix-timestamp` / `svix-signature`, so every lookup inside the SDK returned `None` and verification failed.

## Fix

`services/email_inbound.verify_webhook` now remaps the lowercased input dict to the short keys before calling `resend.Webhooks.verify`:

```python
resend.VerifyWebhookOptions(
    payload=payload,
    headers={
        "id": lowered["svix-id"],
        "timestamp": lowered["svix-timestamp"],
        "signature": lowered["svix-signature"],
    },
    webhook_secret=secret,
)
```

The pre-check (which validates that the prefixed HTTP names are present) is unchanged — that's still the right thing to check at the boundary; only the SDK call needed remapping.

## Test that locks this in

Added `test_passes_short_keys_to_svix_verify` which mocks `resend.Webhooks.verify` and asserts:

- The `headers` dict passed in is exactly `{"id": ..., "timestamp": ..., "signature": ...}` — short keys only.
- Extra HTTP headers (`content-type`, etc.) are dropped.
- Input header case (`Svix-Id` vs `svix-id`) doesn't matter.

The bug shipped because the existing four `TestVerifyWebhook` cases only exercised failure paths (missing secret, missing headers, bad signature). None of them inspected what the SDK actually received.

## Test plan

- [x] `pytest tests/unit/test_email_inbound.py` — 34/34 pass (was 33; +1 regression test)
- [x] `ruff check services/email_inbound.py tests/unit/test_email_inbound.py` — clean
- [ ] **Smoke test after deploy**: send a fresh email to `support@contact.missingtable.com`. Resend webhook event should now show HTTP 200, and a row with `case_number=1` should appear in `email_threads`.

## Live error (for posterity)

```
{"error": "Signature verification failed: svix-id header is required",
 "event": "email_webhook_unauthorized",
 "logger": "api.webhooks_email"}
```

Linear: SB-35

🤖 Generated with [Claude Code](https://claude.com/claude-code)