### PR TITLE
feat(load-tournament-matches): upsert match scores from screenshots

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: load-tournament-matches
-description: Load a tournament's bracket and results into Missing Table from a pasted screenshot. Extracts matches, teams, and logos via vision; confirms each club/team with the user before creating; then POSTs the matches to the tournament. Use when the user pastes a screenshot of a tournament results / bracket page (mlssoccer.com, GotSport, etc.).
+description: Load a tournament's bracket and results into Missing Table from a pasted screenshot. Extracts matches, teams, and logos via vision; confirms each club/team with the user before creating; then upserts the matches into the tournament — creating new matchups and filling in scores on matches that already exist. Use when the user pastes a screenshot of a tournament results / bracket page (mlssoccer.com, GotSport, etc.), including follow-up screenshots that add scores to a round you already loaded.
 allowed-tools: Bash, Read
 ---
 
 # Load Tournament Matches
 
-This skill loads a tournament's matches into Missing Table from a screenshot. It handles the **full richness** flow: it creates missing clubs (with cropped logos) and teams, then POSTs the matches to the tournament. Resolution is human-confirmed at every fuzzy step — nothing is silently created.
+This skill loads a tournament's matches into Missing Table from a screenshot. It handles the **full richness** flow: it creates missing clubs (with cropped logos) and teams, then **upserts** the matches into the tournament. Resolution is human-confirmed at every fuzzy step — nothing is silently created or overwritten.
+
+**Upsert, not just insert.** A round's scores rarely arrive all at once. The typical loop is: load the matchups (scheduled, no scores) → later upload a screenshot where some scores are in → later again with more scores → then the next round's matchups, and repeat. So every run *reconciles* the screenshot against what's already in the tournament: it **creates** matchups that don't exist yet, **fills in scores** on matches that exist but aren't scored, leaves already-correct matches **untouched**, and **flags** (never silently overwrites) any match whose existing score disagrees with the screenshot.
 
 ## Prerequisites — check these BEFORE doing anything else
 
@@ -56,8 +58,10 @@ Quick subcommand map:
 | Look up a team (admin endpoint with exact + similar) | `team lookup "<name>"` |
 | Create a team | `team create --name --city --age-group-id --division-id [--club-id] [--academy-team]` |
 | Find a tournament by name | `tournament find "<name>"` |
+| List a tournament's existing matches (for upsert mapping) | `tournament matches <tournament_id>` |
 | Create a tournament | `tournament create --name --start-date [--end-date --age-group-ids 1,2,3]` |
 | Add a match to a tournament | `match create --tournament-id --our-team-id --opponent-name --match-date --age-group-id --season-id [--home-score ... --tournament-round ...]` |
+| Update an existing match (fill in scores/status) | `match update --tournament-id --match-id [--home-score ... --away-score ... --match-status completed ...]` |
 
 ## Workflow
 
@@ -156,9 +160,33 @@ Response shape: `{"exact": team | null, "similar": [team, ...]}`.
 
 Keep a running map of resolved `team name → team id` so you don't lookup the same team twice across multiple matches.
 
-### Step 5 — create each match
+### Step 5 — reconcile the screenshot against existing matches
 
-For every match in the screenshot:
+**Before writing anything, find out what's already in the tournament.** This is what turns the skill from insert-only into upsert and lets the user upload scores in waves.
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py tournament matches <tournament_id>
+```
+
+This returns `{"matches": [{id, match_date, match_status, tournament_round, home_team:{id,name}, away_team:{id,name}, home_score, away_score, home_penalty_score, away_penalty_score}, ...]}`.
+
+**Match each screenshot row to an existing match** by `match_date` + the **pair of team names** (compare the existing `home_team.name`/`away_team.name` against the screenshot names using the same normalization you used for team resolution in Step 4 — and the team `id`s you already resolved, when the side is a tracked team). Within one round on one date a pairing is unique, so this is reliable. **If a row is ambiguous (matches zero or several), show it to the user and ask — never guess.**
+
+For each screenshot row, classify it and act per this table:
+
+| Situation | Action |
+|-----------|--------|
+| **No existing match** for this pairing/date | **Create** it — go to Step 6 (create). |
+| Exists, **no score yet** (`home_score`/`away_score` null, status `scheduled`), screenshot has a score | **Update** it — Step 6 (update). |
+| Exists, **already scored identically** to the screenshot | **Skip** (no-op). Report as "already correct". |
+| Exists, **scored differently** from the screenshot | **Flag — do NOT overwrite.** List it for the user (existing vs. screenshot) and let them decide. Only update if they explicitly confirm. |
+| Exists, still no score in the screenshot either | **Skip** — nothing to do yet. |
+
+Build the create-list and update-list, show the user a short plan ("N to create, M to score, K already correct, J conflicts to review"), and proceed once confirmed.
+
+### Step 6 — create or update each match
+
+**Create** a match that doesn't exist yet:
 
 ```bash
 cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py match create \
