### PR TITLE
feat(ig-share): goal scorers on result share cards (SB-33)

### DIFF
--- a/docs/features/IG_SHARE_CARD.md
+++ b/docs/features/IG_SHARE_CARD.md
@@ -1,6 +1,6 @@
 # Instagram Match Share Card
 
-**Status:** v1 shipped (SB-32) | **Parent:** SB-19 | **Backend:** SB-31
+**Status:** v1 shipped (SB-32) · goal scorers (SB-33) | **Parent:** SB-19 | **Backend:** SB-31
 
 A "Share to Instagram" flow on the match detail page that generates a
 **1080×1080 PNG** suitable for an Instagram square post.
@@ -39,6 +39,31 @@ The Tournament Round option is only surfaced in the picker when the match has `t
 
 Modes are independent of templates — every template supports both.
 
+### Goal scorers (SB-33)
+
+When a completed match was **live-scored** (it has goal events), the
+**Result** card lists the scorers under the scoreboard — two columns
+(home right-aligned, away left-aligned), **one line per goal in
+chronological order**, mirroring the in-app match scoreboard. Each line
+shows the scorer (player name or jersey number) and the minute
+(`56'`, or `90+5'` for stoppage time).
+
+Multi-goal games are highlighted:
+
+- **Brace (2 goals):** the scorer's lines render in accent **gold**.
+- **Hat-trick (3+ goals):** adds a gold **"⚽⚽⚽ HAT-TRICK · {name}"**
+  banner above the columns (shows the tally, e.g. "4 GOALS", beyond 3).
+
+Scorers appear on **all four templates** in Result mode only — never in
+Preview, and never when the match has no goal events (e.g. a result
+entered directly without live scoring). A scorer's goals are tallied by
+`player_id` when present, otherwise by name **scoped to their team** (so
+each side's `#9` stays distinct).
+
+Events are fetched once by `MatchDetailView`
+(`GET /api/matches/{id}/live/events`) and passed into the modal → card →
+templates; the derivation lives in `useIgShareData`.
+
 ### Graceful degradation
 
 If R2 is unavailable (503: not configured, or a transient error), the
@@ -54,10 +79,14 @@ a clear message ("Card will download but the photo will not be saved").
 - `frontend/src/components/ig/IgSplit.vue` — Brand Split template.
 - `frontend/src/components/ig/IgTournamentRound.vue` — Tournament Round template.
 - `frontend/src/components/ig/IgStadium.vue` — Stadium Scoreboard template.
+- `frontend/src/components/ig/IgScorers.vue` — presentational goal-scorers
+  block (two columns + hat-trick banner). Shared by all four templates;
+  `size` prop ('lg' | 'sm') scales it for the roomy vs. tighter cards.
 - `frontend/src/composables/useIgShareData.js` — shared computed props
   (team data, score, dateLabel, tournament-name preference, "Unknown"
-  filtering, round-name normalization). Single source of truth across
-  all four templates.
+  filtering, round-name normalization) **plus scorer derivation**
+  (`homeScorers`, `awayScorers`, `hasScorers`, `hatTricks`). Single
+  source of truth across all four templates.
 - `frontend/src/components/IgShareModal.vue` — file pick, template
   picker, upload, capture, download/clipboard flow.
 - `frontend/src/components/MatchDetailView.vue` — entry-point button +
