### PR TITLE
fix(tournament-bracket): render R16/QF/SF/Final from match data

### DIFF
--- a/frontend/src/__tests__/components/TournamentBracket.spec.js
+++ b/frontend/src/__tests__/components/TournamentBracket.spec.js
@@ -1,0 +1,67 @@
+/**
+ * TournamentBracket.vue Tests
+ *
+ * Regression guard: the bracket must render Round of 16 (and later rounds) from
+ * real match data — not just hardcoded placeholders. Previously only
+ * round_of_32 was rendered from data and R16/QF/SF/Final were always empty
+ * "—" cells, so loaded R16 matchups never appeared on the bracket.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TournamentBracket from '@/components/TournamentBracket.vue';
+
+const mkMatch = (id, round, home, away, extra = {}) => ({
+  id,
+  tournament_round: round,
+  home_team: { name: home },
+  away_team: { name: away },
+  match_status: 'scheduled',
+  home_score: null,
+  away_score: null,
+  match_date: '2026-05-25',
+  ...extra,
+});
+
+describe('TournamentBracket', () => {
+  it('shows the empty-state when there are no round_of_32 matches', () => {
+    const wrapper = mount(TournamentBracket, { props: { matches: [] } });
+    expect(wrapper.text()).toContain('No matches in this bracket yet');
+  });
+
+  it('renders round_of_16 matches from data, not just placeholders', () => {
+    const matches = [
+      mkMatch(1, 'round_of_32', 'Team A', 'Team B'),
+      mkMatch(2, 'round_of_32', 'Team C', 'Team D'),
+      mkMatch(10, 'round_of_16', 'PDA', 'IFA'),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(wrapper.text()).toContain('Round of 16');
+    // The regression we are guarding: R16 teams come from match data.
+    expect(wrapper.text()).toContain('PDA');
+    expect(wrapper.text()).toContain('IFA');
+  });
+
+  it('pads not-yet-loaded later-round slots with placeholders', () => {
+    const matches = [mkMatch(1, 'round_of_32', 'Team A', 'Team B')];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+    // No R16/QF/SF/Final loaded -> those slots fall back to "—".
+    expect(wrapper.text()).toContain('—');
+  });
+
+  it('emits match-click with the match when a round_of_16 cell is clicked', async () => {
+    const r16 = mkMatch(10, 'round_of_16', 'PDA', 'IFA');
+    const matches = [mkMatch(1, 'round_of_32', 'Team A', 'Team B'), r16];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    const r16Btn = wrapper
+      .findAll('button')
+      .find(b => b.text().includes('IFA'));
+    expect(r16Btn).toBeTruthy();
+
+    await r16Btn.trigger('click');
+    expect(wrapper.emitted('match-click')).toBeTruthy();
+    expect(wrapper.emitted('match-click')[0][0]).toEqual(r16);
+  });
+});

--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -25,30 +25,34 @@
           <BracketCell :match="m" @click="$emit('match-click', m)" />
         </div>
 
-        <!-- Placeholder cells for future rounds (no matches in DB yet) -->
+        <!-- Later rounds: real matches where loaded, placeholder otherwise -->
         <div
-          v-for="i in 8"
-          :key="`r16-${i}`"
-          :class="['bracket-cell', `col-2`, `r16-${i - 1}`]"
+          v-for="(m, idx) in r16Cells"
+          :key="`r16-${idx}`"
+          :class="['bracket-cell', `col-2`, `r16-${idx}`]"
         >
-          <BracketCell :match="null" />
+          <BracketCell :match="m" @click="$emit('match-click', m)" />
         </div>
         <div
-          v-for="i in 4"
-          :key="`qf-${i}`"
-          :class="['bracket-cell', `col-3`, `qf-${i - 1}`]"
+          v-for="(m, idx) in qfCells"
+          :key="`qf-${idx}`"
+          :class="['bracket-cell', `col-3`, `qf-${idx}`]"
         >
-          <BracketCell :match="null" />
+          <BracketCell :match="m" @click="$emit('match-click', m)" />
         </div>
         <div
-          v-for="i in 2"
-          :key="`sf-${i}`"
-          :class="['bracket-cell', `col-4`, `sf-${i - 1}`]"
+          v-for="(m, idx) in sfCells"
+          :key="`sf-${idx}`"
+          :class="['bracket-cell', `col-4`, `sf-${idx}`]"
         >
-          <BracketCell :match="null" />
+          <BracketCell :match="m" @click="$emit('match-click', m)" />
         </div>
         <div :class="['bracket-cell', `col-5`, `final-0`]">
-          <BracketCell :match="null" :is-final="true" />
+          <BracketCell
+            :match="finalCell"
+            :is-final="true"
+            @click="$emit('match-click', finalCell)"
+          />
         </div>
       </div>
     </div>
@@ -79,6 +83,21 @@ const r32Matches = computed(() =>
     .filter(m => m.tournament_round === 'round_of_32')
     .sort((a, b) => a.id - b.id)
 );
+
+// Fixed-length cell list for a round: real matches (ascending id, mirroring the
+// source schedule order) padded with nulls so every bracket slot renders, even
+// before its match has been loaded/advanced.
+function roundCells(roundKey, slotCount) {
+  const ms = props.matches
+    .filter(m => m.tournament_round === roundKey)
+    .sort((a, b) => a.id - b.id);
+  return Array.from({ length: slotCount }, (_, i) => ms[i] ?? null);
+}
+
+const r16Cells = computed(() => roundCells('round_of_16', 8));
+const qfCells = computed(() => roundCells('quarterfinal', 4));
+const sfCells = computed(() => roundCells('semifinal', 2));
+const finalCell = computed(() => roundCells('final', 1)[0]);
 
 // ── Inline child component for match cells ──
 const BracketCell = {


### PR DESCRIPTION
## What
Fixes the tournament bracket so it shows **Round of 16, Quarterfinals, Semifinals, and Final** — not just Round of 32.

## Why
`TournamentBracket.vue` only rendered `round_of_32` matches from data; R16/QF/SF/Final were hardcoded empty placeholder cells (commented *"no matches in DB yet"* — a stale assumption from when only R32 was loaded). The parent (`TournamentMatchCenter.vue`) already passes **all** bracket-round matches, so loaded R16+ matchups were handed to the component but never displayed. Result: after loading a round past R32 (e.g. the U15 R16 matchups), the bracket still looked empty even though the matches were saved and visible in the match list.

## How
- Add a `roundCells(roundKey, slotCount)` helper that pulls the round's matches from the `matches` prop (sorted by ascending id, mirroring schedule order) and pads with `null` to the fixed slot count.
- Render R16 (8), QF (4), SF (2), Final (1) from those cells, with placeholder fallback so the full bracket shape still shows before later rounds are loaded.

**Note:** matches are placed in id order (same convention already used for R32). The boxes display correctly; pixel-exact connector-line alignment to feeder matches (winner of r32-0 + r32-1 → r16-0) is a possible follow-up.

## Testing
- New `TournamentBracket.spec.js` (4 tests): R16 renders from data, placeholder fallback for unloaded slots, empty state, and `match-click` emission. All pass.
- `eslint` clean on both files.

## Scope
Frontend only. No backend/API changes; no change to how matches are stored or fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
