### PR TITLE
feat(ig-share): result-mode CTA + cooler red footer band

### DIFF
--- a/frontend/src/__tests__/components/IgShareTemplates.spec.js
+++ b/frontend/src/__tests__/components/IgShareTemplates.spec.js
@@ -129,16 +129,33 @@ describe('IgTournamentRound template', () => {
 });
 
 describe('tagline', () => {
-  const expected = 'Check out missingtable.com for live match updates';
+  const previewCopy = 'Check out missingtable.com for live match updates';
+  const resultCopy = 'Go to missingtable.com to request an invite';
+
   for (const template of ['overlay', 'split', 'tournament-round', 'stadium']) {
-    it(`renders the CTA tagline on the ${template} template`, () => {
+    it(`renders the preview CTA on the ${template} template`, () => {
       const wrapper = mountCard(template, {
         match: createMockMatch({
           tournament_round: template === 'tournament-round' ? 'final' : null,
           tournament_name: template === 'tournament-round' ? 'Cup' : null,
         }),
       });
-      expect(wrapper.find('[data-testid="ig-tagline"]').text()).toBe(expected);
+      expect(wrapper.find('[data-testid="ig-tagline"]').text()).toBe(
+        previewCopy
+      );
+    });
+
+    it(`renders the result CTA on the ${template} template`, () => {
+      const wrapper = mountCard(template, {
+        mode: 'result',
+        match: createMockMatch({
+          tournament_round: template === 'tournament-round' ? 'final' : null,
+          tournament_name: template === 'tournament-round' ? 'Cup' : null,
+        }),
+      });
+      expect(wrapper.find('[data-testid="ig-tagline"]').text()).toBe(
+        resultCopy
+      );
     });
   }
 });

--- a/frontend/src/components/ig/IgOverlay.vue
+++ b/frontend/src/components/ig/IgOverlay.vue
@@ -200,7 +200,7 @@
 
 <script>
 import { computed, ref, toRefs } from 'vue';
-import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
+import { useIgShareData } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
 import IgScorers from './IgScorers.vue';
 
@@ -225,7 +225,7 @@ export default {
     const photoCrossOrigin = computed(() =>
       props.photoIsCrossOrigin ? 'anonymous' : null
     );
-    return { root, ...data, photoCrossOrigin, tagline: IG_SHARE_TAGLINE };
+    return { root, ...data, photoCrossOrigin };
   },
 };
 </script>

--- a/frontend/src/components/ig/IgSplit.vue
+++ b/frontend/src/components/ig/IgSplit.vue
@@ -139,7 +139,7 @@
 
 <script>
 import { computed, ref, toRefs } from 'vue';
-import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
+import { useIgShareData } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
 import IgScorers from './IgScorers.vue';
 
@@ -206,7 +206,6 @@ export default {
       root,
       ...data,
       photoCrossOrigin,
-      tagline: IG_SHARE_TAGLINE,
       panelPath,
     };
   },
@@ -428,18 +427,27 @@ export default {
 }
 
 .footer-band {
-  background: #dc2626;
-  /* Negative margins cancel the panel's padding so the band reaches
-     the panel's edges (left + right + bottom). The clip-path then
-     trims the band's right side along the torn edge. */
-  margin: 0 -140px -48px -48px;
-  padding: 18px 140px 18px 48px;
+  /* Subtle gradient + warm inner highlight reads more polished than a
+     flat fill. Diagonal so the right side (under the torn-paper crop)
+     stays a touch brighter and catches the eye. */
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 55%, #b91c1c 100%);
+  /* Inset from the panel edges so the rounded corners are visible. The
+     right inset stays small because the torn-paper SVG crops further
+     in; the left/bottom insets are the visible breathing room. */
+  margin: 24px -116px -24px -24px;
+  padding: 18px 124px 18px 28px;
+  border-radius: 18px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   color: #ffffff;
   font-weight: 700;
   letter-spacing: 0.04em;
+  /* Soft drop shadow + 1px top inner highlight = depth without
+     ornament. html2canvas handles both. */
+  box-shadow:
+    0 10px 24px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
 }
 
 .footer-row {

--- a/frontend/src/components/ig/IgStadium.vue
+++ b/frontend/src/components/ig/IgStadium.vue
@@ -138,7 +138,7 @@
 
 <script>
 import { ref, toRefs } from 'vue';
-import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
+import { useIgShareData } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
 import IgScorers from './IgScorers.vue';
 
@@ -162,7 +162,7 @@ export default {
     const root = ref(null);
     const { match, mode, events } = toRefs(props);
     const data = useIgShareData(match, mode, events);
-    return { root, ...data, tagline: IG_SHARE_TAGLINE };
+    return { root, ...data };
   },
 };
 </script>

--- a/frontend/src/components/ig/IgTournamentRound.vue
+++ b/frontend/src/components/ig/IgTournamentRound.vue
@@ -136,7 +136,7 @@
 
 <script>
 import { computed, ref, toRefs } from 'vue';
