### PR TITLE
feat(tournaments): optional logo (header + IG share cards)

### DIFF
--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -581,5 +581,24 @@ def logo_upload(
             _err_exit("failed to upload club logo", exc)
 
 
+@tournament_app.command("logo-upload")
+def tournament_logo_upload(
+    tournament_id: int = typer.Option(..., "--tournament-id"),
+    path: str = typer.Option(..., "--path"),
+) -> None:
+    """Upload a PNG/JPG (≤2MB) as a tournament's logo. Admin only.
+
+    Shown on the public tournament page header and on IG share cards for
+    matches in this tournament. Mirrors the club logo upload flow — the
+    backend generates `_sm` (64px) and `_md` (128px) variants for PNGs
+    automatically.
+    """
+    with _client() as c:
+        try:
+            _out(c.upload_tournament_logo(tournament_id=tournament_id, file_path=path))
+        except APIError as exc:
+            _err_exit("failed to upload tournament logo", exc)
+
+
 if __name__ == "__main__":
     app()

--- a/backend/api_client/client.py
+++ b/backend/api_client/client.py
@@ -1099,6 +1099,16 @@ class MissingTableClient:
             )
         return response.json()
 
+    def upload_tournament_logo(self, tournament_id: int, file_path: str) -> dict[str, Any]:
+        """Upload a tournament logo (multipart). Admin only."""
+        with open(file_path, "rb") as f:
+            response = self._request_multipart(
+                "POST",
+                f"/api/admin/tournaments/{tournament_id}/logo",
+                files={"file": (file_path.split("/")[-1], f)},
+            )
+        return response.json()
+
     # Player stats
 
     def get_my_player_stats(self, season_id: int | None = None) -> dict[str, Any]:

--- a/backend/app.py
+++ b/backend/app.py
@@ -6582,6 +6582,81 @@ async def admin_delete_tournament(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+@app.post("/api/admin/tournaments/{tournament_id}/logo")
+async def admin_upload_tournament_logo(
+    tournament_id: int,
+    file: UploadFile = File(...),
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    """Upload a logo image for a tournament (admin only).
+
+    Mirrors the club-logo flow: PNG/JPG, 2MB max, uploaded to Supabase
+    Storage `tournament-logos` bucket. PNGs also get 64px/128px size
+    variants so the IG share cards can pull a small render without
+    downsampling the full asset at render time.
+    """
+    allowed_types = ["image/png", "image/jpeg", "image/jpg"]
+    if file.content_type not in allowed_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid file type. Allowed types: PNG, JPG. Got: {file.content_type}",
+        )
+
+    content = await file.read()
+    max_size = 2 * 1024 * 1024  # 2MB
+    if len(content) > max_size:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File too large. Maximum size is 2MB. Got: {len(content) / 1024 / 1024:.2f}MB",
+        )
+
+    ext = "png" if file.content_type == "image/png" else "jpg"
+    file_path = f"{tournament_id}.{ext}"
+
+    try:
+        storage = match_dao.client.storage
+
+        storage.from_("tournament-logos").upload(
+            file_path, content, file_options={"content-type": file.content_type, "upsert": "true"}
+        )
+
+        # Size variants — only for PNGs, same as club logos.
+        if ext == "png":
+            from io import BytesIO
+
+            from PIL import Image as PILImage
+
+            base_img = PILImage.open(BytesIO(content))
+            for suffix, px in [("_sm", 64), ("_md", 128)]:
+                variant = base_img.resize((px, px), PILImage.LANCZOS)
+                buf = BytesIO()
+                variant.save(buf, "PNG")
+                variant_path = f"{tournament_id}{suffix}.png"
+                storage.from_("tournament-logos").upload(
+                    variant_path,
+                    buf.getvalue(),
+                    file_options={"content-type": "image/png", "upsert": "true"},
+                )
+            logger.info(f"Uploaded size variants for tournament {tournament_id}")
+
+        public_url = storage.from_("tournament-logos").get_public_url(file_path)
+
+        updated = tournament_dao.update_tournament(
+            tournament_id=tournament_id, logo_url=public_url
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail=f"Tournament with id {tournament_id} not found")
+
+        logger.info(f"Uploaded logo for tournament {tournament_id}: {public_url}")
+        return {"logo_url": public_url, "tournament": updated}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error uploading tournament logo: {e!s}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to upload logo: {e!s}") from e
+
+
 @app.post("/api/admin/tournaments/{tournament_id}/matches", status_code=201)
 async def admin_create_tournament_match(
     tournament_id: int,

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -986,7 +986,7 @@ class MatchDAO(BaseDAO):
                     age_group:age_groups(id, name),
                     match_type:match_types(id, name),
                     division:divisions(id, name, leagues(id, name, sport_type)),
-                    tournament:tournaments(id, name)
+                    tournament:tournaments(id, name, logo_url)
                 """)
                 .eq("id", match_id)
                 .execute()
@@ -1044,6 +1044,7 @@ class MatchDAO(BaseDAO):
                     "division": match.get("division"),  # Include full division object with leagues
                     "tournament_id": match.get("tournament_id"),
                     "tournament_name": tournament["name"] if tournament else None,
+                    "tournament_logo_url": tournament.get("logo_url") if tournament else None,
                     "tournament_group": match.get("tournament_group"),
                     "tournament_round": match.get("tournament_round"),
                     "sport_type": sport_type,

--- a/backend/dao/tournament_dao.py
+++ b/backend/dao/tournament_dao.py
@@ -104,7 +104,7 @@ class TournamentDAO(BaseDAO):
         try:
             response = (
                 self.client.table("tournaments")
-                .select("id, name, start_date, end_date, location, description, is_active")
+                .select("id, name, start_date, end_date, location, description, is_active, logo_url")
                 .eq("is_active", True)
                 .order("start_date", desc=True)
                 .execute()
@@ -121,7 +121,7 @@ class TournamentDAO(BaseDAO):
         try:
             response = (
                 self.client.table("tournaments")
-                .select("id, name, start_date, end_date, location, description, is_active")
+                .select("id, name, start_date, end_date, location, description, is_active, logo_url")
                 .order("start_date", desc=True)
                 .execute()
             )
@@ -141,7 +141,7 @@ class TournamentDAO(BaseDAO):
         try:
             t_response = (
                 self.client.table("tournaments")
-                .select("id, name, start_date, end_date, location, description, is_active")
+                .select("id, name, start_date, end_date, location, description, is_active, logo_url")
                 .eq("id", tournament_id)
                 .single()
                 .execute()
@@ -244,6 +244,7 @@ class TournamentDAO(BaseDAO):
         description: str | None = None,
         age_group_ids: list[int] | None = None,
         is_active: bool | None = None,
+        logo_url: str | None = None,
     ) -> dict | None:
         """Update tournament fields. Only provided (non-None) fields are changed.
 
@@ -262,6 +263,8 @@ class TournamentDAO(BaseDAO):
             updates["description"] = description
         if is_active is not None:
             updates["is_active"] = is_active
+        if logo_url is not None:
+            updates["logo_url"] = logo_url
 
         try:
             if updates:

--- a/frontend/src/__tests__/components/IgShareTemplates.spec.js
+++ b/frontend/src/__tests__/components/IgShareTemplates.spec.js
@@ -271,3 +271,40 @@ describe('IgStadium template', () => {
     expect(wrapper.find('[data-testid="ig-status"]').text()).toBe('FINAL');
   });
 });