@@ -78,4 +107,4 @@ original "any logged-in user" scope from SB-19.
 
 - [SB-19 — IG match share image umbrella](https://linear.app) (Linear)
 - [SB-31 — R2 photo upload backend](https://github.com/silverbeer/missing-table/pull/360)
-- SB-33 — goal scorers overlay (follow-up, not in v1)
+- SB-33 — goal scorers overlay (shipped: scorer list + brace/hat-trick highlight on result cards)

--- a/frontend/src/__tests__/components/IgScorers.spec.js
+++ b/frontend/src/__tests__/components/IgScorers.spec.js
@@ -1,0 +1,341 @@
+/**
+ * Goal-scorers tests (SB-33).
+ *
+ * Two layers:
+ *  1. IgScorers presentational component — props in, markup out.
+ *  2. End-to-end through IgShareCard — verifies useIgShareData derives
+ *     scorers from raw events, gates them to result mode, orders by
+ *     minute, splits by team, and flags braces / hat-tricks. Exercised on
+ *     all four templates.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import IgScorers from '@/components/ig/IgScorers.vue';
+import IgShareCard from '@/components/IgShareCard.vue';
+import {
+  createCompletedMatch,
+  createGoalEvent,
+} from '../helpers/matchFactories';
+
+const TEMPLATES = ['overlay', 'split', 'tournament-round', 'stadium'];
+
+// Completed tournament match so every template (incl. tournament-round)
+// renders cleanly in result mode.
+const resultMatch = (overrides = {}) =>
+  createCompletedMatch({
+    home_score: 3,
+    away_score: 1,
+    tournament_name: 'Spring Cup',
+    tournament_round: 'final',
+    ...overrides,
+  });
+
+const mountResult = (template, { events = [], match } = {}) =>
+  mount(IgShareCard, {
+    props: {
+      match: match || resultMatch(),
+      mode: 'result',
+      template,
+      events,
+    },
+  });
+
+describe('IgScorers (presentational)', () => {
+  const mountScorers = (props = {}) =>
+    mount(IgScorers, {
+      props: {
+        home: [{ id: 1, name: '#10', minute: "22'", goalCount: 1 }],
+        away: [{ id: 2, name: '#7', minute: "55'", goalCount: 1 }],
+        ...props,
+      },
+    });
+
+  it('renders one line per goal with name and minute', () => {
+    const wrapper = mountScorers();
+    const home = wrapper.findAll('[data-testid="ig-scorer-home"]');
+    const away = wrapper.findAll('[data-testid="ig-scorer-away"]');
+    expect(home).toHaveLength(1);
+    expect(away).toHaveLength(1);
+    expect(home[0].text()).toContain('#10');
+    expect(home[0].text()).toContain("22'");
+    expect(away[0].text()).toContain('#7');
+  });
+
+  it('flags multi-goal lines with the gold accent class', () => {
+    const wrapper = mountScorers({
+      home: [
+        { id: 1, name: '#9', minute: "10'", goalCount: 2, isMultiGoal: true },
+        { id: 2, name: '#9', minute: "40'", goalCount: 2, isMultiGoal: true },
+      ],
+    });
+    const home = wrapper.findAll('[data-testid="ig-scorer-home"]');
+    expect(home.every(l => l.classes().includes('ig-scorer-multi'))).toBe(true);
+  });
+
+  it('flags hat-trick lines and renders the celebration banner', () => {
+    const wrapper = mountScorers({
+      home: [
+        { id: 1, name: '#9', minute: "10'", goalCount: 3, isHatTrick: true },
+      ],
+      hatTricks: [{ name: '#9', count: 3 }],
+    });
+    expect(wrapper.find('[data-testid="ig-scorer-home"]').classes()).toContain(
+      'ig-scorer-hat'
+    );
+    const banner = wrapper.find('[data-testid="ig-hat-banner"]');
+    expect(banner.exists()).toBe(true);
+    expect(banner.text()).toContain('HAT-TRICK');
+    expect(banner.text()).toContain('#9');
+  });
+
+  it('shows the tally instead of HAT-TRICK for 4+ goals', () => {
+    const wrapper = mountScorers({
+      home: [],
+      away: [],
+      hatTricks: [{ name: 'Ronaldo', count: 4 }],
+    });
+    const banner = wrapper.find('[data-testid="ig-hat-banner"]');
+    expect(banner.text()).toContain('4 GOALS');
+    expect(banner.text()).not.toContain('HAT-TRICK');
+  });
+
+  it('omits the banner when there are no hat-tricks', () => {
+    const wrapper = mountScorers();
+    expect(wrapper.find('[data-testid="ig-hat-banner"]').exists()).toBe(false);
+  });
+
+  it('applies the size variant class', () => {
+    const wrapper = mountScorers({ size: 'sm' });
+    expect(wrapper.find('[data-testid="ig-scorers"]').classes()).toContain(
+      'ig-scorers-sm'
+    );
+  });
+});
+
+describe('goal scorers on result cards (SB-33)', () => {
+  // #10 home @22', #7 away @55'.
+  const oneEach = () => [
+    createGoalEvent({
+      id: 1,
+      team_id: 1,
+      player_name: '#10',
+      match_minute: 22,
+    }),
+    createGoalEvent({ id: 2, team_id: 2, player_name: '#7', match_minute: 55 }),
+  ];
+
+  for (const template of TEMPLATES) {
+    it(`renders the scorers block in result mode on the ${template} card`, () => {
+      const wrapper = mountResult(template, { events: oneEach() });
+      expect(wrapper.find('[data-testid="ig-scorers"]').exists()).toBe(true);
+      expect(wrapper.findAll('[data-testid="ig-scorer-home"]')).toHaveLength(1);
+      expect(wrapper.findAll('[data-testid="ig-scorer-away"]')).toHaveLength(1);
+    });
+  }
+
+  it('hides scorers in preview mode even when events exist', () => {
+    const wrapper = mount(IgShareCard, {
+      props: {
+        match: resultMatch(),
+        mode: 'preview',
+        template: 'stadium',
+        events: oneEach(),
+      },
+    });
+    expect(wrapper.find('[data-testid="ig-scorers"]').exists()).toBe(false);
+  });
+
+  it('hides scorers when the match has no goal events', () => {
+    const wrapper = mountResult('stadium', { events: [] });
+    expect(wrapper.find('[data-testid="ig-scorers"]').exists()).toBe(false);
+  });
+
+  it('ignores non-goal events (cards do not appear as scorers)', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({ id: 1, team_id: 1, player_name: '#10' }),
+        createGoalEvent({
+          id: 2,
+          team_id: 1,
+          event_type: 'yellow_card',
+          player_name: '#4',
+          match_minute: 70,
+        }),
+      ],
+    });
+    const home = wrapper.findAll('[data-testid="ig-scorer-home"]');
+    expect(home).toHaveLength(1);
+    expect(home[0].text()).toContain('#10');
+    expect(wrapper.text()).not.toContain('#4');
+  });
+
+  it('orders scorers by match minute', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({
+          id: 1,
+          team_id: 1,
+          player_name: 'Late',
+          match_minute: 60,
+        }),
+        createGoalEvent({
+          id: 2,
+          team_id: 1,
+          player_name: 'Early',
+          match_minute: 8,
+        }),
+        createGoalEvent({
+          id: 3,
+          team_id: 1,
+          player_name: 'Mid',
+          match_minute: 33,
+        }),
+      ],
+    });
+    const names = wrapper
+      .findAll('[data-testid="ig-scorer-home"]')
+      .map(l => l.find('.ig-scorer-name').text());
+    expect(names).toEqual(['Early', 'Mid', 'Late']);
+  });
+
+  it('formats stoppage-time minutes as "90+5\'"', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({
+          id: 1,
+          team_id: 1,
+          player_name: '#11',
+          match_minute: 90,
+          extra_time: 5,
+        }),
+      ],
+    });
+    expect(wrapper.find('[data-testid="ig-scorer-home"]').text()).toContain(
+      "90+5'"
+    );
+  });
+
+  it('splits goals to the correct team column', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({ id: 1, team_id: 1, player_name: 'HomeGuy' }),
+        createGoalEvent({
+          id: 2,
+          team_id: 2,
+          player_name: 'AwayGuy',
+          match_minute: 30,
+        }),
+      ],
+    });
+    expect(wrapper.find('[data-testid="ig-scorer-home"]').text()).toContain(
+      'HomeGuy'
+    );
+    expect(wrapper.find('[data-testid="ig-scorer-away"]').text()).toContain(
+      'AwayGuy'
+    );
+  });
+
+  it('highlights a brace (2 goals) without a hat-trick banner', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({
+          id: 1,
+          team_id: 1,
+          player_name: '#37',
+          match_minute: 56,
+        }),
+        createGoalEvent({
+          id: 2,
+          team_id: 1,
+          player_name: '#37',
+          match_minute: 62,
+        }),
+      ],
+    });
+    const home = wrapper.findAll('[data-testid="ig-scorer-home"]');
+    expect(home).toHaveLength(2);
+    expect(home.every(l => l.classes().includes('ig-scorer-multi'))).toBe(true);
+    expect(wrapper.find('[data-testid="ig-hat-banner"]').exists()).toBe(false);
+  });
+
+  it('celebrates a hat-trick (3 goals by one player)', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({
+          id: 1,
+          team_id: 1,
+          player_name: 'Messi',
+          match_minute: 12,
+        }),
+        createGoalEvent({
+          id: 2,
+          team_id: 1,
+          player_name: 'Messi',
+          match_minute: 44,
+        }),
+        createGoalEvent({
+          id: 3,
+          team_id: 1,
+          player_name: 'Messi',
+          match_minute: 77,
+        }),
+      ],
+    });
+    const banner = wrapper.find('[data-testid="ig-hat-banner"]');
+    expect(banner.exists()).toBe(true);
+    expect(banner.text()).toContain('HAT-TRICK');
+    expect(banner.text()).toContain('Messi');
+    const home = wrapper.findAll('[data-testid="ig-scorer-home"]');
+    expect(home.every(l => l.classes().includes('ig-scorer-hat'))).toBe(true);
+  });
+
+  it('does not group distinct players who share no id/name into a brace', () => {
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({
+          id: 1,
+          team_id: 1,
+          player_name: '#5',
+          match_minute: 10,
+        }),
+        createGoalEvent({
+          id: 2,
+          team_id: 1,
+          player_name: '#6',
+          match_minute: 20,
+        }),
+      ],
+    });
+    const home = wrapper.findAll('[data-testid="ig-scorer-home"]');
+    expect(home.some(l => l.classes().includes('ig-scorer-multi'))).toBe(false);
+  });
+
+  it('does not merge the same jersey number across opposing teams', () => {
+    // Both teams field a #9 with no player_id — different players, so
+    // neither line should be flagged multi-goal and there is no banner.
+    const wrapper = mountResult('stadium', {
+      events: [
+        createGoalEvent({
+          id: 1,
+          team_id: 1,
+          player_name: '#9',
+          match_minute: 15,
+        }),
+        createGoalEvent({
+          id: 2,
+          team_id: 2,
+          player_name: '#9',
+          match_minute: 40,
+        }),
+      ],
+    });
+    expect(
+      wrapper.find('[data-testid="ig-scorer-home"]').classes()
+    ).not.toContain('ig-scorer-multi');
+    expect(
+      wrapper.find('[data-testid="ig-scorer-away"]').classes()
+    ).not.toContain('ig-scorer-multi');
+    expect(wrapper.find('[data-testid="ig-hat-banner"]').exists()).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/helpers/matchFactories.js
+++ b/frontend/src/__tests__/helpers/matchFactories.js
@@ -273,6 +273,26 @@ export const createSeasonMatchList = () => [
 ];
 
 // =============================================================================
+// MATCH EVENT FACTORIES
+// =============================================================================
+
+// A single goal event as returned by /api/matches/{id}/live/events.
+// Defaults to a home-team (team_id 1) goal so tests only override what
+// they care about.
+export const createGoalEvent = (overrides = {}) => ({
+  id: 100,
+  match_id: 1,
+  event_type: 'goal',
+  player_name: '#10',
+  player_id: null,
+  team_id: 1,
+  match_minute: 22,
+  extra_time: null,
+  created_at: '2025-01-15T19:30:00Z',
+  ...overrides,
+});
+
+// =============================================================================
 // AUTH STORE FACTORIES
 // =============================================================================
 

--- a/frontend/src/components/IgShareCard.vue
+++ b/frontend/src/components/IgShareCard.vue
@@ -10,6 +10,7 @@
     :match="match"
     :photo-src="photoSrc"
     :photo-is-cross-origin="photoIsCrossOrigin"
+    :events="events"
     :mode="mode"
   />
 </template>
@@ -37,6 +38,7 @@ export default {
     match: { type: Object, required: true },
     photoSrc: { type: String, default: null },
     photoIsCrossOrigin: { type: Boolean, default: false },
+    events: { type: Array, default: () => [] },
     mode: {
       type: String,
       required: true,

--- a/frontend/src/components/IgShareModal.vue
+++ b/frontend/src/components/IgShareModal.vue
@@ -127,6 +127,7 @@
             <IgShareCard
               :match="match"
               :photo-src="localPhotoUrl"
+              :events="events"
               :mode="mode"
               :template="template"
               data-testid="ig-preview-card"
@@ -176,6 +177,7 @@
         ref="captureCard"
         :match="match"
         :photo-src="localPhotoUrl"
+        :events="events"
         :mode="mode"
         :template="template"
         data-testid="ig-capture-card"
@@ -231,6 +233,9 @@ export default {
   props: {
     open: { type: Boolean, default: false },
     match: { type: Object, required: true },
+    // Goal/card events for the match. Used to render scorers on the
+    // result card when the match was live-scored (SB-33).
+    events: { type: Array, default: () => [] },
   },
   emits: ['close', 'photo-uploaded'],
   setup(props, { emit }) {

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -707,6 +707,7 @@
       <IgShareModal
         :open="igShareOpen"
         :match="match"
+        :events="events"
         @close="closeIgShare"
         @photo-uploaded="onPhotoUploaded"
       />

--- a/frontend/src/components/ig/IgOverlay.vue
+++ b/frontend/src/components/ig/IgOverlay.vue
@@ -180,6 +180,15 @@
         </div>
       </div>
 
+      <!-- Goal scorers (live-scored result only) -->
+      <IgScorers
+        v-if="isResult && hasScorers"
+        :home="homeScorers"
+        :away="awayScorers"
+        :hat-tricks="hatTricks"
+        size="lg"
+      />
+
       <div class="ig-footer">
         <span class="ig-date" data-testid="ig-date">{{ dateLabel }}</span>
         <span class="ig-brand" data-testid="ig-brand">missingtable.com</span>
@@ -193,14 +202,16 @@
 import { computed, ref, toRefs } from 'vue';
 import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
+import IgScorers from './IgScorers.vue';
 
 export default {
   name: 'IgOverlay',
-  components: { MlsNextBadge },
+  components: { MlsNextBadge, IgScorers },
   props: {
     match: { type: Object, required: true },
     photoSrc: { type: String, default: null },
     photoIsCrossOrigin: { type: Boolean, default: false },
+    events: { type: Array, default: () => [] },
     mode: {
       type: String,
       required: true,
@@ -209,8 +220,8 @@ export default {
   },
   setup(props) {
     const root = ref(null);
-    const { match, mode } = toRefs(props);
-    const data = useIgShareData(match, mode);
+    const { match, mode, events } = toRefs(props);
+    const data = useIgShareData(match, mode, events);
     const photoCrossOrigin = computed(() =>
       props.photoIsCrossOrigin ? 'anonymous' : null
     );

--- a/frontend/src/components/ig/IgScorers.vue
+++ b/frontend/src/components/ig/IgScorers.vue
@@ -1,0 +1,303 @@
+<template>
+  <!--
+    Goal-scorers block (SB-33). Shown on result cards when a match was
+    live-scored. Two columns — home right-aligned, away left-aligned —
+    one line per goal in chronological order, mirroring the in-app
+    scoreboard. Braces (2 goals) glow gold; hat-tricks (3+) add a
+    celebratory banner above the columns.
+
+    Pure presentational: all data is derived in useIgShareData. The `size`
+    prop ('lg' | 'sm') scales type so the block fits both the roomy
+    Overlay/Stadium cards and the tighter Split/Tournament panels.
+  -->
+  <div
+    class="ig-scorers"
+    :class="`ig-scorers-${size}`"
+    data-testid="ig-scorers"
+  >
+    <div
+      v-if="hatTricks.length"
+      class="ig-hat-banner"
+      data-testid="ig-hat-banner"
+    >
+      <span
+        v-for="ht in hatTricks"
+        :key="ht.name"
+        class="ig-hat-pill"
+        data-testid="ig-hat-pill"
+      >
+        <span class="ig-hat-balls">
+          <svg
+            v-for="n in 3"
+            :key="n"
+            class="ig-ball ig-hat-ball"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="11" fill="#1f2937" />
+            <polygon
+              points="12,6.4 16.4,9.6 14.7,14.8 9.3,14.8 7.6,9.6"
+              fill="#fbbf24"
+            />
+          </svg>
+        </span>
+        <span class="ig-hat-text">
+          {{ ht.count > 3 ? `${ht.count} GOALS` : 'HAT-TRICK' }} ·
+          {{ ht.name }}
+        </span>
+      </span>
+    </div>
+
+    <div class="ig-scorers-grid">
+      <div class="ig-scorers-col ig-scorers-home">
+        <div
+          v-for="g in home"
+          :key="g.id"
+          class="ig-scorer"
+          :class="{
+            'ig-scorer-multi': g.isMultiGoal,
+            'ig-scorer-hat': g.isHatTrick,
+          }"
+          data-testid="ig-scorer-home"
+        >
+          <span class="ig-scorer-text">
+            <span class="ig-scorer-name">{{ g.name }}</span>
+            <span class="ig-scorer-min">{{ g.minute }}</span>
+          </span>
+          <svg
+            class="ig-ball ig-scorer-ball"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="11" fill="#ffffff" />
+            <polygon
+              points="12,6.4 16.4,9.6 14.7,14.8 9.3,14.8 7.6,9.6"
+              fill="#0f172a"
+            />
+          </svg>
+        </div>
+      </div>
+
+      <div class="ig-scorers-divider"></div>
+
+      <div class="ig-scorers-col ig-scorers-away">
+        <div
+          v-for="g in away"
+          :key="g.id"
+          class="ig-scorer"
+          :class="{
+            'ig-scorer-multi': g.isMultiGoal,
+            'ig-scorer-hat': g.isHatTrick,
+          }"
+          data-testid="ig-scorer-away"
+        >
+          <svg
+            class="ig-ball ig-scorer-ball"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="11" fill="#ffffff" />
+            <polygon
+              points="12,6.4 16.4,9.6 14.7,14.8 9.3,14.8 7.6,9.6"
+              fill="#0f172a"
+            />
+          </svg>
+          <span class="ig-scorer-text">
+            <span class="ig-scorer-name">{{ g.name }}</span>
+            <span class="ig-scorer-min">{{ g.minute }}</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'IgScorers',
+  props: {
+    // Each entry: { id, name, minute, goalCount, isMultiGoal, isHatTrick }
+    home: { type: Array, default: () => [] },
+    away: { type: Array, default: () => [] },
+    // Each entry: { name, count } for players with 3+ goals.
+    hatTricks: { type: Array, default: () => [] },
+    size: {
+      type: String,
+      default: 'lg',
+      validator: v => ['lg', 'sm'].includes(v),
+    },
+  },
+};
+</script>
+
+<style scoped>
+.ig-scorers {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+}
+
+/* --- Hat-trick celebration banner --- */
+.ig-hat-banner {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+
+.ig-hat-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 24px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f59e0b 0%, #fde68a 50%, #f59e0b 100%);
+  color: #1f2937;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 24px rgba(251, 191, 36, 0.5);
+}
+
+.ig-hat-balls {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.ig-hat-text {
+  white-space: nowrap;
+}
+
+/* --- Two-column scorer lists --- */
+.ig-scorers-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: start;
+  gap: 28px;
+  width: 100%;
+}
+
+.ig-scorers-divider {
+  width: 2px;
+  align-self: stretch;
+  background: rgba(255, 255, 255, 0.22);
+  border-radius: 2px;
+}
+
+.ig-scorers-col {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.ig-scorers-home {
+  align-items: flex-end;
+}
+
+.ig-scorers-away {
+  align-items: flex-start;
+}
+
+.ig-scorer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-width: 100%;
+}
+
+.ig-scorer-text {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.ig-scorers-home .ig-scorer-text {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.ig-scorer-name {
+  font-weight: 700;
+  color: #ffffff;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  word-break: break-word;
+}
+
+.ig-scorer-min {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Brace+ : gold accent so a multi-goal game stands out. */
+.ig-scorer-multi .ig-scorer-name {
+  color: #fbbf24;
+}
+
+.ig-scorer-multi .ig-scorer-min {
+  color: rgba(251, 191, 36, 0.85);
+}
+
+/* Hat-trick : brighter gold + glow. */
+.ig-scorer-hat .ig-scorer-name {
+  color: #fbbf24;
+  text-shadow:
+    0 0 16px rgba(251, 191, 36, 0.7),
+    0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+.ig-ball {
+  flex-shrink: 0;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.45));
+}
+
+/* --- Size variants --- */
+.ig-scorers-lg .ig-scorer-name {
+  font-size: 30px;
+}
+.ig-scorers-lg .ig-scorer-min {
+  font-size: 26px;
+}
+.ig-scorers-lg .ig-scorer-ball {
+  width: 30px;
+  height: 30px;
+}
+.ig-scorers-lg .ig-hat-pill {
+  font-size: 24px;
+}
+.ig-scorers-lg .ig-hat-ball {
+  width: 24px;
+  height: 24px;
+}
+
+.ig-scorers-sm .ig-scorers-grid {
+  gap: 18px;
+}
+.ig-scorers-sm .ig-scorer {
+  gap: 8px;
+}
+.ig-scorers-sm .ig-scorer-name {
+  font-size: 20px;
+}
+.ig-scorers-sm .ig-scorer-min {
+  font-size: 17px;
+}
+.ig-scorers-sm .ig-scorer-ball {
+  width: 18px;
+  height: 18px;
+}
+.ig-scorers-sm .ig-hat-pill {
+  font-size: 16px;
+  padding: 7px 16px;
+  gap: 8px;
+}
+.ig-scorers-sm .ig-hat-ball {
+  width: 16px;
+  height: 16px;
+}
+</style>

--- a/frontend/src/components/ig/IgSplit.vue
+++ b/frontend/src/components/ig/IgSplit.vue
@@ -101,6 +101,16 @@
         </div>
       </div>
 
+      <!-- Goal scorers (live-scored result only) -->
+      <div v-if="isResult && hasScorers" class="panel-scorers">
+        <IgScorers
+          :home="homeScorers"
+          :away="awayScorers"
+          :hat-tricks="hatTricks"
+          size="sm"
+        />
+      </div>
+
       <div class="footer-band">
         <div class="footer-row">
           <div class="footer-date" data-testid="ig-date">
@@ -131,14 +141,16 @@
 import { computed, ref, toRefs } from 'vue';
 import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
+import IgScorers from './IgScorers.vue';
 
 export default {
   name: 'IgSplit',
-  components: { MlsNextBadge },
+  components: { MlsNextBadge, IgScorers },
   props: {
     match: { type: Object, required: true },
     photoSrc: { type: String, default: null },
     photoIsCrossOrigin: { type: Boolean, default: false },
+    events: { type: Array, default: () => [] },
     mode: {
       type: String,
       required: true,
@@ -147,8 +159,8 @@ export default {
   },
   setup(props) {
     const root = ref(null);
-    const { match, mode } = toRefs(props);
-    const data = useIgShareData(match, mode);
+    const { match, mode, events } = toRefs(props);
+    const data = useIgShareData(match, mode, events);
     const photoCrossOrigin = computed(() =>
       props.photoIsCrossOrigin ? 'anonymous' : null
     );
@@ -339,6 +351,12 @@ export default {
   gap: 16px;
   margin-top: 32px;
   margin-bottom: 32px;
+}
+
+.panel-scorers {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 28px;
 }
 
 .crest-block {

--- a/frontend/src/components/ig/IgStadium.vue
+++ b/frontend/src/components/ig/IgStadium.vue
@@ -100,6 +100,15 @@
         </div>
       </div>
 
+      <!-- Goal scorers (live-scored result only) -->
+      <IgScorers
+        v-if="isResult && hasScorers"
+        :home="homeScorers"
+        :away="awayScorers"
+        :hat-tricks="hatTricks"
+        size="lg"
+      />
+
       <!-- Match details -->
       <div class="details">
         <div class="detail">
@@ -131,16 +140,18 @@
 import { ref, toRefs } from 'vue';
 import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
+import IgScorers from './IgScorers.vue';
 
 export default {
   name: 'IgStadium',
-  components: { MlsNextBadge },
+  components: { MlsNextBadge, IgScorers },
   props: {
     match: { type: Object, required: true },
     // Photo is unused by this template but accepted so the dispatcher
     // can pass props uniformly.
     photoSrc: { type: String, default: null },
     photoIsCrossOrigin: { type: Boolean, default: false },
+    events: { type: Array, default: () => [] },
     mode: {
       type: String,
       required: true,
@@ -149,8 +160,8 @@ export default {
   },
   setup(props) {
     const root = ref(null);
-    const { match, mode } = toRefs(props);
-    const data = useIgShareData(match, mode);
+    const { match, mode, events } = toRefs(props);
+    const data = useIgShareData(match, mode, events);
     return { root, ...data, tagline: IG_SHARE_TAGLINE };
   },
 };

--- a/frontend/src/components/ig/IgTournamentRound.vue
+++ b/frontend/src/components/ig/IgTournamentRound.vue
@@ -108,6 +108,16 @@
         </div>
       </div>
 
+      <!-- Goal scorers (live-scored result only) -->
+      <div v-if="isResult && hasScorers" class="panel-scorers">
+        <IgScorers
+          :home="homeScorers"
+          :away="awayScorers"
+          :hat-tricks="hatTricks"
+          size="sm"
+        />
+      </div>
+
       <div class="footer-band">
         <div class="footer-row">
           <div class="footer-date" data-testid="ig-date">
@@ -128,14 +138,16 @@
 import { computed, ref, toRefs } from 'vue';
 import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
+import IgScorers from './IgScorers.vue';
 
 export default {
   name: 'IgTournamentRound',
-  components: { MlsNextBadge },
+  components: { MlsNextBadge, IgScorers },
   props: {
     match: { type: Object, required: true },
     photoSrc: { type: String, default: null },
     photoIsCrossOrigin: { type: Boolean, default: false },
+    events: { type: Array, default: () => [] },
     mode: {
       type: String,
       required: true,
@@ -144,8 +156,8 @@ export default {
   },
   setup(props) {
     const root = ref(null);
-    const { match, mode } = toRefs(props);
-    const data = useIgShareData(match, mode);
+    const { match, mode, events } = toRefs(props);
+    const data = useIgShareData(match, mode, events);
     const photoCrossOrigin = computed(() =>
       props.photoIsCrossOrigin ? 'anonymous' : null
     );
@@ -295,6 +307,12 @@ export default {
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 32px;
+}
+
+.panel-scorers {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 28px;
 }
 
 .crest-block {

--- a/frontend/src/composables/useIgShareData.js
+++ b/frontend/src/composables/useIgShareData.js
@@ -27,13 +27,43 @@ const initialsFor = name => {
     .toUpperCase();
 };
 
+// Format a goal event's minute the same way the in-app scoreboard does
+// (MatchDetailView.formatMinute): "22'" or, with stoppage time, "90+5'".
+const formatGoalMinute = event => {
+  if (!event?.match_minute) return '';
+  if (event.extra_time) {
+    return `${event.match_minute}+${event.extra_time}'`;
+  }
+  return `${event.match_minute}'`;
+};
+
+// Identity key for tallying a player's goals across the match. Prefer the
+// stable player_id; fall back to the displayed name scoped to the team —
+// live-scored youth matches often store only a jersey number like "#9"
+// with no id, and that number is unique only within a team (both sides
+// can field a #9). Goals with neither id nor name stay unique so they
+// never group into a phantom brace/hat-trick.
+const scorerKey = event => {
+  if (event?.player_id != null) return `id:${event.player_id}`;
+  if (event?.player_name)
+    return `team:${event.team_id}|name:${event.player_name}`;
+  return `ev:${event?.id}`;
+};
+
+// Chronological sort: match minute, then stoppage time, then insertion id
+// as a stable tiebreak for goals logged in the same minute.
+const byGoalTime = (a, b) =>
+  (a.match_minute || 0) - (b.match_minute || 0) ||
+  (a.extra_time || 0) - (b.extra_time || 0) ||
+  (a.id || 0) - (b.id || 0);
+
 // Filter the backend's "Unknown" sentinel — see match_dao.get_match_by_id,
 // which substitutes "Unknown" when a relation (division, season, etc.) is
 // null. Without this filter the share card would print "UNKNOWN" for
 // tournament matches that have no division.
 const cleanName = v => (v && v !== 'Unknown' && v !== 'unknown' ? v : null);
 
-export function useIgShareData(matchRef, modeRef) {
+export function useIgShareData(matchRef, modeRef, eventsRef) {
   const homeTeamName = computed(() => matchRef.value?.home_team_name || '');
   const awayTeamName = computed(() => matchRef.value?.away_team_name || '');
   const homeLogoUrl = computed(
@@ -164,6 +194,72 @@ export function useIgShareData(matchRef, modeRef) {
     );
   });
 
+  // --- Goal scorers (SB-33) ---------------------------------------------
+  // Live-scored matches carry per-goal events; templates surface these on
+  // the result card. The composable owns the derivation so all four cards
+  // agree on ordering and on what counts as a brace / hat-trick.
+  const goalEvents = computed(() =>
+    (eventsRef?.value || []).filter(e => e?.event_type === 'goal')
+  );
+
+  // Goals per scorer across BOTH teams, used to flag multi-goal games.
+  const goalCountByScorer = computed(() => {
+    const counts = new Map();
+    for (const e of goalEvents.value) {
+      const key = scorerKey(e);
+      counts.set(key, (counts.get(key) || 0) + 1);
+    }
+    return counts;
+  });
+
+  // One entry per goal, in chronological order. Each carries the scorer's
+  // full-match tally so the template can highlight braces (>=2) and
+  // hat-tricks (>=3).
+  const buildScorers = teamId =>
+    goalEvents.value
+      .filter(e => e.team_id === teamId)
+      .slice()
+      .sort(byGoalTime)
+      .map(e => {
+        const goalCount = goalCountByScorer.value.get(scorerKey(e)) || 1;
+        return {
+          id: e.id,
+          name: e.player_name || 'Goal',
+          minute: formatGoalMinute(e),
+          goalCount,
+          isMultiGoal: goalCount >= 2,
+          isHatTrick: goalCount >= 3,
+        };
+      });
+
+  const homeScorers = computed(() =>
+    buildScorers(matchRef.value?.home_team_id)
+  );
+  const awayScorers = computed(() =>
+    buildScorers(matchRef.value?.away_team_id)
+  );
+  const hasScorers = computed(
+    () => homeScorers.value.length > 0 || awayScorers.value.length > 0
+  );
+
+  // Players with 3+ goals, de-duped and ordered by their first goal so the
+  // celebration banner reads in match order. 4+ still qualifies — the
+  // banner shows the tally.
+  const hatTricks = computed(() => {
+    const seen = new Set();
+    const out = [];
+    for (const e of goalEvents.value.slice().sort(byGoalTime)) {
+      const key = scorerKey(e);
+      if (seen.has(key)) continue;
+      const count = goalCountByScorer.value.get(key) || 0;
+      if (count >= 3) {
+        seen.add(key);
+        out.push({ name: e.player_name || 'Goal', count });
+      }
+    }
+    return out;
+  });
+
   return {
     homeTeamName,
     awayTeamName,
@@ -187,5 +283,9 @@ export function useIgShareData(matchRef, modeRef) {
     isResult,
     leagueName,
     isHomegrownLeague,
+    homeScorers,
+    awayScorers,
+    hasScorers,
+    hatTricks,
   };
 }


### PR DESCRIPTION
## Summary

Adds goal scorers to the **Result** variant of the Instagram match share cards (SB-33, child of SB-19). When a completed match was **live-scored** (it has goal events), every template now lists the scorers beneath the scoreboard.

- **Layout:** two columns — home right-aligned, away left-aligned — **one line per goal in chronological order**, mirroring the in-app match scoreboard. Each line shows the scorer (name or jersey number) and minute (`56'`, or `90+5'` for stoppage time).
- **Multi-goal highlight (as requested):**
  - **Brace (2 goals):** the scorer's lines render in accent **gold**.
  - **Hat-trick (3+ goals):** adds a gold **"⚽⚽⚽ HAT-TRICK · {name}"** banner above the columns (shows the tally, e.g. "4 GOALS", beyond 3).
- Shown on **all four templates** (Photo Overlay, Brand Split, Tournament Round, Stadium), **Result mode only** — never in Preview, never when a match has no goal events.
- Scorer tally is keyed by `player_id` when present, otherwise by name **scoped to the team**, so each side's `#9` stays a distinct player.

## How it's wired

- `useIgShareData.js` — takes an optional `eventsRef`; derives `homeScorers` / `awayScorers` / `hasScorers` / `hatTricks`.
- New `ig/IgScorers.vue` — presentational two-column block + hat-trick banner, with an `lg`/`sm` `size` prop (lg for Overlay/Stadium, sm for the tighter Split/Tournament panels).
- `events` threaded through `MatchDetailView → IgShareModal → IgShareCard →` each template (fetched once from `GET /api/matches/{id}/live/events`).

## Testing

- **20 new tests** in `IgScorers.spec.js` (mode gating, no-events, chronological ordering, stoppage time, team split, brace/hat-trick flags, 4+ tally, and the cross-team same-jersey edge case).
- Full frontend suite: **280 passed**. Lint clean.
- Docs: `docs/features/IG_SHARE_CARD.md` updated.

## Notes

No backend or schema changes — purely frontend, reusing the existing live-events endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)