### PR TITLE
feat(support): add admin API for support inbox (SB-40)

### DIFF
--- a/backend/api/admin_emails.py
+++ b/backend/api/admin_emails.py
@@ -1,0 +1,228 @@
+"""
+Admin API for the Support Inbox (SB-35 Phase 2).
+
+Exposes the JSON surface the Phase 3 admin UI will consume:
+
+    GET    /api/admin/emails/threads               list w/ keyset pagination
+    GET    /api/admin/emails/threads/{id_or_mt_n}  thread + messages
+    POST   /api/admin/emails/threads/{id}/reply    send outbound + persist
+    PATCH  /api/admin/emails/threads/{id}/status   manual status override
+    PATCH  /api/admin/emails/threads/{id}/read     zero unread_count + stamp read_at
+    GET    /api/admin/emails/unread-count          attention badge
+
+All endpoints gated by `require_admin`. Admin operations use the service-role
+client (same project pattern as backend/api/invites.py) so the auth dependency
+is the trust gate.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Any, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from supabase import create_client
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from auth import require_admin
+from dao.email_messages_dao import EmailMessagesDAO
+from dao.email_threads_dao import EmailThreadsDAO
+from dao.match_dao import SupabaseConnection as DbConnectionHolder
+from services.email_outbound import send_admin_reply
+
+logger = structlog.get_logger(__name__)
+
+# Service-role connection for admin reads/writes. require_admin is the trust
+# gate — same pattern as backend/api/invites.py.
+_supabase_url = os.getenv("SUPABASE_URL", "")
+_service_key = os.getenv("SUPABASE_SERVICE_KEY")
+if _service_key:
+    _service_client = create_client(_supabase_url, _service_key)
+    _conn_holder = DbConnectionHolder()
+    # Pin the DAO's client to the service-role client by reaching into the
+    # holder. Mirrors how invites.py uses service_client directly but keeps
+    # the DAOs' query surface.
+    _conn_holder.client = _service_client
+else:
+    _conn_holder = DbConnectionHolder()
+
+_threads_dao = EmailThreadsDAO(_conn_holder)
+_messages_dao = EmailMessagesDAO(_conn_holder)
+
+router = APIRouter(prefix="/api/admin/emails", tags=["admin-emails"])
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_DEFAULT_STATUSES = ("new", "awaiting_admin")
+_ALL_STATUSES = frozenset(
+    {"new", "awaiting_admin", "awaiting_user", "resolved", "spam"}
+)
+_MT_PATH_RE = re.compile(r"^MT-(\d+)$", re.IGNORECASE)
+_LIMIT_DEFAULT = 50
+_LIMIT_MAX = 200
+
+
+# ── Pydantic models ──────────────────────────────────────────────────────────
+
+
+class ReplyRequest(BaseModel):
+    body_text: str = Field(..., min_length=1)
+    body_html: str | None = None
+
+
+class StatusUpdateRequest(BaseModel):
+    status: Literal["resolved", "spam", "awaiting_admin"]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _admin_user_id(current_user: dict[str, Any]) -> str:
+    """Pluck the user id out of the auth payload. Different code paths populate
+    different keys (id / user_id / sub) — same fallback chain as invites.py.
+    """
+    user_id = (
+        current_user.get("id")
+        or current_user.get("user_id")
+        or current_user.get("sub")
+    )
+    if not user_id:
+        raise HTTPException(status_code=400, detail="user id missing from auth payload")
+    return user_id
+
+
+def _resolve_thread_or_404(thread_id_or_case_number: str) -> dict[str, Any]:
+    """Path-param resolver: accepts either a UUID or `MT-{n}` form."""
+    mt_match = _MT_PATH_RE.match(thread_id_or_case_number)
+    if mt_match:
+        case_number = int(mt_match.group(1))
+        thread = _threads_dao.get_by_case_number(case_number)
+    else:
+        thread = _threads_dao.get_thread_by_id(thread_id_or_case_number)
+
+    if not thread:
+        raise HTTPException(
+            status_code=404, detail=f"thread {thread_id_or_case_number!r} not found"
+        )
+    return thread
+
+
+def _parse_statuses(raw: str | None) -> list[str]:
+    if not raw:
+        return list(_DEFAULT_STATUSES)
+    values = [v.strip() for v in raw.split(",") if v.strip()]
+    invalid = [v for v in values if v not in _ALL_STATUSES]
+    if invalid:
+        raise HTTPException(
+            status_code=400, detail=f"invalid status value(s): {invalid}"
+        )
+    return values
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get("/threads")
+async def list_threads(
+    status: str | None = Query(
+        default=None,
+        description="CSV of status values; default 'new,awaiting_admin'.",
+    ),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Paginated list of threads. Keyset cursor on (last_message_at, id)."""
+    statuses = _parse_statuses(status)
+    try:
+        return _threads_dao.list_by_status(statuses, limit=limit, cursor=cursor)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get("/unread-count")
+async def get_unread_count(
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, int]:
+    """Sum of unread_count across threads in (new, awaiting_admin)."""
+    return {"count": _threads_dao.unread_count_for_attention()}
+
+
+@router.get("/threads/{thread_id_or_case_number}")
+async def get_thread(
+    thread_id_or_case_number: str,
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Thread + all messages in chronological order. Accepts UUID or `MT-{n}`."""
+    # Resolve to UUID first, then fetch with embedded messages.
+    thread = _resolve_thread_or_404(thread_id_or_case_number)
+    full = _threads_dao.get_thread_with_messages(thread["id"])
+    if not full:
+        # Could only happen on a race with deletion.
+        raise HTTPException(status_code=404, detail="thread not found")
+    return full
+
+
+@router.post("/threads/{thread_id}/reply")
+async def reply_to_thread(
+    thread_id: str,
+    request: ReplyRequest,
+    current_user: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Send an outbound reply on the thread.
+
+    - Generates a fresh Message-ID and threads correctly via In-Reply-To/References.
+    - Idempotently prefixes the subject with [MT-{n}].
+    - Persists the outbound message and transitions the thread to awaiting_user.
+    """
+    thread = _resolve_thread_or_404(thread_id)
+    admin_user_id = _admin_user_id(current_user)
+
+    try:
+        row = send_admin_reply(
+            _threads_dao,
+            _messages_dao,
+            thread=thread,
+            body_text=request.body_text,
+            body_html=request.body_html,
+            admin_user_id=admin_user_id,
+        )
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return row
+
+
+@router.patch("/threads/{thread_id}/status")
+async def patch_status(
+    thread_id: str,
+    request: StatusUpdateRequest,
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Manual status override (resolved / spam / awaiting_admin)."""
+    thread = _resolve_thread_or_404(thread_id)
+    try:
+        updated = _threads_dao.set_status(thread["id"], request.status)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if not updated:
+        raise HTTPException(status_code=404, detail="thread not found")
+    return updated
+
+
+@router.patch("/threads/{thread_id}/read")
+async def mark_read(
+    thread_id: str,
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Zero unread_count and stamp read_at on every unread message."""
+    thread = _resolve_thread_or_404(thread_id)
+    updated = _threads_dao.mark_all_read(thread["id"])
+    return {"thread_id": thread["id"], "messages_marked_read": updated}

--- a/backend/api/webhooks_email.py
+++ b/backend/api/webhooks_email.py
@@ -32,6 +32,7 @@ from services.email_inbound import (
     sanitize_html,
     verify_webhook,
 )
+from services.email_service import ensure_resend_api_key
 
 logger = structlog.get_logger(__name__)
 
@@ -219,23 +220,6 @@ async def email_inbound(request: Request) -> dict[str, Any]:
     }
 
 
-def _ensure_resend_api_key() -> None:
-    """Make sure resend.api_key is set before calling the Resend API.
-
-    EmailService.__init__ sets resend.api_key as a side effect, but that
-    only runs when an outbound email is actually sent. Inbound webhooks
-    can fire before any outbound has gone out — e.g. immediately after
-    a fresh pod start — at which point resend.api_key is still None and
-    the SDK raises ValidationError('API key is invalid') for any API
-    call. Set it ourselves from the env var; idempotent.
-    """
-    if resend.api_key:
-        return
-    api_key = os.getenv("RESEND_API_KEY")
-    if api_key:
-        resend.api_key = api_key
-
-
 def _fetch_received_email(email_id: str) -> dict[str, Any]:
     """Fetch the full ReceivedEmail from the Resend API.
 
@@ -243,7 +227,7 @@ def _fetch_received_email(email_id: str) -> dict[str, Any]:
     exceptions become 502 from the caller's perspective — Resend will
     retry, which is the right behavior for transient upstream failures.
     """
-    _ensure_resend_api_key()
+    ensure_resend_api_key()
     try:
         return resend.Emails.Receiving.get(email_id)
     except Exception as e:

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 import r2_client
+from api.admin_emails import router as admin_emails_router
 from api.channel_requests import router as channel_requests_router
 from api.club_notifications import router as club_notifications_router
 from api.invite_requests import router as invite_requests_router
@@ -259,6 +260,7 @@ app.include_router(invite_requests_router)
 app.include_router(channel_requests_router)
 app.include_router(club_notifications_router)
 app.include_router(webhooks_email_router)
+app.include_router(admin_emails_router)
 
 # Version endpoint
 import contextlib

--- a/backend/dao/email_messages_dao.py
+++ b/backend/dao/email_messages_dao.py
@@ -2,8 +2,10 @@
 EmailMessagesDAO — individual messages in support-inbox threads (SB-35).
 
 Phase 1 surface (webhook ingest): insert_inbound, find_by_message_id,
-find_thread_id_by_in_reply_to. Phase 2 (admin API) will add list_by_thread
-and insert_outbound for admin replies.
+find_thread_id_by_in_reply_to.
+
+Phase 2 surface (admin API): list_by_thread, insert_outbound,
+get_latest_inbound_for_thread.
 """
 
 from __future__ import annotations
@@ -109,5 +111,87 @@ class EmailMessagesDAO(BaseDAO):
             thread_id=thread_id,
             direction="inbound",
             had_attachments=had_attachments,
+        )
+        return row
+
+    # ── Phase 2: admin API surface ───────────────────────────────────────────
+
+    def list_by_thread(self, thread_id: str) -> list[dict[str, Any]]:
+        """All messages in a thread, oldest first."""
+        response = (
+            self.client.table("email_messages")
+            .select("*")
+            .eq("thread_id", thread_id)
+            .order("created_at", desc=False)
+            .execute()
+        )
+        return response.data or []
+
+    def get_latest_inbound_for_thread(
+        self, thread_id: str
+    ) -> dict[str, Any] | None:
+        """The most recent inbound message on a thread. Used by the admin-reply
+        path to set In-Reply-To on the outgoing message.
+        """
+        response = (
+            self.client.table("email_messages")
+            .select("*")
+            .eq("thread_id", thread_id)
+            .eq("direction", "inbound")
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    @invalidates_cache(EMAIL_MESSAGES_CACHE_PATTERN)
+    def insert_outbound(
+        self,
+        *,
+        thread_id: str,
+        message_id: str,
+        from_email: str,
+        to_email: str,
+        subject: str,
+        sent_by_user_id: str,
+        in_reply_to: str | None = None,
+        references: str | None = None,
+        body_text: str | None = None,
+        body_html: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert an outbound admin-reply message row.
+
+        Symmetric to insert_inbound, but the caller is the admin sending
+        the reply — sent_by_user_id is required and direction is 'outbound'.
+        had_attachments and raw_payload don't apply (we don't attach files
+        or have a provider payload to preserve on outbound).
+
+        message_id should be the angle-brackets-stripped form, for parity
+        with inbound storage (so In-Reply-To lookups work in both directions).
+        """
+        payload: dict[str, Any] = {
+            "thread_id": thread_id,
+            "direction": "outbound",
+            "message_id": message_id,
+            "from_email": from_email,
+            "to_email": to_email,
+            "subject": subject,
+            "in_reply_to": in_reply_to,
+            "references": references,
+            "body_text": body_text,
+            "body_html": body_html,
+            "had_attachments": False,
+            "sent_by_user_id": sent_by_user_id,
+        }
+        response = self.client.table("email_messages").insert(payload).execute()
+        if not response.data:
+            raise RuntimeError("email_messages insert returned no data")
+        row = response.data[0]
+        logger.info(
+            "email_message_inserted",
+            message_id=message_id,
+            thread_id=thread_id,
+            direction="outbound",
+            sent_by_user_id=sent_by_user_id,
         )
         return row

--- a/backend/dao/email_threads_dao.py
+++ b/backend/dao/email_threads_dao.py
@@ -2,12 +2,16 @@
 EmailThreadsDAO — support-inbox conversations (SB-35).
 
 Phase 1 surface (webhook ingest): create_for_inbound, transition_on_inbound,
-get_by_id, get_by_case_number. Phase 2 (admin API) will add listing,
-status overrides, and outbound-reply transitions.
+get_by_id, get_by_case_number.
+
+Phase 2 surface (admin API): list_by_status, get_thread_with_messages,
+transition_on_outbound, set_status, mark_all_read, unread_count_for_attention.
 """
 
 from __future__ import annotations
 
+import base64
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -17,6 +21,29 @@ from dao.base_dao import BaseDAO, invalidates_cache
 logger = structlog.get_logger()
 
 EMAIL_THREADS_CACHE_PATTERN = "mt:dao:email_threads:*"
+EMAIL_MESSAGES_CACHE_PATTERN = "mt:dao:email_messages:*"
+
+_VALID_STATUSES = frozenset({"new", "awaiting_admin", "awaiting_user", "resolved", "spam"})
+_MANUAL_STATUSES = frozenset({"resolved", "spam", "awaiting_admin"})
+
+
+def encode_cursor(last_message_at: str, thread_id: str) -> str:
+    """Opaque cursor for keyset pagination on (last_message_at desc, id desc).
+
+    Base64-encoded so callers don't depend on the internal shape.
+    """
+    raw = f"{last_message_at}|{thread_id}".encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_cursor(cursor: str) -> tuple[str, str]:
+    """Inverse of encode_cursor. Returns (last_message_at, thread_id)."""
+    padded = cursor + "=" * (-len(cursor) % 4)
+    raw = base64.urlsafe_b64decode(padded).decode()
+    ts, _, tid = raw.partition("|")
+    if not ts or not tid:
+        raise ValueError("invalid cursor")
+    return ts, tid
 
 
 class EmailThreadsDAO(BaseDAO):
@@ -167,3 +194,170 @@ class EmailThreadsDAO(BaseDAO):
             .execute()
         )
         return response.data[0] if response.data else None
+
+    # ── Phase 2: admin API surface ───────────────────────────────────────────
+
+    def list_by_status(
+        self,
+        statuses: list[str],
+        *,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Paginated list of threads filtered by status, newest-first.
+
+        Keyset cursor on `(last_message_at desc, id desc)` — stable across
+        inserts and avoids OFFSET's slow-scan behavior on large inboxes.
+
+        Args:
+            statuses: list of status values to include (e.g. ['new', 'awaiting_admin'])
+            limit: page size (caller should clamp to a sane max)
+            cursor: opaque cursor from a previous call (or None for first page)
+
+        Returns:
+            {"items": [thread_dict, ...], "next_cursor": str | None}
+
+            Threads come back with an embedded `message_count` so the admin UI's
+            list view doesn't have to N+1.
+        """
+        query = (
+            self.client.table("email_threads")
+            .select("*, email_messages(count)")
+            .in_("status", statuses)
+        )
+
+        if cursor:
+            try:
+                ts, tid = decode_cursor(cursor)
+            except (ValueError, Exception) as e:
+                raise ValueError(f"invalid cursor: {e}") from e
+            # PostgREST keyset: (last_message_at < ts) OR (last_message_at = ts AND id < tid)
+            query = query.or_(
+                f"last_message_at.lt.{ts},"
+                f"and(last_message_at.eq.{ts},id.lt.{tid})"
+            )
+
+        response = (
+            query.order("last_message_at", desc=True)
+            .order("id", desc=True)
+            .limit(limit + 1)
+            .execute()
+        )
+        rows = response.data or []
+
+        # Flatten embedded message_count and trim peek row used for cursor calc.
+        for row in rows:
+            embedded = row.pop("email_messages", None) or []
+            row["message_count"] = embedded[0]["count"] if embedded else 0
+
+        next_cursor: str | None = None
+        if len(rows) > limit:
+            rows = rows[:limit]
+            last = rows[-1]
+            next_cursor = encode_cursor(last["last_message_at"], last["id"])
+
+        return {"items": rows, "next_cursor": next_cursor}
+
+    def get_thread_with_messages(self, thread_id: str) -> dict[str, Any] | None:
+        """Fetch a thread plus all its messages in one round trip.
+
+        Messages are sorted chronologically (oldest first) — the order the
+        admin UI renders.
+        """
+        response = (
+            self.client.table("email_threads")
+            .select("*, email_messages(*)")
+            .eq("id", thread_id)
+            .limit(1)
+            .execute()
+        )
+        if not response.data:
+            return None
+        row = response.data[0]
+        messages = row.pop("email_messages", None) or []
+        messages.sort(key=lambda m: m.get("created_at") or "")
+        row["messages"] = messages
+        return row
+
+    @invalidates_cache(EMAIL_THREADS_CACHE_PATTERN)
+    def transition_on_outbound(
+        self,
+        thread_id: str,
+        *,
+        last_message_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        """An outbound admin reply was just sent on this thread.
+
+        Side effects:
+        - status → 'awaiting_user' (unconditional — admin has acted)
+        - last_message_at = max(existing, last_message_at)
+
+        Symmetric to transition_on_inbound. Does NOT bump unread_count
+        (outbound messages aren't "unread" from the admin's perspective).
+        """
+        updates: dict[str, Any] = {"status": "awaiting_user"}
+        if last_message_at:
+            updates["last_message_at"] = last_message_at
+
+        response = (
+            self.client.table("email_threads")
+            .update(updates)
+            .eq("id", thread_id)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    @invalidates_cache(EMAIL_THREADS_CACHE_PATTERN)
+    def set_status(self, thread_id: str, status: str) -> dict[str, Any] | None:
+        """Manual status override from an admin (resolved, spam, awaiting_admin).
+
+        Only the manual-override statuses are accepted here; auto-transitions
+        (new, awaiting_user) are owned by the inbound/outbound message paths.
+        """
+        if status not in _MANUAL_STATUSES:
+            raise ValueError(
+                f"status must be one of {sorted(_MANUAL_STATUSES)}, got {status!r}"
+            )
+        response = (
+            self.client.table("email_threads")
+            .update({"status": status})
+            .eq("id", thread_id)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    @invalidates_cache(EMAIL_THREADS_CACHE_PATTERN, EMAIL_MESSAGES_CACHE_PATTERN)
+    def mark_all_read(self, thread_id: str) -> int:
+        """Zero out the thread's unread_count and stamp read_at on every
+        previously-unread message. Returns the number of message rows updated.
+        """
+        now_iso = datetime.now(UTC).isoformat()
+
+        # Stamp unread messages first so we know how many actually changed.
+        msg_response = (
+            self.client.table("email_messages")
+            .update({"read_at": now_iso})
+            .eq("thread_id", thread_id)
+            .is_("read_at", None)
+            .execute()
+        )
+        updated_count = len(msg_response.data or [])
+
+        self.client.table("email_threads").update({"unread_count": 0}).eq(
+            "id", thread_id
+        ).execute()
+
+        return updated_count
+
+    def unread_count_for_attention(self) -> int:
+        """Sum of unread_count across threads that need admin attention.
+
+        Powers the Phase 3 nav badge. Cacheable upstream for ~30s.
+        """
+        response = (
+            self.client.table("email_threads")
+            .select("unread_count")
+            .in_("status", ["new", "awaiting_admin"])
+            .execute()
+        )
+        return sum((row.get("unread_count") or 0) for row in (response.data or []))

--- a/backend/services/email_outbound.py
+++ b/backend/services/email_outbound.py
@@ -1,0 +1,198 @@
+"""
+Outbound-reply primitives for the Support Inbox (SB-35 Phase 2).
+
+Pure helpers + a thin orchestrator the admin-API route can call to send
+a reply on an existing thread.
+
+- generate_message_id()              fresh RFC-5322 Message-ID, ours-namespaced
+- prefix_subject_with_case_number()  idempotent [MT-{n}] prefix
+- build_references()                 References chain, deduped
+- send_admin_reply()                 orchestrates: send via Resend + persist + transition
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import resend
+import structlog
+
+from services.email_service import SUPPORT_EMAIL, ensure_resend_api_key
+
+if TYPE_CHECKING:
+    from dao.email_messages_dao import EmailMessagesDAO
+    from dao.email_threads_dao import EmailThreadsDAO
+
+logger = structlog.get_logger()
+
+
+_MESSAGE_ID_DOMAIN = "missingtable.com"
+_REPLY_PREFIX_RE = re.compile(r"^\s*(?:re|fwd?|fw)\s*:\s*", re.IGNORECASE)
+
+
+def generate_message_id() -> str:
+    """Return a stable, ours-namespaced Message-ID without angle brackets.
+
+    Storage form is angle-bracket-stripped for parity with inbound (we
+    strip them at ingest). Callers wrap in `<>` when setting the actual
+    Message-ID header on the outgoing email.
+    """
+    return f"mt-{uuid.uuid4()}@{_MESSAGE_ID_DOMAIN}"
+
+
+def prefix_subject_with_case_number(subject: str | None, case_number: int) -> str:
+    """Ensure the subject carries `[MT-{case_number}]` and starts with `Re: `.
+
+    Idempotent: calling twice produces the same string. Examples (case_number=1):
+        "My Question"                    → "Re: [MT-1] My Question"
+        "Re: My Question"                → "Re: [MT-1] My Question"
+        "Re: Re: My Question"            → "Re: [MT-1] My Question"
+        "[MT-1] My Question"             → "Re: [MT-1] My Question"
+        "Re: [MT-1] My Question"         → "Re: [MT-1] My Question"  (unchanged)
+        "Re: Re: [MT-1] My Question"     → "Re: Re: [MT-1] My Question"  (unchanged)
+    """
+    raw = (subject or "").strip()
+    token_re = re.compile(rf"\[\s*MT-{case_number}\s*\]", re.IGNORECASE)
+
+    if token_re.search(raw):
+        # Already tagged — just make sure it reads like a reply.
+        if _REPLY_PREFIX_RE.match(raw):
+            return raw
+        return f"Re: {raw}"
+
+    # Collapse any leading Re:/Fwd:/Fw: chain before inserting the tag.
+    stripped = raw
+    while True:
+        nxt = _REPLY_PREFIX_RE.sub("", stripped, count=1)
+        if nxt == stripped:
+            break
+        stripped = nxt
+
+    body = stripped or "(no subject)"
+    return f"Re: [MT-{case_number}] {body}"
+
+
+def build_references(existing_references: str | None, in_reply_to_id: str | None) -> str:
+    """Append `in_reply_to_id` (angle-bracketed) to the existing References
+    chain, deduped, whitespace-separated. Returns an empty string when both
+    inputs are empty.
+    """
+    ids: list[str] = (existing_references or "").split()
+    if in_reply_to_id:
+        bracketed = (
+            in_reply_to_id if in_reply_to_id.startswith("<") else f"<{in_reply_to_id}>"
+        )
+        if bracketed not in ids:
+            ids.append(bracketed)
+    return " ".join(ids)
+
+
+def _strip_angle_brackets(value: str | None) -> str | None:
+    """Mirror of the inbound webhook helper. RFC 5322 Message-IDs are wrapped
+    in `<>`. Strip them for storage so equality lookups don't care about wrapping.
+    """
+    if not value:
+        return value
+    s = value.strip()
+    if s.startswith("<") and s.endswith(">"):
+        return s[1:-1]
+    return s
+
+
+def send_admin_reply(
+    threads_dao: EmailThreadsDAO,
+    messages_dao: EmailMessagesDAO,
+    *,
+    thread: dict[str, Any],
+    body_text: str,
+    body_html: str | None,
+    admin_user_id: str,
+) -> dict[str, Any]:
+    """Send an outbound admin reply on a thread, then persist + transition.
+
+    Steps:
+    1. Look up the latest inbound message to set In-Reply-To + extend References.
+    2. Generate a fresh Message-ID; prefix the subject idempotently.
+    3. Call `resend.Emails.send` (with `ensure_resend_api_key()` first — lesson
+       #2 from Phase 1 applies here too).
+    4. Persist the outbound message and transition the thread to `awaiting_user`.
+
+    Returns the inserted message row.
+
+    Raises RuntimeError on send failure — caller maps to 5xx.
+    """
+    latest_inbound = messages_dao.get_latest_inbound_for_thread(thread["id"])
+
+    in_reply_to_stripped = (
+        latest_inbound["message_id"] if latest_inbound else None
+    )
+    in_reply_to_bracketed = (
+        f"<{in_reply_to_stripped}>" if in_reply_to_stripped else None
+    )
+    references = build_references(
+        latest_inbound.get("references") if latest_inbound else None,
+        in_reply_to_stripped,
+    )
+
+    subject = prefix_subject_with_case_number(
+        thread.get("subject"), thread["case_number"]
+    )
+
+    message_id = generate_message_id()  # stored stripped
+    message_id_bracketed = f"<{message_id}>"
+
+    to_email = thread["participant_email"]
+
+    custom_headers: dict[str, str] = {"Message-ID": message_id_bracketed}
+    if in_reply_to_bracketed:
+        custom_headers["In-Reply-To"] = in_reply_to_bracketed
+    if references:
+        custom_headers["References"] = references
+
+    payload: dict[str, Any] = {
+        "from": SUPPORT_EMAIL,
+        "to": [to_email],
+        "subject": subject,
+        "text": body_text,
+        "headers": custom_headers,
+    }
+    if body_html:
+        payload["html"] = body_html
+
+    ensure_resend_api_key()
+    try:
+        resend.Emails.send(payload)
+    except Exception as e:
+        logger.exception(
+            "admin_reply_send_failed",
+            thread_id=thread["id"],
+            case_number=thread["case_number"],
+        )
+        raise RuntimeError(f"failed to send admin reply: {e}") from e
+
+    now_iso = datetime.now(UTC).isoformat()
+    row = messages_dao.insert_outbound(
+        thread_id=thread["id"],
+        message_id=message_id,
+        from_email=SUPPORT_EMAIL,
+        to_email=to_email,
+        subject=subject,
+        sent_by_user_id=admin_user_id,
+        in_reply_to=in_reply_to_stripped,
+        references=references or None,
+        body_text=body_text,
+        body_html=body_html,
+    )
+    threads_dao.transition_on_outbound(thread["id"], last_message_at=now_iso)
+
+    logger.info(
+        "admin_reply_sent",
+        thread_id=thread["id"],
+        case_number=thread["case_number"],
+        message_id=message_id,
+        admin_user_id=admin_user_id,
+    )
+    return row

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -14,6 +14,23 @@ logger = logging.getLogger(__name__)
 SUPPORT_EMAIL = "support@contact.missingtable.com"
 
 
+def ensure_resend_api_key() -> None:
+    """Make sure resend.api_key is set before any Resend SDK call.
+
+    EmailService.__init__ sets resend.api_key as a side effect, but that
+    only runs when an outbound email is actually sent. The inbound webhook
+    and admin-reply paths can fire before any outbound has gone out — e.g.
+    immediately after a fresh pod start — at which point resend.api_key is
+    still None and the SDK raises ValidationError('API key is invalid')
+    for any API call. Set it ourselves from the env var; idempotent.
+    """
+    if resend.api_key:
+        return
+    api_key = os.getenv("RESEND_API_KEY")
+    if api_key:
+        resend.api_key = api_key
+
+
 def _support_html_block() -> str:
     """Inline support line for invite-flow HTML emails."""
     return (

--- a/backend/tests/unit/test_admin_emails.py
+++ b/backend/tests/unit/test_admin_emails.py
@@ -1,0 +1,539 @@
+"""Unit tests for the Support Inbox admin API (SB-35 Phase 2).
+
+Covers:
+- pure helpers in services/email_outbound (subject prefix, references, message-id)
+- send_admin_reply orchestrator with mocked DAOs + resend
+- /api/admin/emails/* endpoints with require_admin overridden + DAOs patched
+
+No database. Integration tests against real Supabase land later.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("EMAIL_INBOUND_WEBHOOK_SECRET", raising=False)
+    yield
+
+
+# ── Pure helpers: prefix_subject_with_case_number ────────────────────────────
+
+
+class TestPrefixSubjectWithCaseNumber:
+    def test_no_token_adds_re_and_prefix(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        assert prefix_subject_with_case_number("My Question", 1) == "Re: [MT-1] My Question"
+
+    def test_strips_single_re_then_adds(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        assert prefix_subject_with_case_number("Re: My Question", 7) == "Re: [MT-7] My Question"
+
+    def test_strips_chained_re_then_adds(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        assert (
+            prefix_subject_with_case_number("Re: Re: Fwd: Hello", 42)
+            == "Re: [MT-42] Hello"
+        )
+
+    def test_already_has_token_and_re_is_unchanged(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        assert (
+            prefix_subject_with_case_number("Re: [MT-1] My Question", 1)
+            == "Re: [MT-1] My Question"
+        )
+
+    def test_already_has_token_no_re_adds_re(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        assert (
+            prefix_subject_with_case_number("[MT-1] My Question", 1)
+            == "Re: [MT-1] My Question"
+        )
+
+    def test_double_re_with_token_unchanged(self):
+        # The brief's "don't double-prefix on Re: Re: [MT-1]" case.
+        from services.email_outbound import prefix_subject_with_case_number
+        assert (
+            prefix_subject_with_case_number("Re: Re: [MT-1] My Question", 1)
+            == "Re: Re: [MT-1] My Question"
+        )
+
+    def test_calling_twice_is_idempotent(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        once = prefix_subject_with_case_number("My Question", 5)
+        twice = prefix_subject_with_case_number(once, 5)
+        assert once == twice
+
+    def test_empty_subject_becomes_no_subject(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        assert prefix_subject_with_case_number("", 9) == "Re: [MT-9] (no subject)"
+
+    def test_lowercase_token_match_idempotent(self):
+        from services.email_outbound import prefix_subject_with_case_number
+        # Case-insensitive on MT, but our prefix output is canonical [MT-1].
+        assert (
+            prefix_subject_with_case_number("Re: [mt-1] My Question", 1)
+            == "Re: [mt-1] My Question"
+        )
+
+
+# ── Pure helpers: generate_message_id ────────────────────────────────────────
+
+
+class TestGenerateMessageId:
+    def test_format(self):
+        from services.email_outbound import generate_message_id
+        mid = generate_message_id()
+        assert mid.startswith("mt-")
+        assert mid.endswith("@missingtable.com")
+        # No angle brackets in returned value.
+        assert "<" not in mid and ">" not in mid
+
+    def test_uniqueness(self):
+        from services.email_outbound import generate_message_id
+        a, b = generate_message_id(), generate_message_id()
+        assert a != b
+
+
+# ── Pure helpers: build_references ───────────────────────────────────────────
+
+
+class TestBuildReferences:
+    def test_empty_inputs_returns_empty_string(self):
+        from services.email_outbound import build_references
+        assert build_references(None, None) == ""
+        assert build_references("", None) == ""
+
+    def test_appends_in_reply_to_bracketed(self):
+        from services.email_outbound import build_references
+        # in_reply_to is the stripped form; helper brackets it for storage.
+        result = build_references("<a@x> <b@x>", "c@x")
+        assert result == "<a@x> <b@x> <c@x>"
+
+    def test_dedupe_when_already_present(self):
+        from services.email_outbound import build_references
+        result = build_references("<a@x> <b@x>", "b@x")
+        # The bracketed form <b@x> is already in the chain.
+        assert result == "<a@x> <b@x>"
+
+    def test_no_existing_references_just_brackets_new(self):
+        from services.email_outbound import build_references
+        assert build_references(None, "lonely@x") == "<lonely@x>"
+
+
+# ── send_admin_reply orchestrator ────────────────────────────────────────────
+
+
+def _thread(case_number: int = 1, **overrides):
+    base = {
+        "id": "thread-uuid",
+        "case_number": case_number,
+        "subject": "My Question",
+        "participant_email": "jane@example.com",
+        "status": "awaiting_admin",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSendAdminReply:
+    def _make_daos(self, latest_inbound=None):
+        threads = MagicMock()
+        messages = MagicMock()
+        messages.get_latest_inbound_for_thread.return_value = latest_inbound
+        messages.insert_outbound.return_value = {
+            "id": "msg-row", "direction": "outbound"
+        }
+        threads.transition_on_outbound.return_value = _thread(status="awaiting_user")
+        return threads, messages
+
+    def test_sets_in_reply_to_and_references_headers(self, monkeypatch):
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        latest = {
+            "message_id": "user-msg-1@example.com",
+            "references": "<orig@example.com> <user-msg-1@example.com>",
+        }
+        threads, messages = self._make_daos(latest_inbound=latest)
+
+        with patch.object(email_outbound.resend.Emails, "send") as mock_send:
+            email_outbound.send_admin_reply(
+                threads, messages,
+                thread=_thread(),
+                body_text="Hi Jane, here's an answer.",
+                body_html=None,
+                admin_user_id="admin-1",
+            )
+
+        kwargs_payload = mock_send.call_args.args[0]
+        headers = kwargs_payload["headers"]
+        assert headers["In-Reply-To"] == "<user-msg-1@example.com>"
+        # References already contained <user-msg-1@example.com> → not re-appended.
+        assert headers["References"] == "<orig@example.com> <user-msg-1@example.com>"
+        assert headers["Message-ID"].startswith("<mt-")
+        assert headers["Message-ID"].endswith("@missingtable.com>")
+
+    def test_subject_prefixed_with_case_number(self, monkeypatch):
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        threads, messages = self._make_daos(
+            latest_inbound={"message_id": "u@x", "references": None}
+        )
+
+        with patch.object(email_outbound.resend.Emails, "send") as mock_send:
+            email_outbound.send_admin_reply(
+                threads, messages,
+                thread=_thread(case_number=42),
+                body_text="answer",
+                body_html=None,
+                admin_user_id="admin-1",
+            )
+
+        payload = mock_send.call_args.args[0]
+        assert payload["subject"] == "Re: [MT-42] My Question"
+        assert payload["from"] == "support@contact.missingtable.com"
+        assert payload["to"] == ["jane@example.com"]
+
+    def test_subject_prefix_idempotent_on_already_prefixed_thread(self, monkeypatch):
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        threads, messages = self._make_daos(
+            latest_inbound={"message_id": "u@x", "references": None}
+        )
+
+        with patch.object(email_outbound.resend.Emails, "send") as mock_send:
+            email_outbound.send_admin_reply(
+                threads, messages,
+                thread=_thread(case_number=1, subject="Re: [MT-1] My Question"),
+                body_text="answer",
+                body_html=None,
+                admin_user_id="admin-1",
+            )
+
+        assert mock_send.call_args.args[0]["subject"] == "Re: [MT-1] My Question"
+
+    def test_persists_outbound_with_stripped_message_id(self, monkeypatch):
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        threads, messages = self._make_daos(
+            latest_inbound={"message_id": "u@x", "references": None}
+        )
+
+        with patch.object(email_outbound.resend.Emails, "send"):
+            email_outbound.send_admin_reply(
+                threads, messages,
+                thread=_thread(),
+                body_text="answer",
+                body_html="<p>answer</p>",
+                admin_user_id="admin-1",
+            )
+
+        ins = messages.insert_outbound.call_args.kwargs
+        # Stored without angle brackets (parity with inbound storage).
+        assert ins["message_id"].startswith("mt-")
+        assert ins["message_id"].endswith("@missingtable.com")
+        assert "<" not in ins["message_id"]
+        # In-Reply-To is the bare (stripped) inbound message_id.
+        assert ins["in_reply_to"] == "u@x"
+        assert ins["sent_by_user_id"] == "admin-1"
+        assert ins["body_html"] == "<p>answer</p>"
+        assert ins["from_email"] == "support@contact.missingtable.com"
+
+    def test_transitions_thread_to_awaiting_user(self, monkeypatch):
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        threads, messages = self._make_daos(
+            latest_inbound={"message_id": "u@x", "references": None}
+        )
+
+        with patch.object(email_outbound.resend.Emails, "send"):
+            email_outbound.send_admin_reply(
+                threads, messages,
+                thread=_thread(),
+                body_text="answer",
+                body_html=None,
+                admin_user_id="admin-1",
+            )
+
+        threads.transition_on_outbound.assert_called_once()
+        kwargs = threads.transition_on_outbound.call_args.kwargs
+        assert kwargs["last_message_at"]  # ISO timestamp string
+
+    def test_ensures_resend_api_key_before_send(self, monkeypatch):
+        """Regression: lesson #2 from Phase 1 applies to the outbound path too.
+        On a fresh pod, resend.api_key may still be None when an admin clicks
+        Reply. Verify the orchestrator sets it from the env var so Emails.send
+        doesn't fail with ValidationError('API key is invalid')."""
+        import resend as resend_mod
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test_outbound_set")
+
+        original = resend_mod.api_key
+        resend_mod.api_key = None
+        try:
+            threads, messages = self._make_daos(
+                latest_inbound={"message_id": "u@x", "references": None}
+            )
+            with patch.object(email_outbound.resend.Emails, "send"):
+                email_outbound.send_admin_reply(
+                    threads, messages,
+                    thread=_thread(),
+                    body_text="answer",
+                    body_html=None,
+                    admin_user_id="admin-1",
+                )
+            assert resend_mod.api_key == "re_test_outbound_set"
+        finally:
+            resend_mod.api_key = original
+
+    def test_no_inbound_yet_still_sends_without_in_reply_to(self, monkeypatch):
+        # Admin starts a thread before any inbound exists — shouldn't crash.
+        from services import email_outbound
+        monkeypatch.setenv("RESEND_API_KEY", "re_test")
+        threads, messages = self._make_daos(latest_inbound=None)
+
+        with patch.object(email_outbound.resend.Emails, "send") as mock_send:
+            email_outbound.send_admin_reply(
+                threads, messages,
+                thread=_thread(),
+                body_text="answer",
+                body_html=None,
+                admin_user_id="admin-1",
+            )
+
+        headers = mock_send.call_args.args[0]["headers"]
+        assert "In-Reply-To" not in headers
+        # References can be empty / omitted.
+        assert headers.get("References", "") == ""
+
+
+# ── Endpoint tests ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def admin_client():
+    """Minimal FastAPI app with the admin_emails router and require_admin
+    overridden to a stub admin user. The module-level DAO singletons are
+    accessible via `module._threads_dao` / `module._messages_dao` so each
+    test can patch their methods."""
+    from api import admin_emails
+    from auth import require_admin
+
+    app = FastAPI()
+    app.include_router(admin_emails.router)
+    app.dependency_overrides[require_admin] = lambda: {
+        "id": "admin-user-1", "role": "admin", "username": "admin"
+    }
+    return TestClient(app), admin_emails
+
+
+class TestListThreadsEndpoint:
+    def test_default_status_filter_applied(self, admin_client):
+        client, module = admin_client
+        with patch.object(
+            module._threads_dao, "list_by_status",
+            return_value={"items": [], "next_cursor": None},
+        ) as mock_list:
+            resp = client.get("/api/admin/emails/threads")
+        assert resp.status_code == 200
+        args, kwargs = mock_list.call_args
+        assert args[0] == ["new", "awaiting_admin"]
+        assert kwargs["limit"] == 50
+        assert kwargs["cursor"] is None
+
+    def test_status_csv_parsed(self, admin_client):
+        client, module = admin_client
+        with patch.object(
+            module._threads_dao, "list_by_status",
+            return_value={"items": [], "next_cursor": None},
+        ) as mock_list:
+            resp = client.get("/api/admin/emails/threads?status=resolved,spam")
+        assert resp.status_code == 200
+        assert mock_list.call_args.args[0] == ["resolved", "spam"]
+
+    def test_invalid_status_returns_400(self, admin_client):
+        client, _ = admin_client
+        resp = client.get("/api/admin/emails/threads?status=nope")
+        assert resp.status_code == 400
+
+    def test_cursor_passed_through_to_dao(self, admin_client):
+        client, module = admin_client
+        with patch.object(
+            module._threads_dao, "list_by_status",
+            return_value={"items": [], "next_cursor": None},
+        ) as mock_list:
+            client.get("/api/admin/emails/threads?cursor=opaque-token")
+        assert mock_list.call_args.kwargs["cursor"] == "opaque-token"
+
+    def test_limit_clamped_by_query_validator(self, admin_client):
+        client, _ = admin_client
+        resp = client.get("/api/admin/emails/threads?limit=999")
+        # 200 ≤ limit ≤ 200 enforced by FastAPI Query(le=200)
+        assert resp.status_code == 422
+
+
+class TestGetThreadEndpoint:
+    def test_resolves_mt_n_form(self, admin_client):
+        client, module = admin_client
+        thread = {"id": "t1", "case_number": 42, "subject": "x", "status": "new"}
+        with (
+            patch.object(module._threads_dao, "get_by_case_number", return_value=thread),
+            patch.object(module._threads_dao, "get_thread_with_messages",
+                         return_value={**thread, "messages": []}),
+        ):
+            resp = client.get("/api/admin/emails/threads/MT-42")
+        assert resp.status_code == 200
+        assert resp.json()["case_number"] == 42
+
+    def test_resolves_uuid_form(self, admin_client):
+        client, module = admin_client
+        thread = {"id": "abc-uuid", "case_number": 7, "subject": "x", "status": "new"}
+        with (
+            patch.object(module._threads_dao, "get_thread_by_id", return_value=thread),
+            patch.object(module._threads_dao, "get_thread_with_messages",
+                         return_value={**thread, "messages": [{"id": "m1"}]}),
+        ):
+            resp = client.get("/api/admin/emails/threads/abc-uuid")
+        assert resp.status_code == 200
+        assert resp.json()["messages"] == [{"id": "m1"}]
+
+    def test_404_when_missing(self, admin_client):
+        client, module = admin_client
+        with patch.object(module._threads_dao, "get_by_case_number", return_value=None):
+            resp = client.get("/api/admin/emails/threads/MT-9999")
+        assert resp.status_code == 404
+
+
+class TestPatchEndpoints:
+    def test_patch_status_sets_status(self, admin_client):
+        client, module = admin_client
+        thread = {"id": "t1", "case_number": 1, "subject": "x", "status": "new"}
+        with (
+            patch.object(module._threads_dao, "get_thread_by_id", return_value=thread),
+            patch.object(module._threads_dao, "set_status",
+                         return_value={**thread, "status": "resolved"}) as set_status,
+        ):
+            resp = client.patch(
+                "/api/admin/emails/threads/t1/status",
+                json={"status": "resolved"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "resolved"
+        set_status.assert_called_once_with("t1", "resolved")
+
+    def test_patch_status_rejects_invalid_status(self, admin_client):
+        client, module = admin_client
+        thread = {"id": "t1", "case_number": 1, "subject": "x", "status": "new"}
+        with patch.object(module._threads_dao, "get_thread_by_id", return_value=thread):
+            resp = client.patch(
+                "/api/admin/emails/threads/t1/status",
+                json={"status": "awaiting_user"},  # not a manual override
+            )
+        # Pydantic Literal rejects → 422.
+        assert resp.status_code == 422
+
+    def test_patch_read_zeros_unread(self, admin_client):
+        client, module = admin_client
+        thread = {"id": "t1", "case_number": 1, "subject": "x", "status": "new"}
+        with (
+            patch.object(module._threads_dao, "get_thread_by_id", return_value=thread),
+            patch.object(module._threads_dao, "mark_all_read", return_value=3) as mark,
+        ):
+            resp = client.patch("/api/admin/emails/threads/t1/read")
+        assert resp.status_code == 200
+        assert resp.json() == {"thread_id": "t1", "messages_marked_read": 3}
+        mark.assert_called_once_with("t1")
+
+
+class TestUnreadCountEndpoint:
+    def test_returns_summed_count(self, admin_client):
+        client, module = admin_client
+        with patch.object(
+            module._threads_dao, "unread_count_for_attention", return_value=7
+        ):
+            resp = client.get("/api/admin/emails/unread-count")
+        assert resp.status_code == 200
+        assert resp.json() == {"count": 7}
+
+
+class TestReplyEndpoint:
+    def test_reply_orchestrator_called_with_thread_and_admin_id(self, admin_client):
+        client, module = admin_client
+        thread = {
+            "id": "t1", "case_number": 1, "subject": "My Q",
+            "participant_email": "j@x", "status": "awaiting_admin",
+        }
+        inserted = {"id": "msg-row", "direction": "outbound", "thread_id": "t1"}
+
+        with (
+            patch.object(module._threads_dao, "get_thread_by_id", return_value=thread),
+            patch("api.admin_emails.send_admin_reply", return_value=inserted) as send,
+        ):
+            resp = client.post(
+                "/api/admin/emails/threads/t1/reply",
+                json={"body_text": "Thanks for reaching out!"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == inserted
+        kwargs = send.call_args.kwargs
+        assert kwargs["thread"] is thread
+        assert kwargs["body_text"] == "Thanks for reaching out!"
+        assert kwargs["admin_user_id"] == "admin-user-1"
+
+    def test_reply_rejects_empty_body(self, admin_client):
+        client, _ = admin_client
+        resp = client.post(
+            "/api/admin/emails/threads/t1/reply",
+            json={"body_text": ""},
+        )
+        assert resp.status_code == 422  # min_length=1
+
+    def test_reply_502_when_send_fails(self, admin_client):
+        client, module = admin_client
+        thread = {
+            "id": "t1", "case_number": 1, "subject": "My Q",
+            "participant_email": "j@x", "status": "awaiting_admin",
+        }
+        with (
+            patch.object(module._threads_dao, "get_thread_by_id", return_value=thread),
+            patch(
+                "api.admin_emails.send_admin_reply",
+                side_effect=RuntimeError("resend exploded"),
+            ),
+        ):
+            resp = client.post(
+                "/api/admin/emails/threads/t1/reply",
+                json={"body_text": "hi"},
+            )
+        assert resp.status_code == 502
+
+
+class TestAuthGating:
+    def test_requires_admin(self):
+        """Without the dependency override, require_admin on a 403-rolled user."""
+        from api import admin_emails
+        from auth import require_admin
+
+        app = FastAPI()
+        app.include_router(admin_emails.router)
+        # Simulate an authenticated non-admin user. require_admin checks role.
+        def _non_admin():
+            from fastapi import HTTPException
+            raise HTTPException(status_code=403, detail="Admin access required")
+        app.dependency_overrides[require_admin] = _non_admin
+
+        client = TestClient(app)
+        for path in [
+            "/api/admin/emails/threads",
+            "/api/admin/emails/unread-count",
+            "/api/admin/emails/threads/MT-1",
+        ]:
+            resp = client.get(path)
+            assert resp.status_code == 403, path


### PR DESCRIPTION
## Summary

Phase 2 of the Support Inbox feature ([SB-35](https://linear.app/silverbeer/issue/SB-35)) — adds the admin-facing HTTP API ([SB-40](https://linear.app/silverbeer/issue/SB-40)) that the Phase 3 UI will consume, plus the outbound reply path so admins can respond from inside MT.

- 6 new endpoints under `/api/admin/emails/*`, all gated by `require_admin`
- Outbound replies set `Message-ID` / `In-Reply-To` / `References` so user mail clients keep the thread
- Subject prefixing with `[MT-{n}]` is idempotent (no double-prefix on `Re: Re: [MT-1]` chains)

## What changed

**New router** — `backend/api/admin_emails.py`:
| Method | Path | Behavior |
|---|---|---|
| `GET` | `/api/admin/emails/threads` | Keyset-paginated list. `status` (CSV, default `new,awaiting_admin`), `cursor` (opaque), `limit` (≤200). |
| `GET` | `/api/admin/emails/threads/{id_or_case_number}` | Thread + chronological messages. Accepts UUID or `MT-{n}`. |
| `POST` | `/api/admin/emails/threads/{thread_id}/reply` | Send outbound + persist + transition to `awaiting_user`. |
| `PATCH` | `/api/admin/emails/threads/{thread_id}/status` | Manual override (`resolved` / `spam` / `awaiting_admin`). |
| `PATCH` | `/api/admin/emails/threads/{thread_id}/read` | Zero `unread_count`, stamp `read_at` on every unread message. |
| `GET` | `/api/admin/emails/unread-count` | Sum across threads in (`new`, `awaiting_admin`). |

**New outbound service** — `backend/services/email_outbound.py`:
- `generate_message_id()` → `mt-{uuid}@missingtable.com` (stored bracket-stripped, sent bracketed)
- `prefix_subject_with_case_number()` — idempotent `[MT-{n}]` insertion + canonical `Re: ` prefix
- `build_references()` — appends to the existing chain, deduped, whitespace-separated
- `send_admin_reply()` — orchestrator; looks up the latest inbound for `In-Reply-To`, prefixes subject, calls Resend, persists, transitions

**DAO extensions** — `dao/email_threads_dao.py` + `dao/email_messages_dao.py`:
- `list_by_status` (keyset cursor `(last_message_at, id)` via base64 opaque token)
- `get_thread_with_messages` (single-query embedded select, no N+1)
- `transition_on_outbound`, `set_status`, `mark_all_read`, `unread_count_for_attention`
- `list_by_thread`, `insert_outbound`, `get_latest_inbound_for_thread`

**Refactor** — `services/email_service.py` gains `ensure_resend_api_key()`:
- Promoted from `api/webhooks_email.py` since the outbound reply path hits the same lazy-init trap that Phase 1 paid for (lesson #2 in the feature doc).
- Inbound webhook now imports from the shared location; behaviour unchanged.

**Schema**: no migration required — Phase 2 is pure-API on the existing tables. Avoids the [SB-37](https://linear.app/silverbeer/issue/SB-37) migration-tracking-drift workaround.

## Test plan

**Automated:**
- [x] 38 new unit tests in `backend/tests/unit/test_admin_emails.py`:
  - 9 covering `prefix_subject_with_case_number` (idempotency, `Re:` chains, the `Re: Re: [MT-1]` no-double-prefix case from the brief)
  - 2 for `generate_message_id`, 4 for `build_references`
  - 7 for the `send_admin_reply` orchestrator — asserts `In-Reply-To`, `References`, `Message-ID` headers passed to a mocked `resend.Emails.send`, subject prefixing, `awaiting_user` transition, `ensure_resend_api_key` on a fresh-pod scenario, and the no-prior-inbound edge case
  - 16 for the endpoints — status CSV parsing, MT-N vs UUID path resolution, 404s, 422s, auth gating on three GETs
- [x] All 35 Phase 1 inbound tests still pass
- [x] Full unit suite: **385 passed, 12 skipped**
- [x] `ruff check .` clean

**Manual (suggested before merge):**
- [ ] Authenticated `curl` against local backend lists threads (MT-1 from prod or seed local)
- [ ] `POST .../reply` — verify reply sends via Resend, persists, and transitions to `awaiting_user`
- [ ] Inspect captured Resend payload: subject = `Re: [MT-{n}] …`, `In-Reply-To` matches latest inbound, `References` chain extended

## Notes

- DB writes use the service-role client (same pattern as `backend/api/invites.py`); `require_admin` is the trust gate.
- Inbound webhook behaviour and DB schema unchanged — the production MT-1 thread is unaffected.
- Phase 3 (admin UI) is intentionally out of scope; will consume these endpoints in a follow-up PR.

Refs: [SB-40](https://linear.app/silverbeer/issue/SB-40), [SB-35](https://linear.app/silverbeer/issue/SB-35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)