### PR TITLE
feat(match): resolve TBD placeholders via match update team-id flags

### DIFF
--- a/.claude/skills/load-tournament-matches/SKILL.md
+++ b/.claude/skills/load-tournament-matches/SKILL.md
@@ -226,8 +226,11 @@ cd backend && uv run python ../.claude/skills/load-tournament-matches/scripts/mt
   [--home-penalty-score 5 --away-penalty-score 4] \
   [--tournament-round round_of_16] [--tournament-group "A"] \
   [--scheduled-kickoff "2026-06-21T15:00:00Z"] [--match-date YYYY-MM-DD] \
-  [--swap-home-away]
+  [--swap-home-away] \
+  [--home-team-id N] [--away-team-id N]    # replace a side's team; primary use is resolving a TBD placeholder once the real team is announced
 ```
+
+**Resolving TBD placeholder matches.** When a tournament has matches loaded with `opponent_name "TBD"` (because one side wasn't announced yet), use `match update --home-team-id` or `--away-team-id` to fill in the real team once announced. Don't combine with `--swap-home-away` (the CLI rejects it). Postgres rejects `home_team_id == away_team_id` so an accidental self-pairing aborts the write rather than silently corrupting data.
 
 **Important semantics:**
 

--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -497,6 +497,16 @@ def match_update(
     scheduled_kickoff: str | None = typer.Option(None, "--scheduled-kickoff"),
     match_date: str | None = typer.Option(None, "--match-date"),
     swap_home_away: bool = typer.Option(False, "--swap-home-away", help="Swap which team is home/away."),
+    home_team_id: int | None = typer.Option(
+        None,
+        "--home-team-id",
+        help="Replace the home team. Use to resolve a TBD placeholder when the real team is announced.",
+    ),
+    away_team_id: int | None = typer.Option(
+        None,
+        "--away-team-id",
+        help="Replace the away team. Use to resolve a TBD placeholder when the real team is announced.",
+    ),
 ) -> None:
     """Partially update an existing tournament match (fill in scores/status as results come in).
 
@@ -518,6 +528,8 @@ def match_update(
         scheduled_kickoff=scheduled_kickoff,
         match_date=match_date,
         swap_home_away=swap_home_away,
+        home_team_id=home_team_id,
+        away_team_id=away_team_id,
     )
     with _client() as c:
         try:

--- a/backend/api_client/models.py
+++ b/backend/api_client/models.py
@@ -154,6 +154,8 @@ class TournamentMatchUpdate(BaseModel):
     scheduled_kickoff: str | None = Field(None, title="Scheduled Kickoff")
     match_date: str | None = Field(None, title="Match Date")
     swap_home_away: bool = Field(False, title="Swap Home Away")
+    home_team_id: int | None = Field(None, title="Home Team Id")
+    away_team_id: int | None = Field(None, title="Away Team Id")
 
 
 class TeamGameTypeMapping(BaseModel):

--- a/backend/app.py
+++ b/backend/app.py
@@ -6470,6 +6470,8 @@ class TournamentMatchUpdate(BaseModel):
     scheduled_kickoff: str | None = None
     match_date: str | None = None
     swap_home_away: bool = False
+    home_team_id: int | None = None
+    away_team_id: int | None = None
 
 
 @app.get("/api/tournaments")
@@ -6711,6 +6713,8 @@ async def admin_update_tournament_match(
             scheduled_kickoff=payload.scheduled_kickoff,
             match_date=payload.match_date,
             swap_home_away=payload.swap_home_away,
+            home_team_id=payload.home_team_id,
+            away_team_id=payload.away_team_id,
         )
         if not updated:
             raise HTTPException(status_code=404, detail="Match not found")

--- a/backend/dao/tournament_dao.py
+++ b/backend/dao/tournament_dao.py
@@ -503,10 +503,23 @@ class TournamentDAO(BaseDAO):
         scheduled_kickoff: str | None = None,
         match_date: str | None = None,
         swap_home_away: bool = False,
+        home_team_id: int | None = None,
+        away_team_id: int | None = None,
     ) -> dict | None:
-        """Update score, status, or context fields on a tournament match."""
+        """Update score, status, or context fields on a tournament match.
+
+        home_team_id / away_team_id are the resolution path for TBD
+        placeholder matches: when the actual team is announced, callers
+        pass the new team's id and the placeholder reference is replaced.
+        Postgres enforces home_team_id <> away_team_id, so an accidental
+        self-pairing aborts the write instead of silently corrupting data.
+        """
         if tournament_round and tournament_round not in VALID_ROUNDS:
             raise ValueError(f"Invalid tournament_round '{tournament_round}'. Must be one of {VALID_ROUNDS}")
+        if swap_home_away and (home_team_id is not None or away_team_id is not None):
+            raise ValueError(
+                "swap_home_away is mutually exclusive with home_team_id / away_team_id"
+            )
 
         updates: dict = {}
         if home_score is not None:
@@ -529,6 +542,10 @@ class TournamentDAO(BaseDAO):
             updates["scheduled_kickoff"] = scheduled_kickoff
         if match_date is not None:
             updates["match_date"] = match_date
+        if home_team_id is not None:
+            updates["home_team_id"] = home_team_id
+        if away_team_id is not None:
+            updates["away_team_id"] = away_team_id
 
         if swap_home_away:
             # Fetch current team IDs to swap them

--- a/backend/tests/unit/test_tournament_match_update_team_ids.py
+++ b/backend/tests/unit/test_tournament_match_update_team_ids.py
@@ -1,0 +1,96 @@
+"""Unit tests for TournamentDAO.update_tournament_match team-id updates.
+
+Specifically covers the TBD-resolution path: matches loaded with a
+placeholder team can have their home_team_id / away_team_id replaced
+when the real team is announced.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def dao():
+    from dao.tournament_dao import TournamentDAO
+
+    # Bypass BaseDAO's connection-holder isinstance check — we never hit a
+    # real DB, just assert what gets staged into the update dict.
+    d = TournamentDAO.__new__(TournamentDAO)
+    d.connection_holder = MagicMock()
+    d.client = MagicMock()
+    return d
+
+
+def _capture_update_payload(dao):
+    """Stub out the supabase client's `.update()` and return the dict it received."""
+    captured = {}
+    table = MagicMock()
+
+    def update(updates):
+        captured["updates"] = updates
+        chain = MagicMock()
+        chain.eq.return_value.execute.return_value.data = [{"id": 1, **updates}]
+        return chain
+
+    table.update.side_effect = update
+    dao.client.table.return_value = table
+    return captured
+
+
+class TestUpdateMatchTeamIds:
+    def test_home_team_id_sets_field(self, dao):
+        captured = _capture_update_payload(dao)
+        dao.update_tournament_match(match_id=1, home_team_id=42)
+        assert captured["updates"] == {"home_team_id": 42}
+
+    def test_away_team_id_sets_field(self, dao):
+        captured = _capture_update_payload(dao)
+        dao.update_tournament_match(match_id=1, away_team_id=42)
+        assert captured["updates"] == {"away_team_id": 42}
+
+    def test_both_team_ids_in_one_update(self, dao):
+        """Common TBD-resolution case: both sides revealed at once."""
+        captured = _capture_update_payload(dao)
+        dao.update_tournament_match(match_id=1, home_team_id=10, away_team_id=20)
+        assert captured["updates"] == {"home_team_id": 10, "away_team_id": 20}
+
+    def test_team_id_change_combines_with_score_update(self, dao):
+        """Resolving a TBD + entering its score should be one atomic call."""
+        captured = _capture_update_payload(dao)
+        dao.update_tournament_match(
+            match_id=1,
+            home_team_id=10,
+            home_score=3,
+            away_score=2,
+            match_status="completed",
+        )
+        assert captured["updates"] == {
+            "home_team_id": 10,
+            "home_score": 3,
+            "away_score": 2,
+            "match_status": "completed",
+        }
+
+    def test_swap_home_away_conflicts_with_explicit_team_id(self, dao):
+        """The two flag families are mutually exclusive — refusing the
+        combination prevents an ambiguous write where the swap might
+        clobber the explicit set or vice-versa."""
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            dao.update_tournament_match(
+                match_id=1, swap_home_away=True, home_team_id=42
+            )
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            dao.update_tournament_match(
+                match_id=1, swap_home_away=True, away_team_id=42
+            )
+
+    def test_no_team_id_update_when_none(self, dao):
+        """Don't include team_id keys in the update payload when not passed —
+        we don't want to accidentally write nulls into a NOT NULL column."""
+        captured = _capture_update_payload(dao)
+        dao.update_tournament_match(match_id=1, home_score=2)
+        assert "home_team_id" not in captured["updates"]
+        assert "away_team_id" not in captured["updates"]


### PR DESCRIPTION
## Summary

Adds `--home-team-id` / `--away-team-id` to the existing match update endpoint + CLI. Designed for the TBD-resolution path: tournament matches loaded with `opponent_name="TBD"` (because the opponent wasn't announced yet) can be resolved later from the CLI without touching the DB directly.

## Motivation

NAC tournament has 2 Friday matches (#21, #25) and 1 Sunday Final (#34) loaded with a TBD placeholder side. Resolving them today requires Supabase Studio SQL — same friction we hit on the U14 Premier crossed-pairing fix.

This is option 1 from the TBD-handling design discussion: minimal CLI surface, no schema change, no frontend change. Future options (nullable team_ids, placeholder labels like "Bracket A #1") stay open as separate tickets if richer placeholders become useful.

## What changed

**Backend**
- `TournamentDAO.update_tournament_match` accepts `home_team_id` / `away_team_id`. Mutually exclusive with `swap_home_away` — the swap reads the existing pair to flip, so combining it with an explicit replacement leaves the resulting state ambiguous; the DAO raises `ValueError` instead of guessing.
- Postgres already enforces `home_team_id <> away_team_id` via the existing `matches_check` CHECK constraint, so accidental self-pairing aborts the write rather than silently corrupting data — no application-layer validation needed.
- `TournamentMatchUpdate` pydantic model in `app.py` + `api_client/models.py` carries both fields. Endpoint `PUT /api/admin/tournaments/{id}/matches/{match_id}` passes them through.

**Skill + CLI**
- `mt.py match update` gains `--home-team-id` / `--away-team-id`.
- `SKILL.md` documents the resolution flow under a new "Resolving TBD placeholder matches" note.

## Usage

Once a TBD opponent is announced:
```bash
cd backend && MT_API_BASE_URL=https://api.missingtable.com \
  uv run python ../.claude/skills/load-tournament-matches/scripts/mt.py \
  match update --tournament-id 6 --match-id 3146 --home-team-id <real_team_id>
```

To fill in the team AND its score atomically (when the match has been played):
```bash
mt.py match update --tournament-id 6 --match-id 3146 \
  --home-team-id <id> --home-score 2 --away-score 1 --match-status completed
```

## Test plan

- [x] 6 new unit tests in `tests/unit/test_tournament_match_update_team_ids.py`:
  - Each flag in isolation
  - Both together
  - Combined with score / status update (atomic team + score fill-in)
  - Mutual exclusion with `--swap-home-away` (asserts ValueError)
  - Don't-write-nulls-when-unset (preserves prior team_ids when only score is updated)
- [x] Full backend suite: 396 / 396, ruff clean
- [ ] Manual (post-merge): resolve NAC match #3146 once the Bracket A #8 team is announced, confirm the bracket UI updates

## Notes

- This is the minimal CLI fix. Richer placeholder labels ("Bracket A #1 vs Bracket A #2" in the Final card) would need nullable team-ids + a `placeholder_label` field — a separate ticket if you want it.
- The shared "TBD" team row in the teams table keeps getting referenced by new placeholder matches. Not pretty, but works; cleanup is a different concern.