@@ -177,14 +205,29 @@ cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt
   [--scheduled-kickoff "2026-06-21T15:00:00Z"]
 ```
 
+**Update** an existing match to fill in (or, with user confirmation, correct) its score. Use the `id` from `tournament matches`. Only the flags you pass change; everything else is left alone:
+
+```bash
+cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py match update \
+  --tournament-id <id> \
+  --match-id <existing match id> \
+  --home-score 2 --away-score 1 \
+  --match-status completed \
+  [--home-penalty-score 5 --away-penalty-score 4] \
+  [--tournament-round round_of_16] [--tournament-group "A"] \
+  [--scheduled-kickoff "2026-06-21T15:00:00Z"] [--match-date YYYY-MM-DD] \
+  [--swap-home-away]
+```
+
 **Important semantics:**
 
-- The endpoint takes `our_team_id` (an existing tracked team) + `opponent_name` (a string). The backend will auto-resolve the opponent: exact-match an existing team, otherwise create a lightweight tournament-only team. This means you don't have to create both sides as full teams — only the "our team" side needs to be a real tracked team.
-- For **MLS Next Cup specifically**: the user is loading the bracket to make the tournament look great in MT, but their own U14 IFA team is not in it. So most matches will have `opponent_name` pointing to an opposing team and `our_team_id` pointing to whatever tracked team is closest. If neither team is "ours", pick the home team to be `our_team_id` and let `is_home=True`.
-- **Penalty shootout scores** are only valid when the regulation score is a draw. Always pass both `--home-penalty-score` and `--away-penalty-score` together or neither.
-- **`match_status`**: use `completed` if the score is final, otherwise `scheduled`.
+- **Create** takes `our_team_id` (an existing tracked team) + `opponent_name` (a string). The backend auto-resolves the opponent: exact-match an existing team, otherwise create a lightweight tournament-only team. So you don't have to create both sides as full teams — only the "our team" side needs to be a real tracked team. **Update** works on the match `id` directly and never touches team identities (unless you pass `--swap-home-away` to fix a reversed fixture).
+- For **MLS Next Cup specifically**: the user is loading the bracket to make the tournament look great in MT, but their own team may not be in it. So most matches will have `opponent_name` pointing to an opposing team and `our_team_id` pointing to whatever tracked team is closest. If neither team is "ours", pick the home team to be `our_team_id` and let `is_home=True`.
+- **Penalty shootout scores** are only valid when the regulation score is a draw. Always pass both `--home-penalty-score` and `--away-penalty-score` together or neither — on both create and update.
+- **`match_status`**: when a score is final use `completed`; a not-yet-played matchup is `scheduled`. When filling in a score on a previously-scheduled match, pass `--match-status completed` alongside the scores.
+- The orientation matters: scores are **home : away**. If the screenshot's home team is the existing match's away team, either map the scores accordingly or use `--swap-home-away`.
 
-### Step 6 — summary
+### Step 7 — summary
 
 Print a single summary block at the end:
 
@@ -194,6 +237,9 @@ Clubs created:     <count> — names...
 Teams created:     <count> — names...
 Logos uploaded:    <count>
 Matches created:   <count>
+Matches updated:   <count> — scores filled in
+Already correct:   <count> — skipped
+Conflicts:         <count> — listed for review (NOT changed)
 Match link:        <MT_API_BASE_URL>/tournaments/<id>
 ```
 
@@ -201,7 +247,7 @@ If any step failed (e.g. a logo upload returned non-2xx), surface it explicitly 
 
 ## Resilience guidance
 
-- **Idempotency**: every helper does a lookup before insert. Re-running the skill on the same screenshot should be a no-op (or it should report "already exists" cleanly).
+- **Idempotency**: every helper does a lookup before insert, and Step 5 reconciles against existing matches before any write. Re-running the skill on the same screenshot should be a no-op — already-scored matches report as "already correct", not duplicated or re-written.
 - **Errors**: API errors print JSON to stderr with `status_code` and `response`. Surface them to the user instead of retrying blindly.
 - **Logo dedup**: if the same club appears across multiple age groups in one screenshot, crop and upload the logo once. Track which clubs you've already processed.
 - **Don't auto-pick fuzzy matches**: the team-lookup endpoint exists specifically so you can confirm before any create. Use it.
@@ -209,4 +255,4 @@ If any step failed (e.g. a logo upload returned non-2xx), surface it explicitly 
 ## Out of scope
 
 - This skill does **not** scrape mlssoccer.com directly. Input must be a pasted screenshot.