+
+describe('tournament logo (all templates)', () => {
+  // The four templates each render a tournament logo at the top of the
+  // card when match.tournament_logo_url is set. When absent, the slot is
+  // omitted entirely so non-tournament matches don't get an empty box.
+  const LOGO_URL = 'https://example.com/logos/nac.png';
+
+  for (const template of ['overlay', 'split', 'tournament-round', 'stadium']) {
+    it(`renders the tournament logo on ${template} when tournament_logo_url is set`, () => {
+      const wrapper = mountCard(template, {
+        match: createMockMatch({
+          tournament_logo_url: LOGO_URL,
+          tournament_name:
+            template === 'tournament-round' ? 'NAC Championships' : null,
+          tournament_round: template === 'tournament-round' ? 'final' : null,
+        }),
+      });
+      const img = wrapper.find('[data-testid="ig-tournament-logo"]');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe(LOGO_URL);
+    });
+
+    it(`omits the logo slot on ${template} when tournament_logo_url is absent`, () => {
+      const wrapper = mountCard(template, {
+        match: createMockMatch({
+          tournament_logo_url: null,
+          tournament_name:
+            template === 'tournament-round' ? 'NAC Championships' : null,
+          tournament_round: template === 'tournament-round' ? 'final' : null,
+        }),
+      });
+      expect(wrapper.find('[data-testid="ig-tournament-logo"]').exists()).toBe(
+        false
+      );
+    });
+  }
+});

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -96,31 +96,45 @@
           class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6"
         >
           <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <h2 class="text-2xl font-bold text-gray-900">
-                {{ selected.name }}
-              </h2>
-              <div
-                class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500"
-              >
-                <span v-if="selected.start_date">
-                  📅 {{ formatDate(selected.start_date) }}
-                  <span v-if="selected.end_date">
-                    – {{ formatDate(selected.end_date) }}</span
-                  >
-                </span>
-                <span v-if="selected.location">📍 {{ selected.location }}</span>
-                <span
-                  v-for="ag in selected.age_groups || []"
-                  :key="ag.id"
-                  class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-brand-100 text-brand-700"
+            <div class="flex items-start gap-4 min-w-0 flex-1">
+              <img
+                v-if="selected.logo_url"
+                :src="selected.logo_url"
+                :alt="`${selected.name} logo`"
+                class="w-16 h-16 rounded-md object-contain bg-white border border-gray-100 shrink-0"
+                data-testid="tournament-logo"
+              />
+              <div class="min-w-0 flex-1">
+                <h2 class="text-2xl font-bold text-gray-900">
+                  {{ selected.name }}
+                </h2>
+                <div
+                  class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500"
                 >
-                  {{ ag.name }}
-                </span>
+                  <span v-if="selected.start_date">
+                    📅 {{ formatDate(selected.start_date) }}
+                    <span v-if="selected.end_date">
+                      – {{ formatDate(selected.end_date) }}</span
+                    >
+                  </span>
+                  <span v-if="selected.location"
+                    >📍 {{ selected.location }}</span
+                  >
+                  <span
+                    v-for="ag in selected.age_groups || []"
+                    :key="ag.id"
+                    class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-brand-100 text-brand-700"
+                  >
+                    {{ ag.name }}
+                  </span>
+                </div>
+                <p
+                  v-if="selected.description"
+                  class="mt-3 text-sm text-gray-600"
+                >
+                  {{ selected.description }}
+                </p>
               </div>
-              <p v-if="selected.description" class="mt-3 text-sm text-gray-600">
-                {{ selected.description }}
-              </p>
             </div>
             <div class="flex flex-col items-end gap-3">
               <div class="text-right text-sm text-gray-500">

--- a/frontend/src/components/ig/IgOverlay.vue
+++ b/frontend/src/components/ig/IgOverlay.vue
@@ -97,6 +97,14 @@
           {{ metaLabel }}
         </span>
         <MlsNextBadge v-if="isHomegrownLeague" class="ig-mls-badge" />
+        <img
+          v-if="tournamentLogoUrl"
+          :src="tournamentLogoUrl"
+          class="ig-tournament-logo"
+          data-testid="ig-tournament-logo"
+          alt=""
+          crossorigin="anonymous"
+        />
       </div>
     </div>
 
