### PR TITLE
feat(admin): add name search to Clubs and Teams management

### DIFF
--- a/frontend/src/__tests__/components/AdminClubs.spec.js
+++ b/frontend/src/__tests__/components/AdminClubs.spec.js
@@ -1,0 +1,77 @@
+/**
+ * AdminClubs.vue — club name search/filter.
+ *
+ * Mocks the auth store's apiRequest (the only data source on mount) and asserts
+ * the client-side name filter narrows the rendered club cards and surfaces a
+ * no-results message.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import AdminClubs from '@/components/admin/AdminClubs.vue';
+
+let mockAuthStore;
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => mockAuthStore }));
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+}));
+
+const CLUBS = [
+  { id: 1, name: 'Players Development Academy', city: 'Somerset, NJ' },
+  { id: 2, name: 'AC River', city: 'Riverside' },
+  { id: 3, name: 'AFC Lightning', city: 'Atlanta' },
+].map(c => ({
+  logo_url: null,
+  primary_color: '#3B82F6',
+  secondary_color: '#1E40AF',
+  pro_academy: false,
+  team_count: 1,
+  is_active: true,
+  ...c,
+}));
+
+const mountClubs = () => {
+  mockAuthStore = {
+    userRole: { value: 'admin' },
+    userClubId: { value: null },
+    apiRequest: vi.fn(() => Promise.resolve(CLUBS.map(c => ({ ...c })))),
+  };
+  return mount(AdminClubs);
+};
+
+describe('AdminClubs search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all clubs before searching', async () => {
+    const wrapper = mountClubs();
+    await flushPromises();
+    expect(wrapper.text()).toContain('Players Development Academy');
+    expect(wrapper.text()).toContain('AC River');
+    expect(wrapper.text()).toContain('AFC Lightning');
+  });
+
+  it('filters clubs by name, case-insensitively', async () => {
+    const wrapper = mountClubs();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="club-search"]').setValue('PLAYER');
+
+    expect(wrapper.text()).toContain('Players Development Academy');
+    expect(wrapper.text()).not.toContain('AC River');
+    expect(wrapper.text()).not.toContain('AFC Lightning');
+  });
+
+  it('shows a no-results message when nothing matches', async () => {
+    const wrapper = mountClubs();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="club-search"]').setValue('zzzzz');
+
+    expect(wrapper.find('[data-testid="club-search-empty"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.text()).toContain('No clubs match');
+  });
+});

--- a/frontend/src/__tests__/components/AdminTeams.spec.js
+++ b/frontend/src/__tests__/components/AdminTeams.spec.js
@@ -1,0 +1,106 @@
+/**
+ * AdminTeams.vue — team name / parent-club search/filter.
+ *
+ * Mocks the auth store's apiRequest (dispatching per URL — teams list plus the
+ * reference-data fetches on mount) and asserts the client-side filter narrows
+ * the rendered team rows and surfaces a no-results row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import AdminTeams from '@/components/admin/AdminTeams.vue';
+
+let mockAuthStore;
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => mockAuthStore }));
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+}));
+
+const TEAMS = [
+  {
+    id: 1,
+    name: 'ALBION SC Colorado',
+    parent_club: { name: 'ALBION SC Colorado' },
+    league_name: 'Homegrown',
+    age_groups: [],
+  },
+  {
+    id: 2,
+    name: 'AC River',
+    parent_club: { name: 'AC River' },
+    league_name: 'Homegrown',
+    age_groups: [],
+  },
+  {
+    id: 3,
+    name: 'PDA Tigers',
+    parent_club: { name: 'Players Development Academy' },
+    league_name: 'Homegrown',
+    age_groups: [],
+  },
+];
+
+// On mount AdminTeams loads teams + age-groups/clubs/divisions/leagues/match-types/seasons.
+const byUrl = url => {
+  if (url.includes('/api/teams'))
+    return Promise.resolve(TEAMS.map(t => ({ ...t })));
+  return Promise.resolve([]);
+};
+
+const mountTeams = () => {
+  mockAuthStore = {
+    userRole: { value: 'admin' },
+    userClubId: { value: null },
+    apiRequest: vi.fn(url => byUrl(url)),
+  };
+  return mount(AdminTeams);
+};
+
+describe('AdminTeams search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all teams before searching', async () => {
+    const wrapper = mountTeams();
+    await flushPromises();
+    expect(wrapper.findAll('[data-team-row]')).toHaveLength(3);
+  });
+
+  it('filters by team name', async () => {
+    const wrapper = mountTeams();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="team-search"]').setValue('albion');
+
+    const rows = wrapper.findAll('[data-team-row]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('ALBION SC Colorado');
+  });
+
+  it('also matches on parent club name', async () => {
+    const wrapper = mountTeams();
+    await flushPromises();
+
+    // "PDA Tigers" team belongs to the "Players Development Academy" club.
+    await wrapper
+      .find('[data-testid="team-search"]')
+      .setValue('players development');
+
+    const rows = wrapper.findAll('[data-team-row]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('PDA Tigers');
+  });
+
+  it('shows a no-results row when nothing matches', async () => {
+    const wrapper = mountTeams();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="team-search"]').setValue('zzzzz');
+
+    expect(wrapper.find('[data-testid="team-search-empty"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.findAll('[data-team-row]')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/admin/AdminClubs.vue
+++ b/frontend/src/components/admin/AdminClubs.vue
@@ -10,6 +10,17 @@
       </button>
     </div>
 
+    <!-- Search -->
+    <div class="mb-4">
+      <input
+        v-model="clubSearch"
+        type="search"
+        placeholder="Search clubs by name…"
+        data-testid="club-search"
+        class="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-brand-500 focus:border-brand-500"
+      />
+    </div>
+
     <!-- Loading State -->
     <div v-if="loading" class="flex justify-center py-8">
       <div
@@ -28,7 +39,7 @@
     <!-- Clubs Grid -->
     <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <div
-        v-for="club in clubs"
+        v-for="club in filteredClubs"
         :key="club.id"
         class="bg-white shadow-md rounded-lg overflow-hidden hover:shadow-lg transition-shadow"
         :style="{
@@ -167,6 +178,15 @@
           </button>
         </div>
       </div>
+    </div>
+
+    <!-- No search results -->
+    <div
+      v-if="!loading && clubs.length > 0 && filteredClubs.length === 0"
+      data-testid="club-search-empty"
+      class="text-center py-8 text-sm text-gray-500"
+    >
+      No clubs match "{{ clubSearch }}".
     </div>
 
     <!-- Empty State -->
@@ -527,7 +547,7 @@
 </template>
 
 <script>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useAuthStore } from '../../stores/auth';
 import { getApiBaseUrl } from '../../config/api';
 import ClubLogo from '../shared/ClubLogo.vue';
@@ -538,6 +558,12 @@ export default {
   setup() {
     const authStore = useAuthStore();
     const clubs = ref([]);
+    const clubSearch = ref('');
+    const filteredClubs = computed(() => {
+      const q = clubSearch.value.trim().toLowerCase();
+      if (!q) return clubs.value;
+      return clubs.value.filter(c => (c.name || '').toLowerCase().includes(q));
+    });
     const loading = ref(true);
     const error = ref(null);
     const showAddModal = ref(false);
@@ -847,6 +873,8 @@ export default {
       editError,
       logoPreview,
       uploadingLogo,
+      clubSearch,
+      filteredClubs,
       openEditModal,
       handleLogoSelect,
       updateClub,

--- a/frontend/src/components/admin/AdminTeams.vue
+++ b/frontend/src/components/admin/AdminTeams.vue
@@ -11,6 +11,17 @@
       </button>
     </div>
 
+    <!-- Search -->
+    <div class="mb-4">
+      <input
+        v-model="teamSearch"
+        type="search"
+        placeholder="Search teams by name or club…"
+        data-testid="team-search"
+        class="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-brand-500 focus:border-brand-500"
+      />
+    </div>
+
     <!-- Loading State -->
     <div
       v-if="loading"
@@ -75,7 +86,15 @@
           data-testid="teams-tbody"
         >
           <tr
-            v-for="team in teams"
+            v-if="teams.length > 0 && filteredTeams.length === 0"
+            data-testid="team-search-empty"
+          >
+            <td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">
+              No teams match "{{ teamSearch }}".
+            </td>
+          </tr>
+          <tr
+            v-for="team in filteredTeams"
             :key="team.id"
             :data-testid="`team-row-${team.id}`"
             data-team-row
@@ -621,6 +640,16 @@ export default {
   setup() {
     const authStore = useAuthStore();
     const teams = ref([]);
+    const teamSearch = ref('');
+    const filteredTeams = computed(() => {
+      const q = teamSearch.value.trim().toLowerCase();
+      if (!q) return teams.value;
+      return teams.value.filter(t => {
+        const name = (t.name || '').toLowerCase();
+        const club = (t.parent_club?.name || '').toLowerCase();
+        return name.includes(q) || club.includes(q);
+      });
+    });
     const clubs = ref([]);
     const ageGroups = ref([]);
     const divisions = ref([]);
@@ -1131,6 +1160,8 @@ export default {
 
     return {
       teams,
+      teamSearch,
+      filteredTeams,
       clubs,
       ageGroups,
       divisions,


### PR DESCRIPTION
## What
Adds a **name search box** to both admin management views under **Admin → Teams & Players**:
- **Clubs** — filters the club cards by club name.
- **Teams** — filters the team rows by team name **or** parent club name.

## Why
Both lists render every record with no way to jump to a specific club/team — painful as the dataset grows (hundreds of MLS NEXT clubs/teams).

## How
- Client-side `computed` filter over the already-loaded list (no API changes): `filteredClubs` / `filteredTeams`, driven by a `clubSearch` / `teamSearch` ref bound to a search input.
- Case-insensitive substring match. Teams also match on `parent_club.name`.
- A "no matches" message/row shows when a query excludes everything (distinct from the existing empty state).

## Testing
- `AdminClubs.spec.js` (3 tests): renders all, filters by name, no-results message.
- `AdminTeams.spec.js` (4 tests): renders all, filters by team name, matches on parent club, no-results row.
- All 7 pass; `eslint` clean on all four files.

## Notes
Frontend only. Filtering is client-side over the full loaded list (these views already load all records, no pagination), so it's instant and complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
