### PR TITLE
fix(bracket): place R16/QF/SF/Final by feeder slot, not id order

### DIFF
--- a/frontend/src/__tests__/components/TournamentBracket.spec.js
+++ b/frontend/src/__tests__/components/TournamentBracket.spec.js
@@ -14,8 +14,14 @@ import TournamentBracket from '@/components/TournamentBracket.vue';
 const mkMatch = (id, round, home, away, extra = {}) => ({
   id,
   tournament_round: round,
-  home_team: { name: home },
-  away_team: { name: away },
+  home_team:
+    typeof home === 'string'
+      ? { name: home }
+      : { name: home.name, id: home.id },
+  away_team:
+    typeof away === 'string'
+      ? { name: away }
+      : { name: away.name, id: away.id },
   match_status: 'scheduled',
   home_score: null,
   away_score: null,
@@ -63,5 +69,111 @@ describe('TournamentBracket', () => {
     await r16Btn.trigger('click');
     expect(wrapper.emitted('match-click')).toBeTruthy();
     expect(wrapper.emitted('match-click')[0][0]).toEqual(r16);
+  });
+});
+
+describe('TournamentBracket — feeder-derived slot placement', () => {
+  // Helper: find which R16 slot a match landed in by inspecting the cell
+  // wrapper's `r16-N` class. Returns N or null if the match wasn't placed.
+  const slotOf = (wrapper, roundPrefix, matchName) => {
+    const cells = wrapper.findAll(
+      `.bracket-cell.col-2, .bracket-cell.col-3, .bracket-cell.col-4, .bracket-cell.col-5`
+    );
+    for (const cell of cells) {
+      if (!cell.text().includes(matchName)) continue;
+      const cls = [...cell.element.classList];
+      const slotClass = cls.find(c => c.startsWith(`${roundPrefix}-`));
+      if (slotClass) return parseInt(slotClass.split('-')[1], 10);
+    }
+    return null;
+  };
+
+  it('places R16 match directly under its two feeder R32 cells, not in id-order', () => {
+    /**
+     * Bracket structure for this test:
+     *   R32 slot 0:  Team A (id=1) vs Team B (id=2)
+     *   R32 slot 1:  Team C (id=3) vs Team D (id=4)
+     *   R32 slot 2:  Team E (id=5) vs Team F (id=6)
+     *   R32 slot 3:  Team G (id=7) vs Team H (id=8)
+     *
+     * Real R16 match: Team E vs Team G — winners of R32 slots 2 and 3.
+     * That pair (2, 3) feeds into R16 slot 1 (floor(2/2)).
+     *
+     * But the R16 match's id is the LOWEST loaded (id=100). Old id-order
+     * placement would put it at R16 slot 0 — wrong. New feeder-derived
+     * placement puts it at slot 1.
+     */
+    const matches = [
+      mkMatch(1, 'round_of_32', { name: 'A', id: 1 }, { name: 'B', id: 2 }),
+      mkMatch(2, 'round_of_32', { name: 'C', id: 3 }, { name: 'D', id: 4 }),
+      mkMatch(3, 'round_of_32', { name: 'E', id: 5 }, { name: 'F', id: 6 }),
+      mkMatch(4, 'round_of_32', { name: 'G', id: 7 }, { name: 'H', id: 8 }),
+      mkMatch(100, 'round_of_16', { name: 'E', id: 5 }, { name: 'G', id: 7 }),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(slotOf(wrapper, 'r16', 'E')).toBe(1);
+  });
+
+  it('places multiple R16 matches at slots derived from their R32 feeders, regardless of id order', () => {
+    /**
+     * Two R16 matches whose ids are flipped relative to their bracket order:
+     *   R16 id=200 = winners of R32 slots 0+1 → should land at R16 slot 0
+     *   R16 id=100 = winners of R32 slots 2+3 → should land at R16 slot 1
+     */
+    const matches = [
+      mkMatch(1, 'round_of_32', { name: 'A', id: 1 }, { name: 'B', id: 2 }),
+      mkMatch(2, 'round_of_32', { name: 'C', id: 3 }, { name: 'D', id: 4 }),
+      mkMatch(3, 'round_of_32', { name: 'E', id: 5 }, { name: 'F', id: 6 }),
+      mkMatch(4, 'round_of_32', { name: 'G', id: 7 }, { name: 'H', id: 8 }),
+      mkMatch(200, 'round_of_16', { name: 'A', id: 1 }, { name: 'C', id: 3 }),
+      mkMatch(100, 'round_of_16', { name: 'E', id: 5 }, { name: 'G', id: 7 }),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(slotOf(wrapper, 'r16', 'A')).toBe(0);
+    expect(slotOf(wrapper, 'r16', 'E')).toBe(1);
+  });
+
+  it('cascades feeder-derived placement to QF / SF / Final', () => {
+    /**
+     * Build R32 pairs that feed into 2 R16 matches, which feed into 1 QF, etc.
+     * Verify the Final cell ends up holding the right match by feeder chain.
+     */
+    const r32 = [
+      mkMatch(1, 'round_of_32', { name: 'A', id: 1 }, { name: 'B', id: 2 }),
+      mkMatch(2, 'round_of_32', { name: 'C', id: 3 }, { name: 'D', id: 4 }),
+      mkMatch(3, 'round_of_32', { name: 'E', id: 5 }, { name: 'F', id: 6 }),
+      mkMatch(4, 'round_of_32', { name: 'G', id: 7 }, { name: 'H', id: 8 }),
+    ];
+    // A advanced (slot 0), C advanced (slot 1), E advanced (slot 2), G advanced (slot 3)
+    const r16 = [
+      mkMatch(11, 'round_of_16', { name: 'A', id: 1 }, { name: 'C', id: 3 }), // slot 0
+      mkMatch(12, 'round_of_16', { name: 'E', id: 5 }, { name: 'G', id: 7 }), // slot 1
+    ];
+    // A advanced from R16 slot 0, E advanced from R16 slot 1 → meet in QF slot 0
+    const qf = [
+      mkMatch(21, 'quarterfinal', { name: 'A', id: 1 }, { name: 'E', id: 5 }),
+    ];
+    const wrapper = mount(TournamentBracket, {
+      props: { matches: [...r32, ...r16, ...qf] },
+    });
+
+    expect(slotOf(wrapper, 'qf', 'A')).toBe(0);
+  });
+
+  it("falls back to id-order placement for matches whose teams aren't in the feeder round", () => {
+    /**
+     * R16 match whose teams never appeared in R32 (e.g. placeholder created
+     * before R32 was loaded, or off-bracket data). It still renders — just
+     * at the first available slot in id order.
+     */
+    const matches = [
+      mkMatch(1, 'round_of_32', { name: 'A', id: 1 }, { name: 'B', id: 2 }),
+      mkMatch(100, 'round_of_16', { name: 'Z', id: 99 }, { name: 'Y', id: 98 }),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(slotOf(wrapper, 'r16', 'Z')).toBe(0);
   });
 });

--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -76,28 +76,92 @@ const ROUNDS = [
   { key: 'final', label: 'Final' },
 ];
 
-// Stable display order: ascending id mirrors the source schedule order
-// (matches were loaded in that order). R32 pairs (M1+M2)→R16 #1, etc.
+// R32 ordering is the source-of-truth slot index for the rest of the bracket.
+// Ascending id mirrors the order matches were loaded into the tournament,
+// which is the order the user expects them to appear top-to-bottom.
 const r32Matches = computed(() =>
   [...props.matches]
     .filter(m => m.tournament_round === 'round_of_32')
     .sort((a, b) => a.id - b.id)
 );
 
-// Fixed-length cell list for a round: real matches (ascending id, mirroring the
-// source schedule order) padded with nulls so every bracket slot renders, even
-// before its match has been loaded/advanced.
-function roundCells(roundKey, slotCount) {
-  const ms = props.matches
-    .filter(m => m.tournament_round === roundKey)
-    .sort((a, b) => a.id - b.id);
-  return Array.from({ length: slotCount }, (_, i) => ms[i] ?? null);
+// ── Feeder-derived placement ──────────────────────────────────────────────
+// For R16 / QF / SF / Final, we don't just sort by id — we place each match
+// directly under its two feeder matches.
+//
+// In a single-elimination bracket, the pair (2k, 2k+1) of feeder slots feeds
+// into slot k of the next round. So if team A advanced from R32 slot 4 and
+// team B from R32 slot 5, the R16 match they meet in goes at R16 slot 2.
+//
+// We detect the feeder slot by looking up each team's id in the feeder
+// round's placement. Matches whose teams aren't in the feeder round (e.g.
+// placeholders before the feeder round is loaded, or off-bracket teams)
+// fall back to id-order placement in whatever slots remain.
+
+function buildFeederSlotByTeam(feederCells) {
+  const map = new Map();
+  feederCells.forEach((m, slot) => {
+    if (!m) return;
+    const homeId = m.home_team?.id;
+    const awayId = m.away_team?.id;
+    if (homeId != null) map.set(homeId, slot);
+    if (awayId != null) map.set(awayId, slot);
+  });
+  return map;
 }
 
-const r16Cells = computed(() => roundCells('round_of_16', 8));
-const qfCells = computed(() => roundCells('quarterfinal', 4));
-const sfCells = computed(() => roundCells('semifinal', 2));
-const finalCell = computed(() => roundCells('final', 1)[0]);
+function placeByFeeder(roundKey, feederCells, slotCount) {
+  const sorted = props.matches
+    .filter(m => m.tournament_round === roundKey)
+    .sort((a, b) => a.id - b.id);
+
+  const feederSlotByTeam = buildFeederSlotByTeam(feederCells);
+  const placed = Array.from({ length: slotCount }, () => null);
+  const unresolved = [];
+
+  for (const m of sorted) {
+    const feederSlots = [];
+    const homeSlot = feederSlotByTeam.get(m.home_team?.id);
+    const awaySlot = feederSlotByTeam.get(m.away_team?.id);
+    if (homeSlot != null) feederSlots.push(homeSlot);
+    if (awaySlot != null) feederSlots.push(awaySlot);
+
+    if (feederSlots.length === 0) {
+      unresolved.push(m);
+      continue;
+    }
+    const targetSlot = Math.floor(Math.min(...feederSlots) / 2);
+    if (
+      targetSlot < 0 ||
+      targetSlot >= slotCount ||
+      placed[targetSlot] != null
+    ) {
+      // Out of range, or two matches resolved to the same slot — fall back
+      // to id-order placement so neither match gets dropped.
+      unresolved.push(m);
+      continue;
+    }
+    placed[targetSlot] = m;
+  }
+
+  // Drop unresolved matches into the remaining empty slots in id order.
+  let cursor = 0;
+  for (const m of unresolved) {
+    while (cursor < slotCount && placed[cursor] != null) cursor++;
+    if (cursor >= slotCount) break;
+    placed[cursor] = m;
+  }
+  return placed;
+}
+
+const r16Cells = computed(() =>
+  placeByFeeder('round_of_16', r32Matches.value, 8)
+);
+const qfCells = computed(() =>
+  placeByFeeder('quarterfinal', r16Cells.value, 4)
+);
+const sfCells = computed(() => placeByFeeder('semifinal', qfCells.value, 2));
+const finalCell = computed(() => placeByFeeder('final', sfCells.value, 1)[0]);
 
 // ── Inline child component for match cells ──
 const BracketCell = {


### PR DESCRIPTION
## Summary

Fixes the bracket connector misalignment on the 2026 MLS NEXT Cup brackets (and any other tournament where match ids don't align with bracket positions). Round of 16, QF, SF, and Final cells are now placed under their actual feeder matches rather than at id-sorted slot positions.

## What was wrong

`TournamentBracket.vue` placed R16 cells in id order at fixed slot positions 0–7. That happens to look right when matches were inserted in bracket order — but silently breaks when match ids and bracket positions disagree. On the U14 Championship view, "ALBION SC San Diego vs Houston Rangers" landed between R32 #4 and R32 #5 instead of between R32 #5 and R32 #6 where its feeder matches actually live.

This was the known follow-up flagged in PR #390's body:
> matches are placed in id order (same convention already used for R32). The boxes display correctly; pixel-exact connector-line alignment to feeder matches (winner of r32-0 + r32-1 → r16-0) is a possible follow-up.

## How it's fixed

For each round past R32, the slot is derived from the **feeder round's placement**, not from the match's id. The pair `(2k, 2k+1)` of feeder slots feeds into slot `k` of the next round — standard single-elimination bracket. So:

- `buildFeederSlotByTeam(cells)` → `team_id → slot` map from the previous round's placement.
- `placeByFeeder(roundKey, feederCells, slotCount)` → for each match, look up its two teams' feeder slots, target slot = `floor(min(slots) / 2)`. Fall back to id-order for matches whose teams aren't in the feeder round (e.g. placeholders before the feeder round is loaded, or off-bracket teams).
- Cascade: R16 derives from R32 placement, QF from R16, SF from QF, Final from SF.

## Test plan

- [x] 4 new tests in `TournamentBracket.spec.js` covering: single R16 not in id order, multiple R16 with flipped ids, cascade through QF, fallback for off-bracket teams.
- [x] Existing 4 tests stay green (the regression guard from PR #390).
- [x] Full frontend suite: **333 passed / 0 failed** (was 329, +4 new).
- [x] `npm run lint` clean.
- [ ] Manual: open the 2026 MLS NEXT Cup U14 Championship bracket on the dev server, confirm the R16 row "ALBION SC San Diego vs Houston Rangers" now sits between R32 #5 and R32 #6 (its feeder matches) with the connectors lining up. Compare to https://www.mlssoccer.com/mlsnext/tournaments/cup/showcase/standings/ as the reference layout.

## Notes

Frontend only; no schema or API changes. The fallback-to-id-order behavior preserves the safety net so the bracket never drops a match — out-of-bracket / placeholder data still renders, just not at a feeder-derived slot.