### PR TITLE
fix(tournaments): bigger logo on header + restore missed bucket migration

### DIFF
--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -101,7 +101,7 @@
                 v-if="selected.logo_url"
                 :src="selected.logo_url"
                 :alt="`${selected.name} logo`"
-                class="w-16 h-16 rounded-md object-contain bg-white border border-gray-100 shrink-0"
+                class="w-24 h-24 sm:w-28 sm:h-28 rounded-md object-contain bg-white border border-gray-100 shrink-0"
                 data-testid="tournament-logo"
               />
               <div class="min-w-0 flex-1">

--- a/supabase-local/migrations/20260525130000_tournament_logos_bucket.sql
+++ b/supabase-local/migrations/20260525130000_tournament_logos_bucket.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Migration: create the `tournament-logos` Supabase Storage bucket
+-- =============================================================================
+-- This is a follow-up to 20260525120000_add_tournament_logo_url.sql. The
+-- original migration also included this INSERT, but it was dropped during
+-- the squash-merge of PR #398, leaving new environments without the bucket
+-- (prod was patched manually via Studio).
+--
+-- Idempotent (ON CONFLICT DO NOTHING) — safe to apply against environments
+-- where the bucket already exists.
+-- =============================================================================
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'tournament-logos',
+    'tournament-logos',
+    true,
+    2097152,                                  -- 2 MiB
+    ARRAY['image/png', 'image/jpeg', 'image/jpg']
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #398:

1. **Logo bigger on the tournament page header** — was 64×64, you said it looked small. Bumped to 96×96 (mobile) / 112×112 (sm+).
2. **Restore the bucket-creation migration that got squash-dropped** — PR #398 was squash-merged using only its first commit, silently dropping the second commit that added `INSERT INTO storage.buckets`. Prod was patched manually, but `npx supabase db reset` locally (and any future fresh env) wouldn't get the bucket. Re-adding as a separate dated migration.

## What changed

- `TournamentMatchCenter.vue`: `w-16 h-16` → `w-24 h-24 sm:w-28 sm:h-28`. Same slot, no layout shift on desktop.
- `supabase-local/migrations/20260525130000_tournament_logos_bucket.sql` (new): the same `INSERT INTO storage.buckets … ON CONFLICT DO NOTHING` from the lost commit, on a fresh timestamp so it can't be skipped.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` — 345 / 345
- [ ] Manual: tournament page header shows the NAC shield visibly bigger; the size step from mobile to sm+ is subtle but noticeable

## Rollout

The migration is **idempotent**, but production already has the bucket (manually). Apply on prod for tracking-history parity:

```sql
INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
VALUES ('tournament-logos', 'tournament-logos', true, 2097152,
        ARRAY['image/png', 'image/jpeg', 'image/jpg'])
ON CONFLICT (id) DO NOTHING;
```

Then sync the tracker:
```
cd supabase-local && npx supabase migration repair --status applied 20260525130000 --linked
```

On a fresh local `npx supabase db reset` the bucket will be created automatically with no further action.

## Note for next time

When merging PRs with multiple commits, prefer **rebase-merge** over **squash-merge** if any of the commits are independently meaningful (migrations especially). Squash is fine for "fix lint" / "address review feedback" commits, less so when a follow-up commit adds a distinct DB change.