-- This skill does **not** edit or delete existing matches. Use a future `mt-crud` skill for that (see https://github.com/silverbeer/missing-table/issues/347).
+- This skill creates and **updates** matches (scores, status, round/group, kickoff, home/away swap) but does **not delete** them. Use a future `mt-crud` skill for deletion (see https://github.com/silverbeer/missing-table/issues/347).

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -31,6 +31,7 @@ from api_client.models import (
     Team,
     TournamentCreate,
     TournamentMatchCreate,
+    TournamentMatchUpdate,
 )
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -329,6 +330,51 @@ def tournament_find(name: str = typer.Argument(...)) -> None:
     _out({"exact": exact[0] if exact else None, "similar": similar})
 
 
+@tournament_app.command("matches")
+def tournament_matches(tournament_id: int = typer.Argument(...)) -> None:
+    """List a tournament's existing matches so screenshot rows can be mapped to match IDs.
+
+    Prints a compact row per match: id, date, kickoff, status, round, both team
+    names/ids, and current scores (incl. penalties). Use this before updating to
+    decide create-vs-update and to find the match_id to PUT against.
+    """
+    with _client() as c:
+        try:
+            tournament = c.get_tournament(tournament_id)
+        except APIError as exc:
+            _err_exit("failed to fetch tournament", exc)
+
+    def _team(side: object) -> dict | None:
+        if isinstance(side, dict):
+            return {"id": side.get("id"), "name": side.get("name")}
+        return None
+
+    matches = [
+        {
+            "id": m.get("id"),
+            "match_date": m.get("match_date"),
+            "scheduled_kickoff": m.get("scheduled_kickoff"),
+            "match_status": m.get("match_status"),
+            "tournament_round": m.get("tournament_round"),
+            "home_team": _team(m.get("home_team")),
+            "away_team": _team(m.get("away_team")),
+            "home_score": m.get("home_score"),
+            "away_score": m.get("away_score"),
+            "home_penalty_score": m.get("home_penalty_score"),
+            "away_penalty_score": m.get("away_penalty_score"),
+        }
+        for m in (tournament.get("matches") or [])
+    ]
+    _out(
+        {
+            "tournament_id": tournament.get("id"),
+            "name": tournament.get("name"),
+            "match_count": len(matches),
+            "matches": matches,
+        }
+    )
+
+
 @tournament_app.command("create")
 def tournament_create(
     name: str = typer.Option(..., "--name"),
@@ -424,6 +470,48 @@ def match_create(
             _out(c.create_tournament_match(tournament_id=tournament_id, match=payload))
         except APIError as exc:
             _err_exit("failed to create tournament match", exc)
+
+
+@match_app.command("update")
+def match_update(
+    tournament_id: int = typer.Option(..., "--tournament-id"),
+    match_id: int = typer.Option(..., "--match-id", help="The MT match id (from `tournament matches`)."),
+    home_score: int | None = typer.Option(None, "--home-score"),
+    away_score: int | None = typer.Option(None, "--away-score"),
+    home_penalty_score: int | None = typer.Option(None, "--home-penalty-score"),
+    away_penalty_score: int | None = typer.Option(None, "--away-penalty-score"),
+    match_status: str | None = typer.Option(None, "--match-status"),
+    tournament_group: str | None = typer.Option(None, "--tournament-group"),
+    tournament_round: str | None = typer.Option(None, "--tournament-round"),
+    scheduled_kickoff: str | None = typer.Option(None, "--scheduled-kickoff"),
+    match_date: str | None = typer.Option(None, "--match-date"),
+    swap_home_away: bool = typer.Option(False, "--swap-home-away", help="Swap which team is home/away."),
+) -> None:
+    """Partially update an existing tournament match (fill in scores/status as results come in).
+
+    Only the options you pass are changed; everything else is left untouched. Use
+    `tournament matches <id>` to find the --match-id. Penalty scores are only valid
+    when regulation ends in a draw; pass both or neither.
+    """
+    if tournament_round is not None and tournament_round not in VALID_ROUNDS:
+        _err_exit(f"invalid --tournament-round '{tournament_round}'; must be one of: {sorted(VALID_ROUNDS)}")
+    payload = TournamentMatchUpdate(
+        home_score=home_score,
+        away_score=away_score,
+        home_penalty_score=home_penalty_score,
+        away_penalty_score=away_penalty_score,
+        match_status=match_status,
+        tournament_group=tournament_group,
+        tournament_round=tournament_round,
+        scheduled_kickoff=scheduled_kickoff,
+        match_date=match_date,
+        swap_home_away=swap_home_away,
+    )
+    with _client() as c:
+        try:
+            _out(c.update_tournament_match(tournament_id=tournament_id, match_id=match_id, match=payload))
+        except APIError as exc:
+            _err_exit("failed to update tournament match", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api_client/client.py
+++ b/backend/api_client/client.py
@@ -60,6 +60,7 @@ from .models import (
     Team,
     TournamentCreate,
     TournamentMatchCreate,
+    TournamentMatchUpdate,
     UserProfileUpdate,
 )
 
@@ -1280,12 +1281,39 @@ class MissingTableClient:
         response = self._request("POST", "/api/admin/tournaments", json_data=tournament.model_dump())
         return response.json()
 
+    def get_tournament(self, tournament_id: int) -> dict[str, Any]:
+        """Get tournament detail including its matches (public).
+
+        The returned dict has a ``matches`` list; each match carries ``id``,
+        ``home_team``/``away_team`` (with ``name``), scores, penalty scores,
+        ``match_status`` and ``tournament_round`` — enough to map a screenshot
+        row to an existing match for updates.
+        """
+        response = self._request("GET", f"/api/tournaments/{tournament_id}")
+        return response.json()
+
     def create_tournament_match(self, tournament_id: int, match: TournamentMatchCreate) -> dict[str, Any]:
         """Add a match to a tournament (admin only)."""
         response = self._request(
             "POST",
             f"/api/admin/tournaments/{tournament_id}/matches",
             json_data=match.model_dump(),
+        )
+        return response.json()
+
+    def update_tournament_match(
+        self, tournament_id: int, match_id: int, match: TournamentMatchUpdate
+    ) -> dict[str, Any]:
+        """Partially update an existing tournament match (admin only).
+
+        Only the fields set on ``match`` are sent (``exclude_none``), so scores
+        and status can be filled in as results come in without disturbing the
+        rest of the match. Returns the updated match row.
+        """
+        response = self._request(
+            "PUT",
+            f"/api/admin/tournaments/{tournament_id}/matches/{match_id}",
+            json_data=match.model_dump(exclude_none=True),
         )
         return response.json()
 

--- a/backend/api_client/models.py
+++ b/backend/api_client/models.py
@@ -134,6 +134,26 @@ class TournamentMatchCreate(BaseModel):
     scheduled_kickoff: str | None = Field(None, title="Scheduled Kickoff")
 
 
+class TournamentMatchUpdate(BaseModel):
+    """Partial update for an existing tournament match (mirrors app.py TournamentMatchUpdate).
+
+    All fields optional — send only what changes. Used to fill in scores/status as
+    results trickle in. Serialize with model_dump(exclude_none=True) so unset fields
+    are left untouched by the backend.
+    """
+
+    home_score: int | None = Field(None, title="Home Score")
+    away_score: int | None = Field(None, title="Away Score")
+    home_penalty_score: int | None = Field(None, title="Home Penalty Score")
+    away_penalty_score: int | None = Field(None, title="Away Penalty Score")
+    match_status: str | None = Field(None, title="Match Status")
+    tournament_group: str | None = Field(None, title="Tournament Group")
+    tournament_round: str | None = Field(None, title="Tournament Round")
+    scheduled_kickoff: str | None = Field(None, title="Scheduled Kickoff")
+    match_date: str | None = Field(None, title="Match Date")
+    swap_home_away: bool = Field(False, title="Swap Home Away")
+
+
 class TeamGameTypeMapping(BaseModel):
     game_type_id: int = Field(..., title="Game Type Id")
     age_group_id: int = Field(..., title="Age Group Id")


### PR DESCRIPTION
## What

Turns the `load-tournament-matches` skill from **insert-only** into an **upsert** loop, so tournament scores can be loaded in waves.

### Why
Tournament results don't arrive all at once. The real workflow is: load a round's matchups (no scores) → upload screenshots as scores come in → next round → repeat. The skill previously could only POST new matches, so re-running meant duplicates or hand-editing in the UI.

### How
Before writing, the skill now **reconciles** the screenshot against the tournament's existing matches and:
- **creates** matchups that don't exist yet,
- **fills in scores** on matches that exist but aren't scored,
- **skips** matches already scored correctly,
- **flags (never silently overwrites)** any match whose existing score disagrees with the screenshot.

### Changes
- `backend/api_client/models.py` — add `TournamentMatchUpdate` model.
- `backend/api_client/client.py` — add `get_tournament()` and `update_tournament_match()` (thin wrappers over existing endpoints).
- `mt.py` — add `tournament matches <id>` (list existing matches for mapping) and `match update` (PUT scores / status / penalties / round / kickoff / home-away swap).
- `SKILL.md` — rewrite Steps 5–7 into reconcile → create-or-update → summary; remove the "does not edit matches" out-of-scope note.

**No backend changes** — `PUT /api/admin/tournaments/{id}/matches/{match_id}` and `GET /api/tournaments/{id}` already existed (and handle penalty scores).

### Testing
- `ruff check` passes on all changed Python files.
- CLI smoke test: `tournament matches` and `match update` register with the expected options.
- `detect-secrets` scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
