### PR TITLE
feat(support): admin UI for support inbox (SB-41)

### DIFF
--- a/frontend/src/__tests__/components/AdminSupportInbox.spec.js
+++ b/frontend/src/__tests__/components/AdminSupportInbox.spec.js
@@ -1,0 +1,189 @@
+/**
+ * AdminSupportInbox.vue Tests (SB-35 Phase 3)
+ *
+ * Parent component — swaps between list and thread view based on the
+ * composable's activeThread ref. Mock the composable so we control state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, computed } from 'vue';
+import { mount } from '@vue/test-utils';
+
+// State refs that the mocked composable will expose. Each test overrides
+// what it cares about before mounting.
+const threadsRef = ref({ items: [], nextCursor: null });
+const activeThreadRef = ref(null);
+const unreadCountRef = ref(0);
+const loadingRef = ref(false);
+const sendingRef = ref(false);
+const errorRef = ref(null);
+const currentStatusRef = ref('new,awaiting_admin');
+
+const loadThreads = vi.fn(() => Promise.resolve());
+const openThread = vi.fn(() => Promise.resolve());
+const closeThread = vi.fn(() => {
+  activeThreadRef.value = null;
+});
+const sendReply = vi.fn(() => Promise.resolve({ id: 'new-msg' }));
+const setStatus = vi.fn(() => Promise.resolve());
+const markAllRead = vi.fn(() => Promise.resolve());
+const startPolling = vi.fn();
+const stopPolling = vi.fn();
+
+vi.mock('@/composables/useSupportInbox', () => ({
+  useSupportInbox: () => ({
+    threads: threadsRef,
+    activeThread: activeThreadRef,
+    unreadCount: unreadCountRef,
+    loading: loadingRef,
+    sending: sendingRef,
+    error: errorRef,
+    currentStatus: currentStatusRef,
+    isThreadOpen: computed(() => activeThreadRef.value !== null),
+    loadThreads,
+    openThread,
+    closeThread,
+    sendReply,
+    setStatus,
+    markAllRead,
+    fetchUnreadCount: vi.fn(),
+    startPolling,
+    stopPolling,
+  }),
+}));
+
+import AdminSupportInbox from '@/components/admin/AdminSupportInbox.vue';
+
+beforeEach(() => {
+  // Reset state and call counts before each test.
+  threadsRef.value = { items: [], nextCursor: null };
+  activeThreadRef.value = null;
+  unreadCountRef.value = 0;
+  loadingRef.value = false;
+  sendingRef.value = false;
+  errorRef.value = null;
+  currentStatusRef.value = 'new,awaiting_admin';
+  loadThreads.mockClear();
+  openThread.mockClear();
+  closeThread.mockClear();
+  sendReply.mockClear();
+  setStatus.mockClear();
+  markAllRead.mockClear();
+  startPolling.mockClear();
+  stopPolling.mockClear();
+});
+
+describe('AdminSupportInbox', () => {
+  it('renders the list view by default and calls loadThreads + startPolling on mount', () => {
+    const wrapper = mount(AdminSupportInbox);
+    expect(wrapper.find('[data-testid="support-inbox-list"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('[data-testid="support-thread-view"]').exists()).toBe(
+      false
+    );
+    expect(loadThreads).toHaveBeenCalled();
+    expect(startPolling).toHaveBeenCalled();
+  });
+
+  it('renders the unread badge in the header when unreadCount > 0', async () => {
+    unreadCountRef.value = 5;
+    const wrapper = mount(AdminSupportInbox);
+    const badge = wrapper.find('[data-testid="support-inbox-unread-badge"]');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toContain('5 unread');
+  });
+
+  it('renders the thread view when activeThread is set', () => {
+    activeThreadRef.value = {
+      id: 'thread-uuid',
+      case_number: 1,
+      subject: 'x',
+      participant_email: 'j@x',
+      status: 'awaiting_admin',
+      unread_count: 0,
+      messages: [],
+    };
+    const wrapper = mount(AdminSupportInbox);
+    expect(wrapper.find('[data-testid="support-thread-view"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('[data-testid="support-inbox-list"]').exists()).toBe(
+      false
+    );
+  });
+
+  it('calls openThread when the list emits select', async () => {
+    threadsRef.value = {
+      items: [
+        {
+          id: 'uuid-1',
+          case_number: 1,
+          subject: 's',
+          participant_email: 'a@b',
+          status: 'new',
+          unread_count: 0,
+          last_message_at: new Date().toISOString(),
+        },
+      ],
+      nextCursor: null,
+    };
+    const wrapper = mount(AdminSupportInbox);
+    await wrapper.find('[data-testid="thread-row-1"]').trigger('click');
+    expect(openThread).toHaveBeenCalledWith('uuid-1');
+  });
+
+  it('routes back to the list when the thread view emits back', async () => {
+    activeThreadRef.value = {
+      id: 'thread-uuid',
+      case_number: 1,
+      subject: 'x',
+      participant_email: 'j@x',
+      status: 'new',
+      unread_count: 0,
+      messages: [],
+    };
+    const wrapper = mount(AdminSupportInbox);
+    await wrapper.find('[data-testid="thread-back"]').trigger('click');
+    expect(closeThread).toHaveBeenCalled();
+  });
+
+  it('calls sendReply when the thread view emits reply', async () => {
+    activeThreadRef.value = {
+      id: 'thread-uuid',
+      case_number: 1,
+      subject: 'x',
+      participant_email: 'j@x',
+      status: 'awaiting_admin',
+      unread_count: 0,
+      messages: [],
+    };
+    const wrapper = mount(AdminSupportInbox);
+    const textarea = wrapper.find('[data-testid="reply-textarea"]');
+    await textarea.setValue('My reply');
+    await wrapper
+      .find('[data-testid="reply-composer"]')
+      .trigger('submit.prevent');
+    expect(sendReply).toHaveBeenCalledWith('My reply');
+  });
+
+  it('shows an error banner when the composable error ref is set', () => {
+    errorRef.value = 'something went wrong';
+    const wrapper = mount(AdminSupportInbox);
+    expect(wrapper.text()).toContain('something went wrong');
+  });
+
+  it('calls openThread with the searched MT-N when the list emits search', async () => {
+    const wrapper = mount(AdminSupportInbox);
+    const input = wrapper.find('[data-testid="support-inbox-search"]');
+    await input.setValue('42');
+    await wrapper.find('form').trigger('submit.prevent');
+    expect(openThread).toHaveBeenCalledWith('MT-42');
+  });
+
+  it('stops polling on unmount', () => {
+    const wrapper = mount(AdminSupportInbox);
+    wrapper.unmount();
+    expect(stopPolling).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/components/SupportInboxList.spec.js
+++ b/frontend/src/__tests__/components/SupportInboxList.spec.js
@@ -1,0 +1,131 @@
+/**
+ * SupportInboxList.vue Tests (SB-35 Phase 3)
+ *
+ * Pure presentational component — receives `threads`, `loading`, `currentStatus`
+ * via props and emits `select` / `filter` / `load-more` / `search`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SupportInboxList from '@/components/admin/SupportInboxList.vue';
+
+const baseThread = (overrides = {}) => ({
+  id: 'uuid-1',
+  case_number: 1,
+  subject: 'My Question',
+  participant_email: 'jane@example.com',
+  participant_name: 'Jane Doe',
+  status: 'awaiting_admin',
+  unread_count: 2,
+  last_message_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  message_count: 3,
+  ...overrides,
+});
+
+const mountList = (props = {}) =>
+  mount(SupportInboxList, {
+    props: {
+      threads: { items: [], nextCursor: null },
+      loading: false,
+      currentStatus: 'new,awaiting_admin',
+      ...props,
+    },
+  });
+
+describe('SupportInboxList', () => {
+  it('renders the empty state when no threads', () => {
+    const wrapper = mountList();
+    expect(wrapper.find('[data-testid="support-inbox-empty"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('renders a row per thread with case number, status pill, and participant', () => {
+    const wrapper = mountList({
+      threads: {
+        items: [
+          baseThread(),
+          baseThread({ id: 'uuid-2', case_number: 2, status: 'new' }),
+        ],
+        nextCursor: null,
+      },
+    });
+    expect(wrapper.find('[data-testid="thread-row-1"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="thread-row-2"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="thread-case-1"]').text()).toBe('MT-1');
+    expect(wrapper.text()).toContain('Jane Doe');
+    expect(wrapper.text()).toContain('jane@example.com');
+  });
+
+  it('emits select with the thread id when a row is clicked', async () => {
+    const wrapper = mountList({
+      threads: { items: [baseThread()], nextCursor: null },
+    });
+    await wrapper.find('[data-testid="thread-row-1"]').trigger('click');
+    expect(wrapper.emitted('select')).toEqual([['uuid-1']]);
+  });
+
+  it('emits filter with the tab status when a status tab is clicked', async () => {
+    const wrapper = mountList();
+    await wrapper.find('[data-testid="status-tab-resolved"]').trigger('click');
+    expect(wrapper.emitted('filter')).toEqual([['resolved']]);
+  });
+
+  it('emits search with normalized MT-N form on Go submit', async () => {
+    const wrapper = mountList();
+    const input = wrapper.find('[data-testid="support-inbox-search"]');
+    await input.setValue('42');
+    await wrapper.find('form').trigger('submit.prevent');
+    expect(wrapper.emitted('search')).toEqual([['MT-42']]);
+  });
+
+  it('also accepts already-formatted MT-N input', async () => {
+    const wrapper = mountList();
+    const input = wrapper.find('[data-testid="support-inbox-search"]');
+    await input.setValue('mt-7');
+    await wrapper.find('form').trigger('submit.prevent');
+    expect(wrapper.emitted('search')).toEqual([['MT-7']]);
+  });
+
+  it('shows the load-more button only when nextCursor is present', () => {
+    const withCursor = mountList({
+      threads: { items: [baseThread()], nextCursor: 'opaque-token' },
+    });
+    expect(
+      withCursor.find('[data-testid="support-inbox-load-more"]').exists()
+    ).toBe(true);
+
+    const noCursor = mountList({
+      threads: { items: [baseThread()], nextCursor: null },
+    });
+    expect(
+      noCursor.find('[data-testid="support-inbox-load-more"]').exists()
+    ).toBe(false);
+  });
+
+  it('emits load-more when the button is clicked', async () => {
+    const wrapper = mountList({
+      threads: { items: [baseThread()], nextCursor: 'opaque-token' },
+    });
+    await wrapper
+      .find('[data-testid="support-inbox-load-more"]')
+      .trigger('click');
+    expect(wrapper.emitted('load-more')).toHaveLength(1);
+  });
+
+  it('shows the unread badge per row when unread_count > 0', () => {
+    const wrapper = mountList({
+      threads: {
+        items: [
+          baseThread({ unread_count: 3 }),
+          baseThread({ id: 'uuid-2', case_number: 2, unread_count: 0 }),
+        ],
+        nextCursor: null,
+      },
+    });
+    expect(wrapper.find('[data-testid="thread-unread-1"]').text()).toBe('3');
+    expect(wrapper.find('[data-testid="thread-unread-2"]').exists()).toBe(
+      false
+    );
+  });
+});

--- a/frontend/src/__tests__/components/SupportThreadView.spec.js
+++ b/frontend/src/__tests__/components/SupportThreadView.spec.js
@@ -1,0 +1,171 @@
+/**
+ * SupportThreadView.vue Tests (SB-35 Phase 3)
+ *
+ * Pure presentational — gets `thread` (with `messages`) + `sending` via props;
+ * emits `back` / `reply` / `set-status` / `mark-all-read`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SupportThreadView from '@/components/admin/SupportThreadView.vue';
+
+const makeThread = (overrides = {}) => ({
+  id: 'thread-uuid',
+  case_number: 42,
+  subject: 'My Question',
+  participant_email: 'jane@example.com',
+  participant_name: 'Jane Doe',
+  status: 'awaiting_admin',
+  unread_count: 2,
+  messages: [
+    {
+      id: 'msg-1',
+      direction: 'inbound',
+      from_email: 'jane@example.com',
+      from_name: 'Jane Doe',
+      subject: '[MT-42] My Question',
+      body_text: 'Hi support, need help.',
+      body_html: '<p>Hi support, need help.</p>',
+      had_attachments: false,
+      created_at: '2026-05-23T12:00:00Z',
+      read_at: null,
+    },
+    {
+      id: 'msg-2',
+      direction: 'outbound',
+      from_email: 'support@contact.missingtable.com',
+      from_name: 'Support',
+      subject: 'Re: [MT-42] My Question',
+      body_text: 'Hi Jane!',
+      body_html: null,
+      had_attachments: false,
+      created_at: '2026-05-23T12:30:00Z',
+      read_at: '2026-05-23T12:30:00Z',
+    },
+  ],
+  ...overrides,
+});
+
+const mountThread = (props = {}) =>
+  mount(SupportThreadView, {
+    props: {
+      thread: makeThread(),
+      sending: false,
+      ...props,
+    },
+  });
+
+describe('SupportThreadView', () => {
+  it('renders the case number and status pill in the header', () => {
+    const wrapper = mountThread();
+    expect(wrapper.find('[data-testid="thread-case-number"]').text()).toBe(
+      'MT-42'
+    );
+    expect(wrapper.find('[data-testid="thread-status-pill"]').text()).toBe(
+      'Awaiting admin'
+    );
+  });
+
+  it('renders messages chronologically with direction-aware data attributes', () => {
+    const wrapper = mountThread();
+    const messages = wrapper.findAll('[data-direction]');
+    expect(messages).toHaveLength(2);
+    expect(messages[0].attributes('data-direction')).toBe('inbound');
+    expect(messages[1].attributes('data-direction')).toBe('outbound');
+  });
+
+  it('renders sanitized HTML body via v-html with a data-testid hook for the regression test', () => {
+    /**
+     * Regression hook: the backend already sanitizes inbound HTML via bleach.
+     * The data-testid below is the canonical anchor for any future test that
+     * wants to verify we DON'T re-sanitize or strip content here.
+     */
+    const wrapper = mountThread();
+    const htmlNode = wrapper.find('[data-testid="message-body-html"]');
+    expect(htmlNode.exists()).toBe(true);
+    expect(htmlNode.html()).toContain('<p>Hi support, need help.</p>');
+  });
+
+  it('falls back to plain text when body_html is null', () => {
+    const wrapper = mountThread();
+    // msg-2 has body_html=null → renders text body
+    expect(wrapper.find('[data-testid="message-body-text"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('shows the attachments-stripped notice when had_attachments is true', () => {
+    const wrapper = mountThread({
+      thread: makeThread({
+        messages: [
+          {
+            id: 'm-att',
+            direction: 'inbound',
+            from_email: 'j@x',
+            body_text: 'see attached',
+            body_html: null,
+            had_attachments: true,
+            created_at: '2026-05-23T12:00:00Z',
+          },
+        ],
+      }),
+    });
+    expect(
+      wrapper.find('[data-testid="message-attachments-notice"]').exists()
+    ).toBe(true);
+  });
+
+  it('emits reply with the textarea body and clears the textarea on submit', async () => {
+    const wrapper = mountThread();
+    const textarea = wrapper.find('[data-testid="reply-textarea"]');
+    await textarea.setValue('Here is my answer.');
+    await wrapper
+      .find('[data-testid="reply-composer"]')
+      .trigger('submit.prevent');
+    expect(wrapper.emitted('reply')).toEqual([['Here is my answer.']]);
+    expect(textarea.element.value).toBe('');
+  });
+
+  it('disables the submit button when sending is true', () => {
+    const wrapper = mountThread({ sending: true });
+    const btn = wrapper.find('[data-testid="reply-submit"]');
+    expect(btn.attributes('disabled')).toBeDefined();
+    expect(btn.text()).toContain('Sending');
+  });
+
+  it('disables the submit button when the textarea is empty', () => {
+    const wrapper = mountThread();
+    const btn = wrapper.find('[data-testid="reply-submit"]');
+    expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  it('shows the Mark all read button only when unread_count > 0 and emits the event', async () => {
+    const withUnread = mountThread();
+    const btn = withUnread.find('[data-testid="thread-mark-all-read"]');
+    expect(btn.exists()).toBe(true);
+    await btn.trigger('click');
+    expect(withUnread.emitted('mark-all-read')).toHaveLength(1);
+
+    const noUnread = mountThread({ thread: makeThread({ unread_count: 0 }) });
+    expect(noUnread.find('[data-testid="thread-mark-all-read"]').exists()).toBe(
+      false
+    );
+  });
+
+  it('emits set-status when a dropdown option is chosen', async () => {
+    const wrapper = mountThread();
+    await wrapper
+      .find('[data-testid="thread-status-dropdown"]')
+      .trigger('click');
+    await wrapper
+      .find('[data-testid="thread-status-resolved"]')
+      .trigger('click');
+    expect(wrapper.emitted('set-status')).toEqual([['resolved']]);
+  });
+
+  it('emits back when the back button is clicked', async () => {
+    const wrapper = mountThread();
+    await wrapper.find('[data-testid="thread-back"]').trigger('click');
+    expect(wrapper.emitted('back')).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/AdminPanel.vue
+++ b/frontend/src/components/AdminPanel.vue
@@ -222,6 +222,15 @@
           <AdminInvites />
         </div>
 
+        <!-- Support Inbox -->
+        <div
+          v-if="currentSection === 'support-inbox'"
+          class="p-3 sm:p-6"
+          data-testid="admin-section-support-inbox"
+        >
+          <AdminSupportInbox />
+        </div>
+
         <!-- Tournaments Management -->
         <div
           v-if="currentSection === 'tournaments'"
@@ -266,6 +275,7 @@ import AdminPlayers from './admin/AdminPlayers.vue';
 import AdminMatches from './admin/AdminMatches.vue';
 import AdminGoals from './admin/AdminGoals.vue';
 import AdminInvites from './admin/AdminInvites.vue';
+import AdminSupportInbox from './admin/AdminSupportInbox.vue';
 import AdminChannelRequests from './admin/AdminChannelRequests.vue';
 import AdminClubNotifications from './admin/AdminClubNotifications.vue';
 import AdminInviteRequests from './admin/AdminInviteRequests.vue';
@@ -287,6 +297,7 @@ export default {
     AdminMatches,
     AdminGoals,
     AdminInvites,
+    AdminSupportInbox,
     AdminChannelRequests,
     AdminClubNotifications,
     AdminInviteRequests,
@@ -321,6 +332,12 @@ export default {
         category: 'access',
       },
       { id: 'invites', name: 'Invites', adminOnly: false, category: 'access' },
+      {
+        id: 'support-inbox',
+        name: 'Support Inbox',
+        adminOnly: true,
+        category: 'access',
+      },
       {
         id: 'age-groups',
         name: 'Age Groups',

--- a/frontend/src/components/admin/AdminSupportInbox.vue
+++ b/frontend/src/components/admin/AdminSupportInbox.vue
@@ -1,0 +1,107 @@
+<template>
+  <div data-testid="admin-support-inbox">
+    <div class="flex items-start justify-between mb-4 sm:mb-6">
+      <h2 class="text-xl sm:text-2xl font-bold">Support Inbox</h2>
+      <span
+        v-if="unreadCount > 0"
+        class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800"
+        :aria-label="`${unreadCount} unread message${unreadCount === 1 ? '' : 's'}`"
+        data-testid="support-inbox-unread-badge"
+      >
+        {{ unreadCount }} unread
+      </span>
+    </div>
+
+    <div
+      v-if="error"
+      class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4"
+      role="alert"
+    >
+      {{ error }}
+    </div>
+
+    <SupportThreadView
+      v-if="activeThread"
+      :thread="activeThread"
+      :sending="sending"
+      @back="closeThread"
+      @reply="onReply"
+      @set-status="onSetStatus"
+      @mark-all-read="onMarkAllRead"
+    />
+    <SupportInboxList
+      v-else
+      :threads="threads"
+      :loading="loading"
+      :current-status="currentStatus"
+      @select="openThread"
+      @filter="onFilter"
+      @load-more="onLoadMore"
+      @search="onSearch"
+    />
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onBeforeUnmount } from 'vue';
+import { useSupportInbox } from '@/composables/useSupportInbox';
+import SupportInboxList from './SupportInboxList.vue';
+import SupportThreadView from './SupportThreadView.vue';
+
+const {
+  threads,
+  activeThread,
+  unreadCount,
+  loading,
+  sending,
+  error,
+  currentStatus,
+  loadThreads,
+  openThread,
+  closeThread,
+  sendReply,
+  setStatus,
+  markAllRead,
+  startPolling,
+  stopPolling,
+} = useSupportInbox();
+
+const onFilter = status => {
+  loadThreads({ status });
+};
+
+const onLoadMore = () => {
+  if (threads.value.nextCursor) {
+    loadThreads({ cursor: threads.value.nextCursor });
+  }
+};
+
+const onSearch = mtN => {
+  openThread(mtN);
+};
+
+const onReply = async body => {
+  try {
+    await sendReply(body);
+  } catch (_e) {
+    // Error already set on composable; nothing to do here.
+  }
+};
+
+const onSetStatus = status => {
+  setStatus(status);
+};
+
+const onMarkAllRead = () => {
+  markAllRead();
+};
+
+onMounted(() => {
+  loadThreads();
+  startPolling();
+});
+
+onBeforeUnmount(() => {
+  stopPolling();
+});
+</script>

--- a/frontend/src/components/admin/SupportInboxList.vue
+++ b/frontend/src/components/admin/SupportInboxList.vue
@@ -1,0 +1,221 @@
+<template>
+  <div data-testid="support-inbox-list">
+    <!-- Filter bar -->
+    <div
+      class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4"
+    >
+      <div
+        class="flex flex-wrap gap-2"
+        role="tablist"
+        aria-label="Status filter"
+      >
+        <button
+          v-for="tab in tabs"
+          :key="tab.value"
+          type="button"
+          role="tab"
+          :aria-selected="currentStatus === tab.value"
+          :data-testid="`status-tab-${tab.id}`"
+          class="px-3 py-1.5 text-sm rounded-full border transition-colors"
+          :class="
+            currentStatus === tab.value
+              ? 'bg-brand-600 text-white border-brand-600'
+              : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+          "
+          @click="$emit('filter', tab.value)"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <form class="flex items-center gap-2" @submit.prevent="onSearchSubmit">
+        <label class="sr-only" for="support-inbox-mt-search"
+          >Jump to case</label
+        >
+        <input
+          id="support-inbox-mt-search"
+          v-model="searchInput"
+          type="text"
+          placeholder="MT-42"
+          data-testid="support-inbox-search"
+          class="px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 w-32"
+        />
+        <button
+          type="submit"
+          class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700"
+          data-testid="support-inbox-search-submit"
+        >
+          Go
+        </button>
+      </form>
+    </div>
+
+    <!-- Loading / empty / rows -->
+    <div
+      v-if="loading && threads.items.length === 0"
+      class="text-center text-gray-500 py-12"
+      data-testid="support-inbox-loading"
+    >
+      Loading threads…
+    </div>
+
+    <div
+      v-else-if="threads.items.length === 0"
+      class="text-center text-gray-500 py-12 bg-gray-50 rounded-lg"
+      data-testid="support-inbox-empty"
+    >
+      <p class="font-medium mb-1">No threads in this view.</p>
+      <p class="text-sm">Try a different status tab.</p>
+    </div>
+
+    <ul
+      v-else
+      class="divide-y divide-gray-200 border border-gray-200 rounded-lg bg-white"
+    >
+      <li
+        v-for="thread in threads.items"
+        :key="thread.id"
+        :data-testid="`thread-row-${thread.case_number}`"
+        class="px-4 py-3 hover:bg-gray-50 cursor-pointer"
+        @click="$emit('select', thread.id)"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2 mb-1">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-100 text-gray-800"
+                :data-testid="`thread-case-${thread.case_number}`"
+              >
+                MT-{{ thread.case_number }}
+              </span>
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                :class="statusPillClasses(thread.status)"
+                :aria-label="`Status: ${statusLabel(thread.status)}`"
+              >
+                {{ statusLabel(thread.status) }}
+              </span>
+              <span
+                v-if="thread.unread_count > 0"
+                class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800"
+                :data-testid="`thread-unread-${thread.case_number}`"
+              >
+                {{ thread.unread_count }}
+              </span>
+            </div>
+            <p class="text-sm font-medium text-gray-900 truncate">
+              {{ participantDisplay(thread) }}
+            </p>
+            <p class="text-sm text-gray-700 truncate">
+              {{ thread.subject || '(no subject)' }}
+            </p>
+          </div>
+          <div class="text-right text-xs text-gray-500 whitespace-nowrap">
+            {{ relativeTime(thread.last_message_at) }}
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <!-- Load more -->
+    <div v-if="threads.nextCursor" class="text-center mt-4">
+      <button
+        type="button"
+        class="px-4 py-2 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700"
+        data-testid="support-inbox-load-more"
+        :disabled="loading"
+        @click="$emit('load-more')"
+      >
+        {{ loading ? 'Loading…' : 'Load more' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+defineProps({
+  threads: { type: Object, required: true },
+  loading: { type: Boolean, default: false },
+  currentStatus: { type: String, required: true },
+});
+
+const emit = defineEmits(['select', 'filter', 'load-more', 'search']);
+
+const searchInput = ref('');
+
+const tabs = [
+  { id: 'attention', label: 'Needs attention', value: 'new,awaiting_admin' },
+  { id: 'waiting-user', label: 'Waiting on user', value: 'awaiting_user' },
+  { id: 'resolved', label: 'Resolved', value: 'resolved' },
+  { id: 'spam', label: 'Spam', value: 'spam' },
+  {
+    id: 'all',
+    label: 'All',
+    value: 'new,awaiting_admin,awaiting_user,resolved,spam',
+  },
+];
+
+const onSearchSubmit = () => {
+  const raw = (searchInput.value || '').trim();
+  if (!raw) return;
+  // Accept "42", "MT-42", "mt-42" — normalize before emitting.
+  const match = raw.match(/^(?:MT-)?(\d+)$/i);
+  const mtN = match ? `MT-${match[1]}` : raw;
+  emit('search', mtN);
+};
+
+const statusLabel = s => {
+  switch (s) {
+    case 'new':
+      return 'New';
+    case 'awaiting_admin':
+      return 'Awaiting admin';
+    case 'awaiting_user':
+      return 'Awaiting user';
+    case 'resolved':
+      return 'Resolved';
+    case 'spam':
+      return 'Spam';
+    default:
+      return s;
+  }
+};
+
+const statusPillClasses = s => {
+  switch (s) {
+    case 'new':
+      return 'bg-red-100 text-red-800';
+    case 'awaiting_admin':
+      return 'bg-orange-100 text-orange-800';
+    case 'awaiting_user':
+      return 'bg-blue-100 text-blue-800';
+    case 'resolved':
+      return 'bg-gray-100 text-gray-700';
+    case 'spam':
+      return 'bg-gray-100 text-gray-500';
+    default:
+      return 'bg-gray-100 text-gray-700';
+  }
+};
+
+const participantDisplay = thread => {
+  if (thread.participant_name) {
+    return `${thread.participant_name} <${thread.participant_email}>`;
+  }
+  return thread.participant_email;
+};
+
+const relativeTime = iso => {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diffSec = Math.round((Date.now() - then) / 1000);
+  if (diffSec < 60) return 'just now';
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86_400) return `${Math.floor(diffSec / 3600)}h ago`;
+  if (diffSec < 604_800) return `${Math.floor(diffSec / 86_400)}d ago`;
+  return new Date(iso).toLocaleDateString();
+};
+</script>

--- a/frontend/src/components/admin/SupportThreadView.vue
+++ b/frontend/src/components/admin/SupportThreadView.vue
@@ -1,0 +1,300 @@
+<template>
+  <div data-testid="support-thread-view">
+    <!-- Header bar -->
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+      <button
+        type="button"
+        class="text-sm text-brand-700 hover:underline"
+        data-testid="thread-back"
+        @click="$emit('back')"
+      >
+        ← Back to inbox
+      </button>
+      <div class="flex items-center gap-2">
+        <button
+          v-if="thread.unread_count > 0"
+          type="button"
+          class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700"
+          data-testid="thread-mark-all-read"
+          @click="$emit('mark-all-read')"
+        >
+          Mark all read
+        </button>
+        <div class="relative" v-click-outside="closeDropdown">
+          <button
+            type="button"
+            class="px-3 py-1.5 text-sm border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 flex items-center gap-1"
+            data-testid="thread-status-dropdown"
+            :aria-expanded="dropdownOpen"
+            @click="dropdownOpen = !dropdownOpen"
+          >
+            Set status
+            <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fill-rule="evenodd"
+                d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 011.08 1.04l-4.25 4.4a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <ul
+            v-if="dropdownOpen"
+            class="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10 py-1"
+            role="menu"
+          >
+            <li>
+              <button
+                type="button"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                data-testid="thread-status-resolved"
+                @click="onPickStatus('resolved')"
+              >
+                Mark resolved
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                data-testid="thread-status-spam"
+                @click="onPickStatus('spam')"
+              >
+                Mark spam
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                data-testid="thread-status-reopen"
+                @click="onPickStatus('awaiting_admin')"
+              >
+                Reopen
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Thread metadata -->
+    <div class="mb-4 pb-4 border-b border-gray-200">
+      <div class="flex items-center gap-2 mb-2">
+        <span
+          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-100 text-gray-800"
+          data-testid="thread-case-number"
+        >
+          MT-{{ thread.case_number }}
+        </span>
+        <span
+          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+          :class="statusPillClasses(thread.status)"
+          :aria-label="`Status: ${statusLabel(thread.status)}`"
+          data-testid="thread-status-pill"
+        >
+          {{ statusLabel(thread.status) }}
+        </span>
+      </div>
+      <h3 class="text-lg font-semibold text-gray-900">
+        {{ thread.subject || '(no subject)' }}
+      </h3>
+      <p class="text-sm text-gray-600">
+        {{ thread.participant_name || thread.participant_email }}
+        <span v-if="thread.participant_name">
+          &lt;{{ thread.participant_email }}&gt;</span
+        >
+      </p>
+    </div>
+
+    <!-- Messages -->
+    <ul class="space-y-3 mb-6">
+      <li
+        v-for="msg in thread.messages || []"
+        :key="msg.id"
+        :data-testid="`message-${msg.id}`"
+        :data-direction="msg.direction"
+        class="flex"
+        :class="msg.direction === 'outbound' ? 'justify-end' : 'justify-start'"
+      >
+        <div
+          class="max-w-[80%] rounded-lg px-4 py-3"
+          :class="
+            msg.direction === 'outbound'
+              ? 'bg-brand-50 border border-brand-200'
+              : 'bg-gray-50 border border-gray-200'
+          "
+        >
+          <div class="flex items-center gap-2 mb-1 text-xs text-gray-500">
+            <span class="font-medium text-gray-700">
+              {{
+                msg.direction === 'outbound'
+                  ? msg.from_name || 'Support'
+                  : msg.from_name || msg.from_email
+              }}
+            </span>
+            <span>·</span>
+            <time :datetime="msg.created_at">{{
+              formatTime(msg.created_at)
+            }}</time>
+          </div>
+          <div
+            v-if="msg.body_html"
+            class="text-sm text-gray-800 prose prose-sm max-w-none"
+            data-testid="message-body-html"
+            v-html="msg.body_html"
+          />
+          <div
+            v-else
+            class="text-sm text-gray-800 whitespace-pre-wrap"
+            data-testid="message-body-text"
+          >
+            {{ msg.body_text }}
+          </div>
+          <p
+            v-if="msg.had_attachments"
+            class="mt-2 text-xs italic text-gray-500"
+            data-testid="message-attachments-notice"
+          >
+            Attachments stripped. Reply via your email client to view them.
+          </p>
+        </div>
+      </li>
+    </ul>
+
+    <!-- Reply composer -->
+    <form
+      class="border-t border-gray-200 pt-4"
+      data-testid="reply-composer"
+      @submit.prevent="onReply"
+    >
+      <label for="reply-body" class="sr-only">Reply</label>
+      <textarea
+        id="reply-body"
+        v-model="replyBody"
+        rows="4"
+        placeholder="Write a reply…"
+        data-testid="reply-textarea"
+        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 text-sm"
+      ></textarea>
+      <div class="flex justify-end mt-2">
+        <button
+          type="submit"
+          class="px-4 py-2 text-sm bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
+          data-testid="reply-submit"
+          :disabled="sending || !replyBody.trim()"
+        >
+          <svg
+            v-if="sending"
+            class="animate-spin h-4 w-4"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+          {{ sending ? 'Sending…' : 'Send reply' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const props = defineProps({
+  thread: { type: Object, required: true },
+  sending: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['back', 'reply', 'set-status', 'mark-all-read']);
+
+const replyBody = ref('');
+const dropdownOpen = ref(false);
+
+const onReply = () => {
+  const body = replyBody.value.trim();
+  if (!body) return;
+  emit('reply', body);
+  replyBody.value = '';
+};
+
+const onPickStatus = status => {
+  dropdownOpen.value = false;
+  emit('set-status', status);
+};
+
+const closeDropdown = () => {
+  dropdownOpen.value = false;
+};
+
+const statusLabel = s => {
+  switch (s) {
+    case 'new':
+      return 'New';
+    case 'awaiting_admin':
+      return 'Awaiting admin';
+    case 'awaiting_user':
+      return 'Awaiting user';
+    case 'resolved':
+      return 'Resolved';
+    case 'spam':
+      return 'Spam';
+    default:
+      return s;
+  }
+};
+
+const statusPillClasses = s => {
+  switch (s) {
+    case 'new':
+      return 'bg-red-100 text-red-800';
+    case 'awaiting_admin':
+      return 'bg-orange-100 text-orange-800';
+    case 'awaiting_user':
+      return 'bg-blue-100 text-blue-800';
+    case 'resolved':
+      return 'bg-gray-100 text-gray-700';
+    case 'spam':
+      return 'bg-gray-100 text-gray-500';
+    default:
+      return 'bg-gray-100 text-gray-700';
+  }
+};
+
+const formatTime = iso => {
+  if (!iso) return '';
+  return new Date(iso).toLocaleString();
+};
+
+// Reference props to keep linter happy (we destructure later in tests).
+void props;
+
+// Local v-click-outside directive (Vue 3 <script setup> auto-registers
+// any `vFoo` const as a directive).
+const vClickOutside = {
+  mounted(el, binding) {
+    el._clickOutsideHandler = event => {
+      if (!(el === event.target || el.contains(event.target))) {
+        binding.value(event);
+      }
+    };
+    document.addEventListener('click', el._clickOutsideHandler);
+  },
+  unmounted(el) {
+    document.removeEventListener('click', el._clickOutsideHandler);
+  },
+};
+</script>

--- a/frontend/src/composables/useSupportInbox.js
+++ b/frontend/src/composables/useSupportInbox.js
@@ -1,0 +1,225 @@
+/**
+ * useSupportInbox composable (SB-35 Phase 3)
+ *
+ * Reactive singleton (matches the auth-store pattern — no Pinia) that backs
+ * the Support Inbox admin UI. Holds thread list + active thread state, talks
+ * to the Phase 2 admin API, and polls the unread-count badge.
+ *
+ * Exposes:
+ *   threads, activeThread, messages, unreadCount, loading, sending, error
+ *   loadThreads({status}), openThread(idOrMtN), closeThread(),
+ *   sendReply(bodyText), setStatus(status), markAllRead(),
+ *   fetchUnreadCount(), startPolling(), stopPolling()
+ */
+
+import { ref, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+
+const UNREAD_POLL_MS = 60_000;
+
+// ── Module-level singleton state ───────────────────────────────────────────
+
+const threads = ref({ items: [], nextCursor: null });
+const activeThread = ref(null); // full thread row with .messages array
+const unreadCount = ref(0);
+const loading = ref(false);
+const sending = ref(false);
+const error = ref(null);
+const currentStatus = ref('new,awaiting_admin'); // CSV status filter
+
+let pollHandle = null;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function _apiFetch(path, { method = 'GET', body, signal } = {}) {
+  const authStore = useAuthStore();
+  const headers = authStore.getAuthHeaders();
+  const opts = { method, headers, signal };
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+  const resp = await fetch(`${getApiBaseUrl()}${path}`, opts);
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    const detail = data.detail || `request failed (${resp.status})`;
+    const err = new Error(detail);
+    err.status = resp.status;
+    throw err;
+  }
+  // 204s are rare on this surface; everything returns JSON.
+  return resp.json();
+}
+
+function _isMtForm(value) {
+  return /^MT-\d+$/i.test(String(value || '').trim());
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+export function useSupportInbox() {
+  const isThreadOpen = computed(() => activeThread.value !== null);
+
+  async function loadThreads({ status, cursor } = {}) {
+    if (status) currentStatus.value = status;
+    loading.value = true;
+    error.value = null;
+    try {
+      const qs = new URLSearchParams({ status: currentStatus.value });
+      if (cursor) qs.set('cursor', cursor);
+      const data = await _apiFetch(`/api/admin/emails/threads?${qs}`);
+      // Append on cursor-driven load-more, replace otherwise.
+      if (cursor) {
+        threads.value = {
+          items: [...threads.value.items, ...(data.items || [])],
+          nextCursor: data.next_cursor || null,
+        };
+      } else {
+        threads.value = {
+          items: data.items || [],
+          nextCursor: data.next_cursor || null,
+        };
+      }
+    } catch (e) {
+      error.value = e.message;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function openThread(idOrMtN) {
+    loading.value = true;
+    error.value = null;
+    try {
+      const key = _isMtForm(idOrMtN) ? idOrMtN.toUpperCase() : idOrMtN;
+      const data = await _apiFetch(
+        `/api/admin/emails/threads/${encodeURIComponent(key)}`
+      );
+      activeThread.value = data;
+    } catch (e) {
+      error.value = e.message;
+      activeThread.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function closeThread() {
+    activeThread.value = null;
+  }
+
+  async function sendReply(bodyText) {
+    if (!activeThread.value) {
+      throw new Error('no active thread');
+    }
+    const trimmed = (bodyText || '').trim();
+    if (!trimmed) {
+      throw new Error('reply body is empty');
+    }
+    sending.value = true;
+    error.value = null;
+    try {
+      const inserted = await _apiFetch(
+        `/api/admin/emails/threads/${activeThread.value.id}/reply`,
+        { method: 'POST', body: { body_text: trimmed } }
+      );
+      // Optimistically append + flip status pill.
+      activeThread.value = {
+        ...activeThread.value,
+        status: 'awaiting_user',
+        messages: [...(activeThread.value.messages || []), inserted],
+      };
+      // Reflect new status in the list cache too.
+      _patchListEntry(activeThread.value.id, { status: 'awaiting_user' });
+      return inserted;
+    } catch (e) {
+      error.value = e.message;
+      throw e;
+    } finally {
+      sending.value = false;
+    }
+  }
+
+  async function setStatus(status) {
+    if (!activeThread.value) return;
+    const updated = await _apiFetch(
+      `/api/admin/emails/threads/${activeThread.value.id}/status`,
+      { method: 'PATCH', body: { status } }
+    );
+    activeThread.value = { ...activeThread.value, status: updated.status };
+    _patchListEntry(activeThread.value.id, { status: updated.status });
+  }
+
+  async function markAllRead() {
+    if (!activeThread.value) return;
+    const result = await _apiFetch(
+      `/api/admin/emails/threads/${activeThread.value.id}/read`,
+      { method: 'PATCH' }
+    );
+    activeThread.value = {
+      ...activeThread.value,
+      unread_count: 0,
+      messages: (activeThread.value.messages || []).map(m =>
+        m.read_at ? m : { ...m, read_at: new Date().toISOString() }
+      ),
+    };
+    _patchListEntry(activeThread.value.id, { unread_count: 0 });
+    // Refresh badge — the count just dropped.
+    fetchUnreadCount();
+    return result;
+  }
+
+  async function fetchUnreadCount() {
+    try {
+      const data = await _apiFetch('/api/admin/emails/unread-count');
+      unreadCount.value = data.count || 0;
+    } catch (e) {
+      // Badge is best-effort — don't surface its errors in the main UI.
+      console.warn('useSupportInbox: unread-count fetch failed', e);
+    }
+  }
+
+  function startPolling() {
+    if (pollHandle) return;
+    fetchUnreadCount();
+    pollHandle = setInterval(fetchUnreadCount, UNREAD_POLL_MS);
+  }
+
+  function stopPolling() {
+    if (pollHandle) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  }
+
+  function _patchListEntry(threadId, patch) {
+    const items = threads.value.items || [];
+    const idx = items.findIndex(t => t.id === threadId);
+    if (idx === -1) return;
+    const next = [...items];
+    next[idx] = { ...next[idx], ...patch };
+    threads.value = { ...threads.value, items: next };
+  }
+
+  return {
+    // state
+    threads,
+    activeThread,
+    unreadCount,
+    loading,
+    sending,
+    error,
+    currentStatus,
+    isThreadOpen,
+    // actions
+    loadThreads,
+    openThread,
+    closeThread,
+    sendReply,
+    setStatus,
+    markAllRead,
+    fetchUnreadCount,
+    startPolling,
+    stopPolling,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Support Inbox feature ([SB-35](https://linear.app/silverbeer/issue/SB-35)) — adds an admin UI inside `AdminPanel` so admins can triage and reply to threads without leaving MT. Consumes the [Phase 2](https://github.com/silverbeer/missing-table/pull/386) admin API.

- New "Support Inbox" sub-section in the Access category, admin-only
- Full read + reply + status management without leaving the app
- Unread badge in the section header, polled every 60s

## What changed

**New components** under `frontend/src/components/admin/`:

| File | Role |
|---|---|
| `AdminSupportInbox.vue` | Parent. Owns the composable, swaps between list and thread view, shows the unread badge. |
| `SupportInboxList.vue` | Status tabs (Needs attention / Waiting on user / Resolved / Spam / All), `MT-N` search, thread rows with color-coded status pill, unread badge, relative timestamp, keyset load-more. |
| `SupportThreadView.vue` | Chronological message bubbles (inbound left / outbound right), sanitized HTML body via `v-html` with `data-testid="message-body-html"` hook, attachments-stripped notice, reply composer, status dropdown (Mark resolved / Mark spam / Reopen), Mark all read button. |

**New composable** — `frontend/src/composables/useSupportInbox.js`:
Reactive singleton matching the auth-store pattern (no Pinia). Exposes refs and actions:
- `threads`, `activeThread`, `unreadCount`, `loading`, `sending`, `error`, `currentStatus`
- `loadThreads({status, cursor})`, `openThread(idOrMtN)`, `closeThread()`
- `sendReply(bodyText)` — optimistically appends outbound + flips status pill
- `setStatus(status)`, `markAllRead()`
- `startPolling()` / `stopPolling()` — 60s unread-count poll

**AdminPanel wiring** — `frontend/src/components/AdminPanel.vue`:
Added `{id: 'support-inbox', name: 'Support Inbox', adminOnly: true, category: 'access'}` to `allAdminSections`. Mounted via the same v-if pattern as the existing sub-sections.

## Test plan

**Automated:**
- [x] 29 new Vitest specs across three files (`AdminSupportInbox.spec.js`, `SupportInboxList.spec.js`, `SupportThreadView.spec.js`)
- [x] Coverage includes: list rendering w/ thread metadata, status tab dispatch, `MT-N`/`mt-42`/bare-`42` search normalization, load-more visibility gated on `next_cursor`, thread chronological order + bubble direction, HTML body regression hook (`data-testid="message-body-html"`), reply textarea clearing on submit, sending-disabled state, mark-all-read gated on `unread_count`, parent composable wiring, error banner rendering, polling lifecycle
- [x] Full frontend suite: **289 passed** (260 existing + 29 new)
- [x] `npm run lint` clean

**Manual (do before merging):**
- [ ] `./missing-table.sh dev`, log in as admin, navigate to Admin → Support Inbox
- [ ] MT-1 (from prod backup if loaded) or a fresh local thread renders
- [ ] Click into a thread, see chronological messages with inbound/outbound bubble styling
- [ ] Reply: composer disables while sending, new message appears, status pill flips to "Awaiting user"
- [ ] Status dropdown: Mark resolved / Mark spam / Reopen all update the pill
- [ ] Mark all read: unread badge clears, section-header badge updates
- [ ] `MT-42`-style search in the list view jumps straight to that thread

## Notes / design decisions

- **`v-html` is intentional and load-bearing.** The backend already sanitizes inbound HTML via bleach (`backend/services/email_inbound.sanitize_html`). Re-sanitizing here would strip content the user already trusted. The `data-testid="message-body-html"` hook is the anchor for any future regression test that wants to verify we don't drift into re-sanitizing.
- **Nav badge location**: inside the section header (next to "Support Inbox" title), not in the global Admin nav. Smaller blast radius; easy to lift to global nav later if desired.
- **Full-pane swap, not modal**: consistent with every other admin sub-section. Long threads + textarea focus management work better in a pane.
- **Subject prefixing + threading**: all backend responsibility (already shipped in Phase 2). The UI doesn't touch headers.

Refs: [SB-41](https://linear.app/silverbeer/issue/SB-41), [SB-35](https://linear.app/silverbeer/issue/SB-35). Depends on [#386](https://github.com/silverbeer/missing-table/pull/386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)