@@ -331,6 +339,13 @@ export default {
 .ig-mls-badge {
   margin-left: auto;
   height: 108px;
+}
+
+.ig-tournament-logo {
+  height: 108px;
+  width: 108px;
+  object-fit: contain;
+  margin-left: 12px;
 }
 
 .ig-chip {

--- a/frontend/src/components/ig/IgSplit.vue
+++ b/frontend/src/components/ig/IgSplit.vue
@@ -35,6 +35,14 @@
             <span class="meta" data-testid="ig-meta">{{ metaLabel }}</span>
           </div>
           <MlsNextBadge v-if="isHomegrownLeague" class="mls-badge" />
+          <img
+            v-if="tournamentLogoUrl"
+            :src="tournamentLogoUrl"
+            class="tournament-logo"
+            data-testid="ig-tournament-logo"
+            alt=""
+            crossorigin="anonymous"
+          />
         </div>
       </div>
 
@@ -286,6 +294,14 @@ export default {
 .mls-badge {
   height: 88px;
   flex-shrink: 0;
+}
+
+.tournament-logo {
+  height: 88px;
+  width: 88px;
+  object-fit: contain;
+  flex-shrink: 0;
+  margin-left: 8px;
 }
 
 .brand-mark {

--- a/frontend/src/components/ig/IgStadium.vue
+++ b/frontend/src/components/ig/IgStadium.vue
@@ -18,6 +18,14 @@
         >missingtable.com</span
       >
       <MlsNextBadge v-if="isHomegrownLeague" class="brand-band-badge" />
+      <img
+        v-if="tournamentLogoUrl"
+        :src="tournamentLogoUrl"
+        class="tournament-logo"
+        data-testid="ig-tournament-logo"
+        alt=""
+        crossorigin="anonymous"
+      />
       <span class="meta" data-testid="ig-meta">{{ metaLabel }}</span>
     </div>
 
@@ -214,6 +222,13 @@ export default {
   height: 84px;
   margin-left: auto;
   margin-right: 24px;
+}
+
+.tournament-logo {
+  height: 84px;
+  width: 84px;
+  object-fit: contain;
+  margin-right: 16px;
 }
 
 .meta {

--- a/frontend/src/components/ig/IgTournamentRound.vue
+++ b/frontend/src/components/ig/IgTournamentRound.vue
@@ -46,6 +46,14 @@
             </span>
           </div>
           <MlsNextBadge v-if="isHomegrownLeague" class="mls-badge" />
+          <img
+            v-if="tournamentLogoUrl"
+            :src="tournamentLogoUrl"
+            class="tournament-logo"
+            data-testid="ig-tournament-logo"
+            alt=""
+            crossorigin="anonymous"
+          />
         </div>
       </div>
 
@@ -259,6 +267,14 @@ export default {
 .mls-badge {
   height: 88px;
   flex-shrink: 0;
+}
+
+.tournament-logo {
+  height: 88px;
+  width: 88px;
+  object-fit: contain;
+  flex-shrink: 0;
+  margin-left: 8px;
 }
 
 .brand-mark {

--- a/frontend/src/composables/useIgShareData.js
+++ b/frontend/src/composables/useIgShareData.js
@@ -97,6 +97,9 @@ export function useIgShareData(matchRef, modeRef, eventsRef) {
   const tournamentGroup = computed(() =>
     cleanName(matchRef.value?.tournament_group)
   );
+  const tournamentLogoUrl = computed(
+    () => matchRef.value?.tournament_logo_url || null
+  );
 
   // Normalize round tokens like "round_of_16" / "quarterfinal" / "final"
   // into a human display. Returns null when no round is set, which the
@@ -285,6 +288,7 @@ export function useIgShareData(matchRef, modeRef, eventsRef) {
     metaLabel,
     tournamentName,
     tournamentGroup,
+    tournamentLogoUrl,
     tournamentRoundLabel,
     hasTournamentRound,
     dateLabel,

--- a/supabase-local/migrations/20260525120000_add_tournament_logo_url.sql
+++ b/supabase-local/migrations/20260525120000_add_tournament_logo_url.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration: add logo_url to tournaments
+-- =============================================================================
+-- Optional logo (small shield / mark) per tournament. Shown on the public
+-- tournament page header and on IG share cards when set. Falls back to the
+-- existing "no logo" rendering when null, so legacy tournaments stay valid.
+-- Uploaded via POST /api/admin/tournaments/{id}/logo (multipart → Supabase
+-- Storage `tournament-logos` bucket) — mirrors the club-logo flow.
+-- =============================================================================
+
+ALTER TABLE public.tournaments
+    ADD COLUMN IF NOT EXISTS logo_url TEXT;
+
+COMMENT ON COLUMN public.tournaments.logo_url IS
+    'Public URL of the tournament logo (Supabase Storage / R2). NULL = no logo set; UI falls back to text-only rendering.';


### PR DESCRIPTION
## Summary

Adds an optional logo per tournament. Shows on the public tournament-page header and on all four IG share card templates (Overlay / Split / TournamentRound / Stadium) when set. Null = legacy "no logo" rendering — no data work required for existing tournaments.

Motivator: the 2026 National Academy Championships brand (image you pasted) — a small logo on the match-recap IG posts adds a nice touch and helps the brand stand out.

## What changed

**Schema** (`supabase-local/migrations/20260525120000_add_tournament_logo_url.sql`)
- `tournaments.logo_url TEXT NULL`, additive + `IF NOT EXISTS`.

**Backend**
- DAO: `tournament_dao` `SELECT`s include `logo_url`; `update_tournament` accepts the field.
- `match_dao.get_match_by_id` joins `tournaments(logo_url)` and surfaces `tournament_logo_url` on the flattened response — that's what the IG share path consumes.
- New endpoint `POST /api/admin/tournaments/{id}/logo` (multipart, PNG/JPG, 2MB max). Mirrors `POST /api/clubs/{id}/logo` line for line: auto-generates `_sm` (64px) + `_md` (128px) PNG variants.
- Storage: Supabase Storage bucket `tournament-logos` (public). Same backend as club logos.

**CLI / Skill**
- `mt.py tournament logo-upload --tournament-id N --path file`.
- `api_client.upload_tournament_logo()` helper.

**Frontend**
- `TournamentMatchCenter.vue` header: 64×64 logo slot to the left of the title (only renders when `selected.logo_url` is set).
- `useIgShareData` exposes `tournamentLogoUrl`.
- All four IG share templates render an 84–108px logo in the top-band slot alongside the MLS Next badge. `crossorigin="anonymous"` for html2canvas.

## Test plan

- [x] **8 new IG-share specs**: 4 templates × renders-when-set + 4 × omits-when-absent. All 38 IG-share tests pass.
- [x] **Backend**: `ruff` clean, 390 unit tests pass.
- [x] **Frontend**: `eslint` clean, 345 tests pass.
- [ ] **Manual** (after rollout): tournament page header shows the NAC logo; any U14 NAC match's IG share card shows the small NAC shield in the top-right.

## Rollout — order matters

1. **Merge** → image build → ArgoCD deploys backend + frontend.
2. **Apply migration on prod** via Studio SQL editor (SB-37 workaround):
   ```sql
   ALTER TABLE public.tournaments ADD COLUMN IF NOT EXISTS logo_url TEXT;
   ```
   Sync the tracker:
   ```bash
   cd supabase-local && npx supabase migration repair --status applied 20260525120000 --linked
   ```
3. **Create the `tournament-logos` Supabase Storage bucket** (public, in the Supabase Studio Storage UI). The upload endpoint will fail with a "bucket not found" error otherwise.
4. **Upload the NAC logo** to tournament 6:
   ```bash
   cd backend && MT_API_BASE_URL=https://api.missingtable.com \
     uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py \
     tournament logo-upload --tournament-id 6 --path /path/to/nac.png
   ```
   I'll do this once you confirm the bucket exists.

## Storage note

Logos are ~50–100KB × 3 variants ≈ 300KB/asset. Even at 500 clubs + 50 tournaments we're at ~165MB, well under Supabase free tier (1GB storage / 2GB egress per month). Worth re-checking only if we add many more asset types.

## Out of scope

- Admin web UI for uploading tournament logos (CLI via the skill works for now).
- Multi-variant uploads (single logo per tournament; user picks shield variant).
- IG share full-lockup variant slot (the wider "NATIONAL ACADEMY CHAMPIONSHIPS" rendering won't fit cleanly in the existing card top bands — small shield only).