### PR TITLE
fix(support): set resend.api_key on demand in inbound webhook (SB-35)

### DIFF
--- a/backend/api/webhooks_email.py
+++ b/backend/api/webhooks_email.py
@@ -219,6 +219,23 @@ async def email_inbound(request: Request) -> dict[str, Any]:
     }
 
 
+def _ensure_resend_api_key() -> None:
+    """Make sure resend.api_key is set before calling the Resend API.
+
+    EmailService.__init__ sets resend.api_key as a side effect, but that
+    only runs when an outbound email is actually sent. Inbound webhooks
+    can fire before any outbound has gone out — e.g. immediately after
+    a fresh pod start — at which point resend.api_key is still None and
+    the SDK raises ValidationError('API key is invalid') for any API
+    call. Set it ourselves from the env var; idempotent.
+    """
+    if resend.api_key:
+        return
+    api_key = os.getenv("RESEND_API_KEY")
+    if api_key:
+        resend.api_key = api_key
+
+
 def _fetch_received_email(email_id: str) -> dict[str, Any]:
     """Fetch the full ReceivedEmail from the Resend API.
 
@@ -226,6 +243,7 @@ def _fetch_received_email(email_id: str) -> dict[str, Any]:
     exceptions become 502 from the caller's perspective — Resend will
     retry, which is the right behavior for transient upstream failures.
     """
+    _ensure_resend_api_key()
     try:
         return resend.Emails.Receiving.get(email_id)
     except Exception as e:

--- a/backend/tests/unit/test_email_inbound.py
+++ b/backend/tests/unit/test_email_inbound.py
@@ -428,6 +428,51 @@ class TestWebhookEndpoint:
         assert resp.json()["status"] == "duplicate"
         insert.assert_not_called()
 
+    def test_ensures_resend_api_key_before_fetch(self, webhook_client, monkeypatch):
+        """Regression: EmailService normally sets resend.api_key as a side effect
+        on first construction, but inbound webhooks can fire on a fresh pod
+        before any outbound has gone out. Verify the webhook sets api_key
+        itself from the env var so resend.Emails.Receiving.get doesn't fail
+        with ValidationError('API key is invalid')."""
+        client, module = webhook_client
+        monkeypatch.setenv("RESEND_API_KEY", "re_test_inbound_set")
+
+        import resend as resend_mod
+        # Simulate a fresh pod: api_key has never been set.
+        original = resend_mod.api_key
+        resend_mod.api_key = None
+        try:
+            received_email = {
+                "from": "x@y.com",
+                "to": ["support@contact.missingtable.com"],
+                "subject": "hi",
+                "message_id": "<m1@e.com>",
+                "html": None,
+                "text": "hi",
+                "headers": {},
+                "attachments": [],
+                "created_at": "2026-05-23T12:00:00Z",
+            }
+            new_thread = {"id": "t", "case_number": 9, "subject": "hi", "status": "new"}
+
+            with (
+                patch("api.webhooks_email.verify_webhook"),
+                patch("api.webhooks_email.resend.Emails.Receiving.get", return_value=received_email),
+                patch.object(module._messages_dao, "find_by_message_id", return_value=None),
+                patch.object(module._messages_dao, "insert_inbound"),
+                patch("api.webhooks_email.resolve_thread", return_value=(new_thread, True)),
+            ):
+                resp = client.post(
+                    "/api/webhooks/email/inbound",
+                    content=json.dumps({"type": "email.received", "data": {"email_id": "e1"}}).encode(),
+                    headers={"content-type": "application/json"},
+                )
+
+            assert resp.status_code == 200
+            assert resend_mod.api_key == "re_test_inbound_set"
+        finally:
+            resend_mod.api_key = original
+
     def test_attachments_flag_set_but_attachments_not_stored(self, webhook_client):
         client, module = webhook_client
         received_email = {


### PR DESCRIPTION
## Summary

Round two of live prod debugging caught this. After [#382](https://github.com/silverbeer/missing-table/pull/382) fixed the signature verification, the next inbound email got past the 401 and crashed at the next step:

```
{"detail":"failed to fetch email 97cbad6f-315d-4d08-b21f-2755f3252a8e"}
```

Logs showed: `resend.exceptions.ValidationError: API key is invalid`.

## Root cause

`EmailService.__init__` sets `resend.api_key` as a side effect, but `EmailService` is only constructed lazily inside request handlers (`app.py:644`). On a fresh pod, `resend.api_key` is `None` until the first outbound email goes out. Inbound webhooks can fire before any outbound has happened, so `resend.Emails.Receiving.get()` fails with the cryptic "API key is invalid" — even though `RESEND_API_KEY` is set in the environment.

## Fix

`api/webhooks_email._ensure_resend_api_key()` sets `resend.api_key` from the env var on demand, called at the top of `_fetch_received_email()`. Idempotent — once set, subsequent calls are no-ops. Doesn't touch the existing `EmailService` flow.

## Test that locks this in

Added `test_ensures_resend_api_key_before_fetch` which:

1. Sets `RESEND_API_KEY` env var to a sentinel.
2. Force-nulls `resend.api_key` (simulating a fresh pod).
3. Fires a webhook through the test client with the receiving.get mocked.
4. Asserts `resend.api_key` ended up equal to the sentinel.

The previous tests mocked `resend.Emails.Receiving.get` directly, so they never exercised the `api_key` code path at all — that's why this latent issue made it to prod.

## Test plan

- [x] `pytest tests/unit/test_email_inbound.py` — 35/35 pass (was 34; +1 regression test)
- [x] `ruff check api/webhooks_email.py tests/unit/test_email_inbound.py` — clean
- [ ] **Smoke test after deploy**: send a fresh email to `support@contact.missingtable.com`. Webhook should now return HTTP 200, a row should land in `email_threads` (first-ever `case_number = 1`), and the message body should land in `email_messages`.

Linear: SB-35

🤖 Generated with [Claude Code](https://claude.com/claude-code)