### PR TITLE
feat(bracket): tournament_round_order for canonical bracket layout

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -70,10 +70,11 @@ Quick subcommand map:
 Look at the pasted image and pull out:
 
 - **Tournament name** (e.g. "2026 MLS Next Cup Championship") and overall **date range** if shown.
-- For each match row: **kickoff date/time**, **home team name**, **away team name**, **regulation score**, **penalty-shootout score** (if visible — usually shown as "(5–4 pens)" or similar), **age group** (U13/U14/...), **bracket round** (group stage, QF, SF, final, etc.), and the **bracket / group label**.
+- For each match row: **kickoff date/time**, **home team name**, **away team name**, **regulation score**, **penalty-shootout score** (if visible — usually shown as "(5–4 pens)" or similar), **age group** (U13/U14/...), **bracket round** (group stage, QF, SF, final, etc.), the **bracket / group label**, and the **bracket position** (top-to-bottom).
   - **Bracket name is mandatory for bracket-round matches** (`round_of_32`/`round_of_16`/`quarterfinal`/`semifinal`/`final`/`third_place`). MLS Next Cup, for example, has a **Championship** bracket and a **Premier** bracket — and the bracket name lives in the same field as group-stage labels (`tournament_group`). The frontend bracket UI filters strictly on this value: a bracket-round match with no `tournament_group` is invisible in the bracket view, even if all the team data is correct.
   - Source clues: the screenshot's heading ("MLS NEXT Cup Championship 2026" → `Championship`), tab/pill above the bracket ("Premier" / "Silver" / "Bronze"), or the URL slug on the source page (`/championship/u15`). If the screenshot only shows the bracket sub-section without naming it, **ask the user which bracket this is** before creating matches — don't guess.
   - For group-stage matches the same field holds the group letter ("A", "B", "C", ...). The convention is one of: a bracket name, a group letter, or `null` for ungrouped one-off rounds.
+  - **Bracket position (`tournament_round_order`) is mandatory for bracket-round matches.** This is the 0-based top-to-bottom index of the match within its round on the source bracket. Top of the bracket = 0; immediately below = 1; etc. Without this field set, the frontend falls back to `id`-order — which only happens to match the canonical layout when matches were loaded in bracket order. If they weren't (e.g. you re-load some matches later, or rounds were loaded out of order), the bracket connectors point at the wrong feeder matches even though the data is otherwise correct. Read the position straight off the screenshot — the order in which match cells appear top-to-bottom on the source bracket is the position you set. Standard pairing convention: R32 slots `(2k, 2k+1)` feed into R16 slot `k`, etc.
 - For each unique team that appears: an approximate **logo bounding box** (`x,y,width,height` in pixels) you can extract from the screenshot.
 
 Show the user a tight summary table of what you found and **ask them to confirm before doing any writes**. This is the single biggest moment to catch parsing errors.
@@ -187,7 +188,10 @@ For each screenshot row, classify it and act per this table:
 
 Build the create-list and update-list, show the user a short plan ("N to create, M to score, K already correct, J conflicts to review"), and proceed once confirmed.
 
-**Bracket-group sanity check (mandatory).** Before sending any creates/updates for bracket-round matches, scan the planned writes for any row where `tournament_round` is in (`round_of_32`/`round_of_16`/`quarterfinal`/`semifinal`/`final`/`third_place`) but `tournament_group` is null/empty. **If any are found, stop and ask the user** which bracket those matches belong to (Championship / Premier / Silver / Bronze / etc.). Apply the answer to every such row before writing. This is the guardrail that prevents loading bracket matches that look fine in the match list but render as empty cells in the bracket UI — the frontend filter is `m.tournament_group === selectedGroup`, so a null group is invisible.
+**Bracket sanity checks (mandatory).** Before sending any creates/updates for bracket-round matches, scan the planned writes:
+
+1. **`tournament_group`** — any row where `tournament_round` is in (`round_of_32`/`round_of_16`/`quarterfinal`/`semifinal`/`final`/`third_place`) but `tournament_group` is null/empty. If any are found, stop and ask the user which bracket those matches belong to (Championship / Premier / Silver / Bronze / etc.) and apply the answer to every such row. Frontend filter is `m.tournament_group === selectedGroup`, so a null group renders as invisible.
+2. **`tournament_round_order`** — any bracket-round row without an explicit position. If you can read positions off the screenshot, set them yourself (0-based top to bottom within the round + bracket). If the screenshot is ambiguous or you only loaded a partial round, stop and confirm with the user. Frontend falls back to `id`-order without this, which produces the wrong layout when ids don't match canonical bracket order.
 
 ### Step 6 — create or update each match
 