-import { useIgShareData, IG_SHARE_TAGLINE } from '@/composables/useIgShareData';
+import { useIgShareData } from '@/composables/useIgShareData';
 import MlsNextBadge from './MlsNextBadge.vue';
 import IgScorers from './IgScorers.vue';
 
@@ -161,7 +161,7 @@ export default {
     const photoCrossOrigin = computed(() =>
       props.photoIsCrossOrigin ? 'anonymous' : null
     );
-    return { root, ...data, photoCrossOrigin, tagline: IG_SHARE_TAGLINE };
+    return { root, ...data, photoCrossOrigin };
   },
 };
 </script>

--- a/frontend/src/composables/useIgShareData.js
+++ b/frontend/src/composables/useIgShareData.js
@@ -12,9 +12,13 @@
 import { computed } from 'vue';
 
 // Promotional CTA shown at the bottom of every IG share-card template.
-// Single source so copy changes are one edit.
+// The preview (pre-match) variant nudges followers to come watch live;
+// the result (full-time) variant pivots to invite acquisition since the
+// match is already over. Single source so copy changes are one edit.
 export const IG_SHARE_TAGLINE =
   'Check out missingtable.com for live match updates';
+export const IG_SHARE_RESULT_TAGLINE =
+  'Go to missingtable.com to request an invite';
 
 const initialsFor = name => {
   if (!name) return '?';
@@ -169,6 +173,12 @@ export function useIgShareData(matchRef, modeRef, eventsRef) {
 
   const isResult = computed(() => modeRef.value === 'result');
 
+  // Mode-aware CTA copy. Preview pre-match nudges live-watching; result
+  // post-match pivots to invite acquisition (the match is already over).
+  const tagline = computed(() =>
+    isResult.value ? IG_SHARE_RESULT_TAGLINE : IG_SHARE_TAGLINE
+  );
+
   // True when match has tournament context — drives whether the
   // Tournament Round template is offered as an option in the picker.
   const hasTournamentRound = computed(() => !!tournamentRoundLabel.value);
@@ -281,6 +291,7 @@ export function useIgShareData(matchRef, modeRef, eventsRef) {
     shortDateLabel,
     kickoffLabel,
     isResult,
+    tagline,
     leagueName,
     isHomegrownLeague,
     homeScorers,


### PR DESCRIPTION
## Summary

Two visible tweaks on the IG share cards, both for the post-match (Result) experience:

1. **CTA copy is now mode-aware.** Preview cards still say "Check out missingtable.com for live match updates" (right for pre-match). Result cards now say **"Go to missingtable.com to request an invite"** — the previous copy reads wrong once the match is over, and the new copy pivots to invite acquisition.
2. **Brand Split footer band looks less dated.** Flat red rectangle with sharp corners → rounded corners, slight inset from the panel edges, diagonal red gradient, soft drop shadow, 1px top inset highlight.

## What changed

**Mode-aware tagline** — `frontend/src/composables/useIgShareData.js`:
- New constant `IG_SHARE_RESULT_TAGLINE = 'Go to missingtable.com to request an invite'` alongside the existing `IG_SHARE_TAGLINE`.
- New `tagline` computed picks based on `isResult`. Single source so the four templates can't drift.
- All four templates (`IgOverlay`, `IgSplit`, `IgTournamentRound`, `IgStadium`) drop the `import { IG_SHARE_TAGLINE }` and consume `tagline` from the composable instead.

**Cooler footer band** — `frontend/src/components/ig/IgSplit.vue` `.footer-band`:
- `border-radius: 18px`
- Inset from the panel edges (`margin: 24px -116px -24px -24px`) so the rounded corners are visible while the right side still tucks under the torn-paper crop.
- `linear-gradient(135deg, #ef4444, #dc2626, #b91c1c)` instead of flat `#dc2626`.
- `box-shadow: 0 10px 24px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.22)` for depth + top highlight.
- All effects html2canvas-safe — verified against the existing capture path.

## Test plan

- [x] `npm run lint` clean
- [x] `IgShareTemplates.spec.js` now asserts both preview AND result taglines on every template (4 templates × 2 modes = 8 tagline assertions, was 4). 30 of 30 IG-share tests pass.
- [x] Full suite stays green
- [ ] Manual on the dev server: open a result-mode share for any completed match, confirm the bottom strip on the Brand Split template reads "Go to missingtable.com to request an invite" and has the rounded corners + gradient.

## Notes

- The result copy is intentionally one short line. Earlier draft was the longer "Head to missingtable.com to request an invite to follow your favorite club"; this version is tighter and scans cleaner on Instagram thumbnails.
- The footer-band cosmetic change is scoped to the Brand Split template — the other three templates have their own footer treatments and don't need the same change. We can lift the pattern to them later if desired.

Refs: SB-19 (parent), SB-32 (templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)