### PR TITLE
chore(tournaments): bump header logo to 128/144px

### DIFF
--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -101,7 +101,7 @@
                 v-if="selected.logo_url"
                 :src="selected.logo_url"
                 :alt="`${selected.name} logo`"
-                class="w-24 h-24 sm:w-28 sm:h-28 rounded-md object-contain bg-white border border-gray-100 shrink-0"
+                class="w-32 h-32 sm:w-36 sm:h-36 rounded-md object-contain bg-white border border-gray-100 shrink-0"
                 data-testid="tournament-logo"
               />
               <div class="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- Tournament header logo was 96/112px (`w-24 h-24 sm:w-28 sm:h-28`); bumped to 128/144px (`w-32 h-32 sm:w-36 sm:h-36`).
- One-class change in `TournamentMatchCenter.vue` — follow-up to #399 which made the logo show in the header in the first place.

## Test plan
- [ ] After deploy, visit https://missingtable.com/tournaments → confirm NAC shield is visibly larger next to the title.
- [ ] Resize browser through the `sm` breakpoint (~640px) and confirm both sizes render and don't push the title off-screen on narrow viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)