### PR TITLE
feat(admin): attention badge on top-nav Admin link

### DIFF
--- a/backend/api/admin_attention.py
+++ b/backend/api/admin_attention.py
@@ -1,0 +1,65 @@
+"""
+Admin attention badge API (SB-4X).
+
+Powers the red dot + hover tooltip on the global top-nav "Admin" link.
+One endpoint, one round trip per poll — aggregates pending counts across
+the Access sub-sections that actually have a request queue.
+
+Live Match Notifications is excluded — it's a per-club config surface
+with no pending state to count.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from supabase import create_client
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from auth import require_admin
+from dao.admin_attention_dao import AdminAttentionDAO
+from dao.match_dao import SupabaseConnection as DbConnectionHolder
+
+logger = structlog.get_logger(__name__)
+
+# Service-role connection — require_admin is the trust gate, same pattern
+# as backend/api/admin_emails.py.
+_supabase_url = os.getenv("SUPABASE_URL", "")
+_service_key = os.getenv("SUPABASE_SERVICE_KEY")
+if _service_key:
+    _service_client = create_client(_supabase_url, _service_key)
+    _conn_holder = DbConnectionHolder()
+    _conn_holder.client = _service_client
+else:
+    _conn_holder = DbConnectionHolder()
+
+_dao = AdminAttentionDAO(_conn_holder)
+
+router = APIRouter(prefix="/api/admin/attention", tags=["admin-attention"])
+
+
+class AttentionCounts(BaseModel):
+    invite_requests: int
+    channel_requests: int
+    support_inbox: int
+    total: int
+
+
+@router.get("/counts", response_model=AttentionCounts)
+async def get_attention_counts(
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, int]:
+    """Per-queue pending counts for the admin nav badge.
+
+    Cached 30s via Redis when CACHE_ENABLED — repeat polls from multiple
+    admin sessions share one DB fan-out per window. With Redis off, every
+    call hits the DB fresh (still cheap — three count queries).
+    """
+    return _dao.get_counts()

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 import r2_client
+from api.admin_attention import router as admin_attention_router
 from api.admin_emails import router as admin_emails_router
 from api.channel_requests import router as channel_requests_router
 from api.club_notifications import router as club_notifications_router
@@ -261,6 +262,7 @@ app.include_router(channel_requests_router)
 app.include_router(club_notifications_router)
 app.include_router(webhooks_email_router)
 app.include_router(admin_emails_router)
+app.include_router(admin_attention_router)
 
 # Version endpoint
 import contextlib

--- a/backend/dao/admin_attention_dao.py
+++ b/backend/dao/admin_attention_dao.py
@@ -1,0 +1,88 @@
+"""
+AdminAttentionDAO — single-shot aggregator for the admin nav badge.
+
+Counts items across three "needs admin attention" queues:
+- Invite Requests in 'pending' status
+- Channel Requests with any platform in 'pending' (telegram or discord)
+- Support Inbox threads with unread messages where status is 'new' or 'awaiting_admin'
+  (delegates to EmailThreadsDAO.unread_count_for_attention)
+
+Result is cached for 30s via @dao_cache when Redis is enabled; otherwise the
+decorator no-ops and every call hits the DB (still fine — these are tiny
+count queries).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from dao.base_dao import BaseDAO, dao_cache
+from dao.email_threads_dao import EmailThreadsDAO
+
+logger = structlog.get_logger()
+
+# 30s TTL: short enough that admins see updates promptly, long enough that
+# multiple admin sessions share a single fan-out per 30s window.
+_CACHE_TTL = 30
+
+
+class AdminAttentionDAO(BaseDAO):
+    """Aggregator for the admin top-nav attention badge."""
+
+    @dao_cache("admin_attention:counts", ttl=_CACHE_TTL)
+    def get_counts(self) -> dict[str, Any]:
+        """Return per-queue pending counts plus a total.
+
+        Shape:
+            {
+              "invite_requests": int,
+              "channel_requests": int,
+              "support_inbox": int,
+              "total": int,
+            }
+
+        Each count is the number of items needing admin attention — not a
+        full record count. invite_requests counts rows with status='pending';
+        channel_requests counts distinct rows with either telegram_status
+        or discord_status in 'pending'; support_inbox sums unread messages
+        across threads in 'new' or 'awaiting_admin'.
+        """
+        invite_requests = self._count_pending_invite_requests()
+        channel_requests = self._count_pending_channel_requests()
+        support_inbox = EmailThreadsDAO(self.connection_holder).unread_count_for_attention()
+
+        total = invite_requests + channel_requests + support_inbox
+        return {
+            "invite_requests": invite_requests,
+            "channel_requests": channel_requests,
+            "support_inbox": support_inbox,
+            "total": total,
+        }
+
+    def _count_pending_invite_requests(self) -> int:
+        response = (
+            self.client.table("invite_requests")
+            .select("id", count="exact")
+            .eq("status", "pending")
+            .execute()
+        )
+        return response.count or 0
+
+    def _count_pending_channel_requests(self) -> int:
+        """Count distinct channel-request rows with any platform pending.
+
+        A single row tracks both Telegram and Discord status, and a request
+        is "pending" if either side is in 'pending'. We count rows (not
+        platform-pending instances) so the badge mirrors the inbox tab's
+        notion of work-to-do.
+        """
+        # PostgREST `or` filter: telegram_status.eq.pending,discord_status.eq.pending
+        response = (
+            self.client.table("channel_requests")
+            .select("id", count="exact")
+            .or_("telegram_status.eq.pending,discord_status.eq.pending")
+            .execute()
+        )
+        return response.count or 0

