### PR TITLE
fix(support): point RESEND_REPLY_TO at support@contact.missingtable.com

### DIFF
--- a/helm/missing-table/values-prod.yaml
+++ b/helm/missing-table/values-prod.yaml
@@ -29,7 +29,7 @@ backend:
       # request approval) includes this Reply-To header so user replies
       # land in a monitored inbox instead of the noreply@ from-address.
       # Change this to whatever inbox you actually read.
-      RESEND_REPLY_TO: "support@missingtable.com"
+      RESEND_REPLY_TO: "support@contact.missingtable.com"
 
 # Live-match notifications (explicit override — defaults to true in values.yaml)
 # The TELEGRAM_BOT_TOKEN key inside the ESO-managed missing-table-secrets must


### PR DESCRIPTION
## Summary

`values-prod.yaml` had `RESEND_REPLY_TO: support@missingtable.com` — but the apex domain has no MX record. Only `contact.missingtable.com` is set up to receive (per [platform-bootstrap#35](https://github.com/silverbeer/missingtable-platform-bootstrap/pull/35)). So replies to invite / password-reset / approval emails have been bouncing.

Single-line fix to align the env var with the actual receivable address.

```diff
-      RESEND_REPLY_TO: "support@missingtable.com"
+      RESEND_REPLY_TO: "support@contact.missingtable.com"
```

After deploy, the `Reply-To` header on outbound transactional emails will route user replies to the Resend Inbound webhook (just like a fresh inbound email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)