@@ -207,6 +211,7 @@ cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt
   [--match-status completed|scheduled|in_progress] \
   [--tournament-round group_stage|round_of_32|round_of_16|quarterfinal|semifinal|final|third_place|wildcard|silver_semifinal|bronze_semifinal|silver_final|bronze_final] \
   [--tournament-group "A" | "Championship" | "Premier" | ...]   # group letter for group_stage, bracket name for everything else; required for bracket rounds \
+  [--tournament-round-order N]   # 0-based top-to-bottom slot within the round; required for bracket rounds (R32 0..15, R16 0..7, QF 0..3, SF 0..1, Final 0) \
   [--scheduled-kickoff "2026-06-21T15:00:00Z"]
 ```
 

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -444,6 +444,11 @@ def match_create(
     match_status: str = typer.Option("scheduled", "--match-status"),
     tournament_group: str | None = typer.Option(None, "--tournament-group"),
     tournament_round: str | None = typer.Option(None, "--tournament-round"),
+    tournament_round_order: int | None = typer.Option(
+        None,
+        "--tournament-round-order",
+        help="Bracket position within the round (0-based, top of bracket = 0). Required for bracket-round matches if you want the bracket UI to render in the canonical order.",
+    ),
     scheduled_kickoff: str | None = typer.Option(None, "--scheduled-kickoff"),
 ) -> None:
     """Add a match to a tournament. our_team_id is one of our tracked teams; opponent_name is the visitor."""
@@ -463,6 +468,7 @@ def match_create(
         match_status=match_status,
         tournament_group=tournament_group,
         tournament_round=tournament_round,
+        tournament_round_order=tournament_round_order,
         scheduled_kickoff=scheduled_kickoff,
     )
     with _client() as c:
@@ -483,6 +489,11 @@ def match_update(
     match_status: str | None = typer.Option(None, "--match-status"),
     tournament_group: str | None = typer.Option(None, "--tournament-group"),
     tournament_round: str | None = typer.Option(None, "--tournament-round"),
+    tournament_round_order: int | None = typer.Option(
+        None,
+        "--tournament-round-order",
+        help="Bracket position within the round (0-based, top of bracket = 0).",
+    ),
     scheduled_kickoff: str | None = typer.Option(None, "--scheduled-kickoff"),
     match_date: str | None = typer.Option(None, "--match-date"),
     swap_home_away: bool = typer.Option(False, "--swap-home-away", help="Swap which team is home/away."),
@@ -503,6 +514,7 @@ def match_update(
         match_status=match_status,
         tournament_group=tournament_group,
         tournament_round=tournament_round,
+        tournament_round_order=tournament_round_order,
         scheduled_kickoff=scheduled_kickoff,
         match_date=match_date,
         swap_home_away=swap_home_away,

--- a/backend/api_client/models.py
+++ b/backend/api_client/models.py
@@ -131,6 +131,7 @@ class TournamentMatchCreate(BaseModel):
     match_status: str = Field("scheduled", title="Match Status")
     tournament_group: str | None = Field(None, title="Tournament Group")
     tournament_round: str | None = Field(None, title="Tournament Round")
+    tournament_round_order: int | None = Field(None, title="Tournament Round Order")
     scheduled_kickoff: str | None = Field(None, title="Scheduled Kickoff")
 
 
@@ -149,6 +150,7 @@ class TournamentMatchUpdate(BaseModel):
     match_status: str | None = Field(None, title="Match Status")
     tournament_group: str | None = Field(None, title="Tournament Group")
     tournament_round: str | None = Field(None, title="Tournament Round")
+    tournament_round_order: int | None = Field(None, title="Tournament Round Order")
     scheduled_kickoff: str | None = Field(None, title="Scheduled Kickoff")
     match_date: str | None = Field(None, title="Match Date")
     swap_home_away: bool = Field(False, title="Swap Home Away")

--- a/backend/app.py
+++ b/backend/app.py
@@ -6454,6 +6454,7 @@ class TournamentMatchCreate(BaseModel):
     match_status: str = "scheduled"
     tournament_group: str | None = None
     tournament_round: str | None = None
+    tournament_round_order: int | None = None
     scheduled_kickoff: str | None = None
 
 
@@ -6465,6 +6466,7 @@ class TournamentMatchUpdate(BaseModel):
     match_status: str | None = None
     tournament_group: str | None = None
     tournament_round: str | None = None
+    tournament_round_order: int | None = None
     scheduled_kickoff: str | None = None
     match_date: str | None = None
     swap_home_away: bool = False
@@ -6603,6 +6605,7 @@ async def admin_create_tournament_match(
             match_status=payload.match_status,
             tournament_group=payload.tournament_group,
             tournament_round=payload.tournament_round,
+            tournament_round_order=payload.tournament_round_order,
             scheduled_kickoff=payload.scheduled_kickoff,
         )
     except ValueError as e:
@@ -6629,6 +6632,7 @@ async def admin_update_tournament_match(
             match_status=payload.match_status,
             tournament_group=payload.tournament_group,
             tournament_round=payload.tournament_round,
+            tournament_round_order=payload.tournament_round_order,
             scheduled_kickoff=payload.scheduled_kickoff,
             match_date=payload.match_date,
             swap_home_away=payload.swap_home_away,

--- a/backend/dao/tournament_dao.py
+++ b/backend/dao/tournament_dao.py
@@ -165,6 +165,7 @@ class TournamentDAO(BaseDAO):
                     away_penalty_score,
                     tournament_group,
                     tournament_round,
+                    tournament_round_order,
                     age_group:age_groups!matches_age_group_id_fkey(id, name),
                     home_team:teams!matches_home_team_id_fkey(id, name),
                     away_team:teams!matches_away_team_id_fkey(id, name)
@@ -404,6 +405,7 @@ class TournamentDAO(BaseDAO):
         match_status: str = "scheduled",
         tournament_group: str | None = None,
         tournament_round: str | None = None,
+        tournament_round_order: int | None = None,
         scheduled_kickoff: str | None = None,
     ) -> dict:
         """Create a match linked to a tournament.
@@ -461,6 +463,8 @@ class TournamentDAO(BaseDAO):
             data["tournament_group"] = tournament_group
         if tournament_round:
             data["tournament_round"] = tournament_round
+        if tournament_round_order is not None:
+            data["tournament_round_order"] = tournament_round_order
         if scheduled_kickoff:
             data["scheduled_kickoff"] = scheduled_kickoff
 
@@ -492,6 +496,7 @@ class TournamentDAO(BaseDAO):
         match_status: str | None = None,
         tournament_group: str | None = None,
         tournament_round: str | None = None,
+        tournament_round_order: int | None = None,
         scheduled_kickoff: str | None = None,
         match_date: str | None = None,
         swap_home_away: bool = False,
@@ -515,6 +520,8 @@ class TournamentDAO(BaseDAO):
             updates["tournament_group"] = tournament_group
         if tournament_round is not None:
             updates["tournament_round"] = tournament_round
+        if tournament_round_order is not None:
+            updates["tournament_round_order"] = tournament_round_order
         if scheduled_kickoff is not None:
             updates["scheduled_kickoff"] = scheduled_kickoff
         if match_date is not None:

--- a/frontend/src/__tests__/components/TournamentBracket.spec.js
+++ b/frontend/src/__tests__/components/TournamentBracket.spec.js
@@ -177,3 +177,135 @@ describe('TournamentBracket — feeder-derived slot placement', () => {
     expect(slotOf(wrapper, 'r16', 'Z')).toBe(0);
   });
 });
+
+describe('TournamentBracket — tournament_round_order placement', () => {
+  // Same helper as above, copied for locality.
+  const slotOf = (wrapper, roundPrefix, matchName) => {
+    const cells = wrapper.findAll('.bracket-cell');
+    for (const cell of cells) {
+      if (!cell.text().includes(matchName)) continue;
+      const cls = [...cell.element.classList];
+      const slotClass = cls.find(c => c.startsWith(`${roundPrefix}-`));
+      if (slotClass) return parseInt(slotClass.split('-')[1], 10);
+    }
+    return null;
+  };
+
+  it('places R32 matches at their explicit tournament_round_order, ignoring id', () => {
+    /**
+     * Match ids are inserted out of canonical order (e.g. an MLS NEXT Cup
+     * R32 that was loaded later). tournament_round_order is the source of
+     * truth.
+     */
+    const matches = [
+      // id=300 but should go at slot 0 (top of bracket)
+      mkMatch(300, 'round_of_32', 'Top of bracket', 'Opponent A', {
+        tournament_round_order: 0,
+      }),
+      // id=100 but should go at slot 5
+      mkMatch(100, 'round_of_32', 'Middle bracket', 'Opponent B', {
+        tournament_round_order: 5,
+      }),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(slotOf(wrapper, 'r32', 'Top of bracket')).toBe(0);
+    expect(slotOf(wrapper, 'r32', 'Middle bracket')).toBe(5);
+  });
+
+  it('explicit tournament_round_order on R16 wins over feeder-derived slot', () => {
+    /**
+     * Feeder math would put PDA vs IFA at slot floor(min(4, 15)/2) = 2,
+     * but the data says it lives at slot 3 (e.g. non-standard bracket
+     * pairing). Explicit field wins.
+     */
+    const matches = [
+      mkMatch(
+        1,
+        'round_of_32',
+        { name: 'A', id: 1 },
+        { name: 'B', id: 2 },
+        { tournament_round_order: 0 }
+      ),
+      mkMatch(
+        2,
+        'round_of_32',
+        { name: 'C', id: 3 },
+        { name: 'D', id: 4 },
+        { tournament_round_order: 1 }
+      ),
+      mkMatch(
+        3,
+        'round_of_32',
+        { name: 'E', id: 5 },
+        { name: 'F', id: 6 },
+        { tournament_round_order: 2 }
+      ),
+      mkMatch(
+        4,
+        'round_of_32',
+        { name: 'G', id: 7 },
+        { name: 'H', id: 8 },
+        { tournament_round_order: 3 }
+      ),
+      mkMatch(
+        5,
+        'round_of_32',
+        { name: 'I', id: 9 },
+        { name: 'J', id: 10 },
+        { tournament_round_order: 4 }
+      ),
+      mkMatch(
+        6,
+        'round_of_32',
+        { name: 'PDA team', id: 11 },
+        { name: 'X', id: 12 },
+        { tournament_round_order: 5 }
+      ),
+      mkMatch(
+        7,
+        'round_of_32',
+        { name: 'IFA team', id: 13 },
+        { name: 'Y', id: 14 },
+        { tournament_round_order: 15 }
+      ),
+      mkMatch(
+        50,
+        'round_of_16',
+        { name: 'PDA team', id: 11 },
+        { name: 'IFA team', id: 13 },
+        { tournament_round_order: 3 }
+      ),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(slotOf(wrapper, 'r16', 'PDA team')).toBe(3);
+  });
+
+  it('mixes explicit order on some matches with feeder/id-order on others', () => {
+    /**
+     * Match A has explicit order=4, match B has no order — explicit takes
+     * the named slot, B falls back to the next available slot in id order.
+     */
+    const matches = [
+      mkMatch(
+        1,
+        'round_of_32',
+        { name: 'A', id: 1 },
+        { name: 'B', id: 2 },
+        { tournament_round_order: 4 }
+      ),
+      mkMatch(2, 'round_of_32', { name: 'C', id: 3 }, { name: 'D', id: 4 }),
+    ];
+    const wrapper = mount(TournamentBracket, { props: { matches } });
+
+    expect(slotOf(wrapper, 'r32', 'A')).toBe(4);
+    // Match without explicit order takes the first empty slot (0).
+    expect(slotOf(wrapper, 'r32', 'C')).toBe(0);
+  });
+
+  it('empty-state still shows when there are no R32 matches at all', () => {
+    const wrapper = mount(TournamentBracket, { props: { matches: [] } });
+    expect(wrapper.text()).toContain('No matches in this bracket yet');
+  });
+});

--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- No matches in this bracket -->
-    <div v-if="r32Matches.length === 0" class="text-center py-10 text-gray-500">
+    <div v-if="!hasAnyR32" class="text-center py-10 text-gray-500">
       No matches in this bracket yet.
     </div>
 
@@ -19,7 +19,7 @@
         <!-- R32 cells (16) -->
         <div
           v-for="(m, idx) in r32Matches"
-          :key="`r32-${m.id}`"
+          :key="`r32-${idx}`"
           :class="['bracket-cell', `col-1`, `r32-${idx}`]"
         >
           <BracketCell :match="m" @click="$emit('match-click', m)" />
@@ -76,14 +76,55 @@ const ROUNDS = [
   { key: 'final', label: 'Final' },
 ];
 
-// R32 ordering is the source-of-truth slot index for the rest of the bracket.
-// Ascending id mirrors the order matches were loaded into the tournament,
-// which is the order the user expects them to appear top-to-bottom.
-const r32Matches = computed(() =>
-  [...props.matches]
-    .filter(m => m.tournament_round === 'round_of_32')
-    .sort((a, b) => a.id - b.id)
-);
+// `tournament_round_order` is the explicit bracket-position field (0-based,
+// top of bracket = 0). When present, the match goes at that slot directly.
+// When absent, the match is placed via the per-round fallback chain below:
+//   R32: id-order
+//   R16 / QF / SF / Final: feeder-derived (pair (2k, 2k+1) → slot k), then id-order
+//
+// The mlssoccer.com canonical layout doesn't always match the order matches
+// were inserted into the DB, so id-order alone produces misaligned
+// brackets — tournament_round_order is the proper fix.
+
+// Place matches into a fixed-size slot array. Explicit tournament_round_order
+// wins; collisions and unordered matches drop into `unresolved` for the
+// caller's secondary placement strategy (feeder-derived or id-order).
+function placeWithExplicitOrder(matches, slotCount) {
+  const placed = Array.from({ length: slotCount }, () => null);
+  const unresolved = [];
+  for (const m of matches) {
+    const slot = m.tournament_round_order;
+    if (slot == null || slot < 0 || slot >= slotCount || placed[slot] != null) {
+      unresolved.push(m);
+      continue;
+    }
+    placed[slot] = m;
+  }
+  return { placed, unresolved };
+}
+
+// Drop unresolved matches into remaining empty slots in id order.
+function fillRemainingByIdOrder(placed, unresolved, slotCount) {
+  const remaining = [...unresolved].sort((a, b) => a.id - b.id);
+  let cursor = 0;
+  for (const m of remaining) {
+    while (cursor < slotCount && placed[cursor] != null) cursor++;
+    if (cursor >= slotCount) break;
+    placed[cursor] = m;
+  }
+  return placed;
+}
+
+// R32 has no feeder round — only explicit-order and id-order placement.
+const r32Matches = computed(() => {
+  const matches = props.matches.filter(
+    m => m.tournament_round === 'round_of_32'
+  );
+  const { placed, unresolved } = placeWithExplicitOrder(matches, 16);
+  return fillRemainingByIdOrder(placed, unresolved, 16);
+});
+
+const hasAnyR32 = computed(() => r32Matches.value.some(m => m != null));
 
 // ── Feeder-derived placement ──────────────────────────────────────────────
 // For R16 / QF / SF / Final, we don't just sort by id — we place each match
@@ -111,15 +152,18 @@ function buildFeederSlotByTeam(feederCells) {
 }
 
 function placeByFeeder(roundKey, feederCells, slotCount) {
-  const sorted = props.matches
-    .filter(m => m.tournament_round === roundKey)
-    .sort((a, b) => a.id - b.id);
+  const matches = props.matches.filter(m => m.tournament_round === roundKey);
 
+  // Pass 1: respect explicit tournament_round_order.
+  const { placed, unresolved: needFeederOrId } = placeWithExplicitOrder(
+    matches,
+    slotCount
+  );
+
+  // Pass 2: for the remainder, derive slot from the two teams' feeder slots.
   const feederSlotByTeam = buildFeederSlotByTeam(feederCells);
-  const placed = Array.from({ length: slotCount }, () => null);
-  const unresolved = [];
-
-  for (const m of sorted) {
+  const stillUnresolved = [];
+  for (const m of needFeederOrId) {
     const feederSlots = [];
     const homeSlot = feederSlotByTeam.get(m.home_team?.id);
     const awaySlot = feederSlotByTeam.get(m.away_team?.id);
@@ -127,7 +171,7 @@ function placeByFeeder(roundKey, feederCells, slotCount) {
     if (awaySlot != null) feederSlots.push(awaySlot);
 
     if (feederSlots.length === 0) {
-      unresolved.push(m);
+      stillUnresolved.push(m);
       continue;
     }
     const targetSlot = Math.floor(Math.min(...feederSlots) / 2);
@@ -136,22 +180,14 @@ function placeByFeeder(roundKey, feederCells, slotCount) {
       targetSlot >= slotCount ||
       placed[targetSlot] != null
     ) {
-      // Out of range, or two matches resolved to the same slot — fall back
-      // to id-order placement so neither match gets dropped.
-      unresolved.push(m);
+      stillUnresolved.push(m);
       continue;
     }
     placed[targetSlot] = m;
   }
 
-  // Drop unresolved matches into the remaining empty slots in id order.
-  let cursor = 0;
-  for (const m of unresolved) {
-    while (cursor < slotCount && placed[cursor] != null) cursor++;
-    if (cursor >= slotCount) break;
-    placed[cursor] = m;
-  }
-  return placed;
+  // Pass 3: id-order fallback for anything that didn't fit.
+  return fillRemainingByIdOrder(placed, stillUnresolved, slotCount);
 }
 
 const r16Cells = computed(() =>

--- a/supabase-local/migrations/20260525000000_add_tournament_round_order.sql
+++ b/supabase-local/migrations/20260525000000_add_tournament_round_order.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- Migration: add tournament_round_order to matches
+-- =============================================================================
+-- Bracket cells in MT are placed in a vertical column. When matches are
+-- loaded into the DB in an order that doesn't match the canonical bracket
+-- top-to-bottom layout, sorting by `id` gives the wrong vertical positions
+-- and the connector lines from R32 -> R16 -> QF -> SF -> Final point at
+-- the wrong feeders.
+--
+-- `tournament_round_order` is the explicit bracket-position field. 0-based,
+-- top of the bracket = 0. Frontend prefers this when present and falls
+-- back to id when null, so older tournaments still render correctly.
+-- =============================================================================
+
+ALTER TABLE public.matches
+    ADD COLUMN IF NOT EXISTS tournament_round_order INTEGER;
+
+COMMENT ON COLUMN public.matches.tournament_round_order IS
+    'Bracket position within a tournament round (0-based; top of bracket = 0). Used for stable bracket-display ordering when match ids do not match the canonical bracket order. Null is fine — frontend falls back to id-order for legacy rows.';
+
+-- Partial index: only tournament matches need fast slot lookup, and only
+-- when the field is set. Keeps the index small.
+CREATE INDEX IF NOT EXISTS idx_matches_tournament_round_order
+    ON public.matches (tournament_id, tournament_round, tournament_round_order)
+    WHERE tournament_id IS NOT NULL AND tournament_round_order IS NOT NULL;


### PR DESCRIPTION
## Summary

Fixes the R32-ordering bug you saw on U15 — where the R16-feeder fix from #396 was correct in logic but couldn't help because the R32 column itself was sorted by `id`, not bracket position. Adds an explicit bracket-position field (`tournament_round_order`) that the frontend honors above everything else, with id-order as a fallback so legacy tournaments still render.

## Why id-order isn't enough

MT renders the bracket as a vertical column sorted by `matches.id`. That works when matches were inserted in canonical bracket order — but ids and bracket positions diverge whenever:

- Matches are loaded in a different order than they appear on the source bracket (e.g. mlssoccer.com → top to bottom doesn't match insert order).
- A round is re-loaded later (new ids ≫ existing ids, even though the new matches are at the top of the bracket).
- An R32 match is updated after teams were finalized but loaded after R16 placeholders.

Result on U15 Championship: every match was present and the feeder-derived R16/QF/SF/Final fix from #396 worked correctly, but the R32 column was visually reordered relative to mlssoccer.com.

## What changed

**Schema** (`supabase-local/migrations/20260525000000_add_tournament_round_order.sql`)
- `matches.tournament_round_order INTEGER` (nullable) + partial index on `(tournament_id, tournament_round, tournament_round_order)`.
- Additive, `IF NOT EXISTS` guards so re-running is a no-op.

**Backend**
- `TournamentDAO.create_tournament_match` / `update_tournament_match` accept `tournament_round_order`.
- DAO's tournament-detail `SELECT` surfaces the column.
- `TournamentMatchCreate` / `TournamentMatchUpdate` pydantic models in both `app.py` and `api_client/models.py` carry the field.
- `POST` + `PUT /api/admin/tournaments/{id}/matches` pass it through.

**Skill + CLI**
- `mt.py` gains `--tournament-round-order N` on `match create` and `match update`.
- `SKILL.md`: bracket position is now mandatory for bracket-round matches alongside `tournament_group`. Step 5's pre-write sanity check stops if any bracket row is missing the field.

**Frontend** (`TournamentBracket.vue`)
- 3-pass placement per round:
  1. Honor explicit `tournament_round_order` — wins over everything else.
  2. For R16/QF/SF/Final, derive slot from feeder pair (existing behavior from #396).
  3. id-order fallback so no match is ever dropped.
- R32 skips step 2 (no feeder round). All cells render even when slot is null.

## Test plan

- [x] **Frontend**: 12 / 12 bracket spec cases pass — 4 existing + 4 feeder-derived (#396) + 4 new explicit-order
- [x] **Backend**: 390 / 390 unit tests pass; `ruff check` clean
- [x] **Lint**: `npm run lint` clean
- [ ] **Manual**: after rollout (see below), open U15 Championship on missingtable.com and confirm the R32 column matches the mlssoccer.com top-to-bottom order; R16 cells line up against their correct feeder pairs.

## Rollout — order matters

Because Postgres rejects writes for unknown columns, the migration must land before any code path tries to write `tournament_round_order`. The backend treats the field as optional, so a stale schema only breaks writes that explicitly include it.

1. **Merge this PR** → CI builds image → ArgoCD deploys backend + frontend.
2. **Apply migration on prod** via Supabase Studio SQL editor (SB-37 workaround — `supabase db push --linked` is still broken):
   ```sql
   ALTER TABLE public.matches
     ADD COLUMN IF NOT EXISTS tournament_round_order INTEGER;
   CREATE INDEX IF NOT EXISTS idx_matches_tournament_round_order
     ON public.matches (tournament_id, tournament_round, tournament_round_order)
     WHERE tournament_id IS NOT NULL AND tournament_round_order IS NOT NULL;
   ```
   Then sync the migration tracker:
   ```bash
   cd supabase-local && npx supabase migration repair --status applied 20260525000000 --linked
   ```
3. **Backfill U15 (next session)**: I'll run 24 `mt.py match update` calls (16 R32 + 8 R16) with the canonical mlssoccer order I extracted from your screenshots. One-shot prod write, not part of this PR.

## Notes

- Local dev: `npx supabase db reset` will pick up the migration automatically, or you can run the SQL block above against your local DB.
- The field is nullable; older tournaments stay rendered via the id-order fallback. No backfill of pre-existing data is required for the bracket UI to work.