--- a/backend/tests/unit/test_admin_attention.py
+++ b/backend/tests/unit/test_admin_attention.py
@@ -1,0 +1,140 @@
+"""Unit tests for the admin-attention badge API.
+
+Covers the aggregator endpoint + DAO summation. DAOs are mocked so we
+exercise the wiring + the `total` math without touching the DB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def admin_client():
+    """Minimal FastAPI app with the admin_attention router and
+    require_admin overridden to a stub admin user."""
+    from api import admin_attention
+    from auth import require_admin
+
+    app = FastAPI()
+    app.include_router(admin_attention.router)
+    app.dependency_overrides[require_admin] = lambda: {
+        "id": "admin-user-1", "role": "admin", "username": "admin"
+    }
+    return TestClient(app), admin_attention
+
+
+class TestAttentionCountsEndpoint:
+    def test_returns_per_queue_counts_and_total(self, admin_client):
+        client, module = admin_client
+        with patch.object(
+            module._dao, "get_counts",
+            return_value={
+                "invite_requests": 3,
+                "channel_requests": 1,
+                "support_inbox": 2,
+                "total": 6,
+            },
+        ):
+            resp = client.get("/api/admin/attention/counts")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "invite_requests": 3,
+            "channel_requests": 1,
+            "support_inbox": 2,
+            "total": 6,
+        }
+
+    def test_zero_when_no_pending_work(self, admin_client):
+        client, module = admin_client
+        with patch.object(
+            module._dao, "get_counts",
+            return_value={
+                "invite_requests": 0,
+                "channel_requests": 0,
+                "support_inbox": 0,
+                "total": 0,
+            },
+        ):
+            resp = client.get("/api/admin/attention/counts")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_requires_admin(self):
+        """Without an admin dep override, non-admins should be rejected."""
+        from api import admin_attention
+        from auth import require_admin
+
+        app = FastAPI()
+        app.include_router(admin_attention.router)
+
+        def _non_admin():
+            from fastapi import HTTPException
+            raise HTTPException(status_code=403, detail="Admin access required")
+        app.dependency_overrides[require_admin] = _non_admin
+
+        client = TestClient(app)
+        resp = client.get("/api/admin/attention/counts")
+        assert resp.status_code == 403
+
+
+class TestAdminAttentionDAO:
+    """Direct tests on the DAO's aggregation math.
+
+    Mocks the source DAO/client calls so we don't hit Supabase, then asserts
+    the `total` is the sum and each queue's count is reported separately.
+    """
+
+    def _make_dao(self):
+        from unittest.mock import MagicMock
+        from dao.admin_attention_dao import AdminAttentionDAO
+
+        # AdminAttentionDAO inherits BaseDAO and uses a SupabaseConnection.
+        # Bypass the runtime isinstance check by patching __init__ to set
+        # the connection_holder + client directly.
+        dao = AdminAttentionDAO.__new__(AdminAttentionDAO)
+        dao.connection_holder = MagicMock()
+        dao.client = MagicMock()
+        return dao
+
+    def test_total_is_sum_of_queues(self):
+        dao = self._make_dao()
+        with (
+            patch.object(dao, "_count_pending_invite_requests", return_value=3),
+            patch.object(dao, "_count_pending_channel_requests", return_value=1),
+            patch(
+                "dao.admin_attention_dao.EmailThreadsDAO"
+            ) as mock_email_threads_cls,
+        ):
+            mock_email_threads_cls.return_value.unread_count_for_attention.return_value = 2
+            result = dao.get_counts()
+
+        assert result == {
+            "invite_requests": 3,
+            "channel_requests": 1,
+            "support_inbox": 2,
+            "total": 6,
+        }
+
+    def test_all_zero_yields_zero_total(self):
+        dao = self._make_dao()
+        with (
+            patch.object(dao, "_count_pending_invite_requests", return_value=0),
+            patch.object(dao, "_count_pending_channel_requests", return_value=0),
+            patch(
+                "dao.admin_attention_dao.EmailThreadsDAO"
+            ) as mock_email_threads_cls,
+        ):
+            mock_email_threads_cls.return_value.unread_count_for_attention.return_value = 0
+            result = dao.get_counts()
+        assert result == {
+            "invite_requests": 0,
+            "channel_requests": 0,
+            "support_inbox": 0,
+            "total": 0,
+        }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -353,6 +353,17 @@
                 aria-label="Beta feature"
                 >Beta</span
               >
+              <span
+                v-if="
+                  tab.id === 'admin' &&
+                  authStore.isAdmin.value &&
+                  adminAttention.total.value > 0
+                "
+                class="admin-attention-dot"
+                data-testid="admin-attention-dot"
+                :title="adminAttention.tooltip.value"
+                :aria-label="`Needs attention: ${adminAttention.tooltip.value}`"
+              ></span>
             </button>
           </nav>
           <!-- Standings -->
@@ -487,6 +498,7 @@
 <script>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useAuthStore } from './stores/auth';
+import { useAdminAttentionCounts } from './composables/useAdminAttentionCounts';
 import { getApiBaseUrl } from './config/api';
 import { recordPageView, recordInviteRequest } from './faro';
 import MatchForm from './components/MatchForm.vue';
@@ -526,6 +538,7 @@ export default {
   },
   setup() {
     const authStore = useAuthStore();
+    const adminAttention = useAdminAttentionCounts();
     const currentTab = ref('table');
     const tableFilters = ref({
       ageGroupId: null,
@@ -851,9 +864,26 @@ export default {
       }
     );
 
+    // Start/stop admin attention-counts polling tied to admin status.
+    // When a user logs in as admin (or already-admin auth resolves on app
+    // boot), kick off the 60s poll; when they log out or lose admin
+    // role, stop. Composable handles the auth check + best-effort errors.
+    watch(
+      () => authStore.isAdmin.value,
+      isAdmin => {
+        if (isAdmin) {
+          adminAttention.startPolling();
+        } else {
+          adminAttention.stopPolling();
+        }
+      },
+      { immediate: true }
+    );
+
     // Cleanup on unmount
     onUnmounted(() => {
       stopLiveMatchPolling();
+      adminAttention.stopPolling();
     });
 
     // Handle clicking on LIVE tab
@@ -886,6 +916,7 @@ export default {
 
     return {
       authStore,
+      adminAttention,
       currentTab,
       tableFilters,
       matchesFilters,
@@ -1062,6 +1093,18 @@ export default {
   50% {
     opacity: 0.5;
   }
+}
+
+.admin-attention-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-left: 6px;
+  vertical-align: 1px;
+  background-color: #dc2626;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.18);
+  cursor: help;
 }
 
 .beta-badge {

--- a/frontend/src/__tests__/composables/useAdminAttentionCounts.spec.js
+++ b/frontend/src/__tests__/composables/useAdminAttentionCounts.spec.js
@@ -1,0 +1,133 @@
+/**
+ * useAdminAttentionCounts tests.
+ *
+ * The composable is a reactive singleton — module-level state persists
+ * across calls within a test file. Each test resets the relevant refs
+ * via fetchCounts mocked responses so we don't fight that.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fetch globally for these tests.
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+// Mock the auth store so isAdmin is controllable per test.
+const isAdminRef = { value: true };
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAdmin: isAdminRef,
+    getAuthHeaders: () => ({ Authorization: 'Bearer test' }),
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+import { useAdminAttentionCounts } from '@/composables/useAdminAttentionCounts';
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  isAdminRef.value = true;
+});
+
+describe('useAdminAttentionCounts.fetchCounts', () => {
+  it('hits /api/admin/attention/counts and exposes total + breakdown', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          invite_requests: 3,
+          channel_requests: 1,
+          support_inbox: 2,
+          total: 6,
+        }),
+    });
+
+    const inbox = useAdminAttentionCounts();
+    await inbox.fetchCounts();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://test.example/api/admin/attention/counts',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test' }),
+      })
+    );
+    expect(inbox.total.value).toBe(6);
+    expect(inbox.breakdown.value).toEqual({
+      invite_requests: 3,
+      channel_requests: 1,
+      support_inbox: 2,
+    });
+  });
+
+  it('skips the fetch and zeros total when user is not admin', async () => {
+    isAdminRef.value = false;
+    const inbox = useAdminAttentionCounts();
+    await inbox.fetchCounts();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(inbox.total.value).toBe(0);
+  });
+
+  it('keeps the prior total when the fetch fails (best-effort badge)', async () => {
+    // Seed a non-zero state via a successful call first.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          total: 5,
+          invite_requests: 5,
+          channel_requests: 0,
+          support_inbox: 0,
+        }),
+    });
+    const inbox = useAdminAttentionCounts();
+    await inbox.fetchCounts();
+    expect(inbox.total.value).toBe(5);
+
+    // Now the next call fails.
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    await inbox.fetchCounts();
+
+    // Total stays at the last good value, error is captured.
+    expect(inbox.total.value).toBe(5);
+    expect(inbox.lastError.value).toBeTruthy();
+  });
+});
+
+describe('useAdminAttentionCounts.tooltip', () => {
+  it('summarizes only the non-zero queues with correct pluralization', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          invite_requests: 1,
+          channel_requests: 0,
+          support_inbox: 4,
+          total: 5,
+        }),
+    });
+    const inbox = useAdminAttentionCounts();
+    await inbox.fetchCounts();
+    expect(inbox.tooltip.value).toBe(
+      '1 invite request · 4 unread support messages'
+    );
+  });
+
+  it('falls back to a friendly empty message when nothing is pending', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          invite_requests: 0,
+          channel_requests: 0,
+          support_inbox: 0,
+          total: 0,
+        }),
+    });
+    const inbox = useAdminAttentionCounts();
+    await inbox.fetchCounts();
+    expect(inbox.tooltip.value).toBe('No items need attention');
+  });
+});

--- a/frontend/src/composables/useAdminAttentionCounts.js
+++ b/frontend/src/composables/useAdminAttentionCounts.js
@@ -1,0 +1,108 @@
+/**
+ * useAdminAttentionCounts — powers the red dot + hover tooltip on the
+ * global top-nav "Admin" link.
+ *
+ * Reactive singleton (same pattern as useSupportInbox; not Pinia). Polls
+ * `GET /api/admin/attention/counts` every 60s while an admin is logged in.
+ * Exposes a `total` ref + a `breakdown` ref the tooltip can render.
+ */
+
+import { ref, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+
+const POLL_MS = 60_000;
+
+// ── Module-level singleton state ───────────────────────────────────────────
+
+const total = ref(0);
+const breakdown = ref({
+  invite_requests: 0,
+  channel_requests: 0,
+  support_inbox: 0,
+});
+const lastError = ref(null);
+
+let pollHandle = null;
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+export function useAdminAttentionCounts() {
+  const authStore = useAuthStore();
+  const isAdmin = computed(() => authStore.isAdmin.value);
+
+  async function fetchCounts() {
+    if (!isAdmin.value) {
+      total.value = 0;
+      return;
+    }
+    try {
+      const resp = await fetch(
+        `${getApiBaseUrl()}/api/admin/attention/counts`,
+        {
+          headers: authStore.getAuthHeaders(),
+        }
+      );
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const data = await resp.json();
+      breakdown.value = {
+        invite_requests: data.invite_requests || 0,
+        channel_requests: data.channel_requests || 0,
+        support_inbox: data.support_inbox || 0,
+      };
+      total.value = data.total || 0;
+      lastError.value = null;
+    } catch (e) {
+      // Badge is best-effort — log and leave the previous count visible.
+      console.warn('useAdminAttentionCounts: fetch failed', e);
+      lastError.value = e.message;
+    }
+  }
+
+  function startPolling() {
+    if (pollHandle) return;
+    fetchCounts();
+    pollHandle = setInterval(fetchCounts, POLL_MS);
+  }
+
+  function stopPolling() {
+    if (pollHandle) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  }
+
+  // Pluralizing helper for the tooltip — keeps the template clean.
+  const tooltip = computed(() => {
+    const parts = [];
+    const b = breakdown.value;
+    if (b.invite_requests > 0) {
+      parts.push(
+        `${b.invite_requests} invite request${b.invite_requests === 1 ? '' : 's'}`
+      );
+    }
+    if (b.channel_requests > 0) {
+      parts.push(
+        `${b.channel_requests} channel request${b.channel_requests === 1 ? '' : 's'}`
+      );
+    }
+    if (b.support_inbox > 0) {
+      parts.push(
+        `${b.support_inbox} unread support message${b.support_inbox === 1 ? '' : 's'}`
+      );
+    }
+    return parts.length ? parts.join(' · ') : 'No items need attention';
+  });
+
+  return {
+    total,
+    breakdown,
+    tooltip,
+    lastError,
+    fetchCounts,
+    startPolling,
+    stopPolling,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a red dot + hover tooltip next to the global "Admin" tab when any Access queue has pending items. Admins see "there's work to do" without first clicking into the panel.

| Source | Counted when |
|---|---|
| Invite Requests | `status = 'pending'` |
| Channel Requests | `telegram_status = 'pending'` OR `discord_status = 'pending'` (deduped per row) |
| Support Inbox | sum of `unread_count` across threads in `new` / `awaiting_admin` |
| Live Match Notifications | **not counted** — it's a per-club config surface, no pending state |

## What changed

**Backend:**
- New `backend/dao/admin_attention_dao.py` — `AdminAttentionDAO.get_counts()` decorated with `@dao_cache("admin_attention:counts", ttl=30)`. When `CACHE_ENABLED`, Redis serves repeat polls within 30s; otherwise every call hits the DB (still cheap: three count queries).
- New `backend/api/admin_attention.py` exposing `GET /api/admin/attention/counts`. Gated by `require_admin`, service-role client. Pattern mirrors `api/admin_emails.py` from SB-35 Phase 2.
- Reuses `EmailThreadsDAO.unread_count_for_attention` for the support figure.

**Frontend:**
- New composable `useAdminAttentionCounts.js` — reactive singleton (same pattern as `useSupportInbox`). Polls `/api/admin/attention/counts` every 60s while `authStore.isAdmin` is true; stops on logout, role change, or unmount.
- Exposes `total`, `breakdown`, and a pre-formatted `tooltip` (e.g., `"1 invite request · 4 unread support messages"`). Failed fetches keep the prior count visible — the badge is best-effort.
- `App.vue` wires the composable, starts/stops polling on an `isAdmin` watcher, and renders an 8×8px red dot with `title=` tooltip + `aria-label` next to "Admin" in the top nav when `total > 0`.

## Test plan

**Automated:**
- [x] 5 backend tests in `tests/unit/test_admin_attention.py` (endpoint admin-gating, response shape on pending + idle states, DAO summation math, `total=sum` invariant)
- [x] 5 frontend tests in `__tests__/composables/useAdminAttentionCounts.spec.js` (fetch shape, isAdmin gating, stale-on-failure, tooltip pluralization, empty-state copy)
- [x] Full suites green: backend **390 passed / 12 skipped**, frontend **329 passed**
- [x] `ruff check` clean, `npm run lint` clean

**Manual:**
- [ ] Local dev: log in as admin, create a pending invite request from a different account, confirm dot appears on "Admin" within 60s. Hover → tooltip reads "1 invite request".
- [ ] Approve the request; within 60s the dot disappears.
- [ ] Log out → dot gone (poll stopped).
- [ ] Log in as a non-admin role → dot never appears.

## Notes

- 30s server-side cache + 60s client-side poll means worst-case lag from "new item arrives" to "dot appears" is ~90s. Tunable — happy to drop one or both if you want faster feedback.
- If we later want Live Match Notifications to contribute (e.g., "clubs without channels configured"), it's an isolated `_count_*` method on the DAO + one more line in `get_counts`.