### PR TITLE
feat(support): move support link from avatar dropdown to global footer

### DIFF
--- a/frontend/src/components/AuthNav.vue
+++ b/frontend/src/components/AuthNav.vue
@@ -45,14 +45,6 @@
             class="dropdown-menu"
             data-testid="dropdown-menu"
           >
-            <SupportEmailLink
-              :subject="supportSubject"
-              :body="supportBody"
-              display-text="Contact support"
-              class="dropdown-item support-item"
-              data-testid="support-link"
-            />
-            <div class="dropdown-divider"></div>
             <button
               @click="handleLogout"
               class="dropdown-item logout-item"
@@ -87,11 +79,9 @@
 <script>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useAuthStore } from '@/stores/auth';
-import SupportEmailLink from '@/components/SupportEmailLink.vue';
 
 export default {
   name: 'AuthNav',
-  components: { SupportEmailLink },
   emits: ['show-login', 'logout'],
   setup(props, { emit }) {
     const authStore = useAuthStore();
@@ -188,19 +178,6 @@ export default {
       document.removeEventListener('click', handleClickOutside);
     });
 
-    const supportSubject = computed(() => {
-      const email = authStore.state.profile?.email;
-      return email ? `[Account: ${email}] Help request` : 'Help request';
-    });
-    const supportBody = computed(() => {
-      const lines = ['Hi support team,', '', 'I need help with my account.'];
-      const profile = authStore.state.profile;
-      if (profile?.email) lines.push('', `Account email: ${profile.email}`);
-      if (profile?.display_name)
-        lines.push(`Display name: ${profile.display_name}`);
-      return lines.join('\n');
-    });
-
     return {
       authStore,
       showDropdown,
@@ -210,8 +187,6 @@ export default {
       hideDropdown,
       showLogin,
       handleLogout,
-      supportSubject,
-      supportBody,
     };
   },
 };
@@ -412,26 +387,6 @@ export default {
 
 .logout-item:hover {
   background-color: #fef2f2;
-}
-
-.support-item {
-  color: #374151;
-  font-weight: 500;
-}
-
-.support-item:hover {
-  background-color: #f8fafc;
-}
-
-/* Override SupportEmailLink's default underlined-link styling when used
-   as a dropdown row. */
-:deep(.support-item.support-email-link) {
-  text-decoration: none;
-  color: #374151;
-}
-
-:deep(.support-item.support-email-link:hover) {
-  color: #111827;
 }
 
 .login-btn {

--- a/frontend/src/components/VersionFooter.vue
+++ b/frontend/src/components/VersionFooter.vue
@@ -41,8 +41,20 @@
         <span v-else class="version-loading">Loading version...</span>
       </div>
 
-      <!-- Copyright/branding (center) -->
-      <div class="copyright">© {{ currentYear }} Missing Table</div>
+      <!-- Copyright/branding + support link (center) -->
+      <div class="copyright">
+        <div>© {{ currentYear }} Missing Table</div>
+        <div class="support-line">
+          Need help?
+          <SupportEmailLink
+            :subject="supportSubject"
+            :body="supportBody"
+            display-text="Contact support"
+            class="support-footer-link"
+            data-testid="footer-support-link"
+          />
+        </div>
+      </div>
 
       <!-- Status indicator (right side) — only show when healthy -->
       <div class="status-indicator">
@@ -57,15 +69,41 @@
 
 <script>
 import { ref, onMounted, computed } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import SupportEmailLink from '@/components/SupportEmailLink.vue';
 
 export default {
   name: 'VersionFooter',
+  components: { SupportEmailLink },
   setup() {
+    const authStore = useAuthStore();
     const version = ref(null);
     const environment = ref('unknown');
     const status = ref('healthy');
     const currentYear = computed(() => new Date().getFullYear());
     const errorDismissed = ref(false);
+
+    // Pre-fill support email with the user's account context when logged in.
+    // Falls through to a generic "Help request" subject + empty body for
+    // anonymous visitors.
+    const supportSubject = computed(() => {
+      const email = authStore.state.profile?.email;
+      return email ? `[Account: ${email}] Help request` : 'Help request';
+    });
+    const supportBody = computed(() => {
+      const profile = authStore.state.profile;
+      if (!profile?.email) return '';
+      const lines = [
+        'Hi support team,',
+        '',
+        'I need help with my account.',
+        '',
+        `Account email: ${profile.email}`,
+      ];
+      if (profile.display_name)
+        lines.push(`Display name: ${profile.display_name}`);
+      return lines.join('\n');
+    });
 
     // Determine environment based on current hostname
     const determineEnvironment = () => {
@@ -128,6 +166,8 @@ export default {
       errorDismissed,
       fetchVersion,
       retryFetch,
+      supportSubject,
+      supportBody,
     };
   },
 };
@@ -190,6 +230,19 @@ export default {
 .copyright {
   text-align: center;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+}
+
+.support-line {
+  font-size: 0.8125rem;
+  color: #6c757d;
+}
+
+.support-footer-link {
+  font-weight: 500;
 }
 
 .status-indicator {


### PR DESCRIPTION
## Summary

Move the "Contact support" link from the user-avatar dropdown to the global `VersionFooter`. Discoverability for logged-in users goes from "hidden in a dropdown" to "always visible at the bottom of every page", and we eliminate the accidental-mailto-while-clicking-Logout footgun.

## Why

Logged-in users had no persistent support affordance — the only one was tucked inside the avatar dropdown alongside Logout. Two problems:

1. **Low discoverability** — users had to know to click the avatar before they could find support.
2. **Accidental clicks** — aiming for Logout sometimes hit "Contact support" instead, firing a `mailto:` that opens Mac Mail (or whatever the OS mail client is). For users who don't use the OS mail app, that's an annoying interruption.

## What changed

- **`frontend/src/components/VersionFooter.vue`** — adds a "Need help? Contact support" line under the copyright in the existing center column. Pre-fills subject/body from the auth profile when logged in (`[Account: {email}] Help request` + body with email + display name); falls back to a plain "Help request" for anonymous visitors.
- **`frontend/src/components/AuthNav.vue`** — removes the `<SupportEmailLink>` block from the dropdown, plus its import, `components` registration, `supportSubject` / `supportBody` computeds, and the dropdown-specific support styling.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` — full suite 320 passed
- [ ] Manual: open http://localhost:8080, scroll to footer, confirm the line reads "Need help? Contact support". Hover the link, confirm the mailto includes account context when logged in. Open avatar dropdown, confirm only Logout shows now.

Refs: [SB-35](https://linear.app/silverbeer/issue/SB-35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)