### PR TITLE
feat(live-match): guard halftime click + rollback to 1st half (SB-42)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2920,6 +2920,7 @@ async def update_match_clock(
         valid_actions = [
             "start_first_half",
             "start_halftime",
+            "cancel_halftime",
             "start_second_half",
             "end_match",
         ]
@@ -2941,6 +2942,7 @@ async def update_match_clock(
         action_messages = {
             "start_first_half": "Match kicked off",
             "start_halftime": "Halftime",
+            "cancel_halftime": "Returned to first half",
             "start_second_half": "Second half started",
             "end_match": "Full time",
         }

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -1306,7 +1306,7 @@ class MatchDAO(BaseDAO):
         Args:
             match_id: The match to update
             action: Clock action - 'start_first_half', 'start_halftime',
-                    'start_second_half', 'end_match'
+                    'cancel_halftime', 'start_second_half', 'end_match'
             updated_by: UUID of user performing the action
             half_duration: Duration of each half in minutes (only for start_first_half)
 
@@ -1329,6 +1329,35 @@ class MatchDAO(BaseDAO):
             elif action == "start_halftime":
                 # Mark halftime started
                 data["halftime_start"] = now
+            elif action == "cancel_halftime":
+                # Roll back from halftime to first half. Clearing halftime_start
+                # lets the derived clock resume as (now - kickoff_time), which is
+                # the real game time since kickoff (including the seconds spent
+                # mistakenly in halftime). second_half_start must already be null
+                # for this state to be valid — guarded below.
+                current = (
+                    self.client.table("matches")
+                    .select("halftime_start,second_half_start")
+                    .eq("id", match_id)
+                    .single()
+                    .execute()
+                )
+                if not current.data:
+                    logger.warning("cancel_halftime rejected - match not found", match_id=match_id)
+                    return None
+                if not current.data.get("halftime_start"):
+                    logger.warning(
+                        "cancel_halftime rejected - halftime not started",
+                        match_id=match_id,
+                    )
+                    return None
+                if current.data.get("second_half_start"):
+                    logger.warning(
+                        "cancel_halftime rejected - second half already started",
+                        match_id=match_id,
+                    )
+                    return None
+                data["halftime_start"] = None
             elif action == "start_second_half":
                 # Start second half
                 data["second_half_start"] = now

--- a/backend/models/live_match.py
+++ b/backend/models/live_match.py
@@ -25,7 +25,13 @@ class LiveMatchClock(BaseModel):
 
     @property
     def valid_actions(self) -> list[str]:
-        return ["start_first_half", "start_halftime", "start_second_half", "end_match"]
+        return [
+            "start_first_half",
+            "start_halftime",
+            "cancel_halftime",
+            "start_second_half",
+            "end_match",
+        ]
 
 
 class GoalEvent(BaseModel):

--- a/frontend/src/components/live/LiveAdminControls.vue
+++ b/frontend/src/components/live/LiveAdminControls.vue
@@ -67,7 +67,7 @@
 
       <button
         v-if="matchPeriod === '1st Half'"
-        @click="$emit('update-clock', 'start_halftime')"
+        @click="clickHalftime"
         class="control-button halftime"
       >
         Halftime
@@ -79,6 +79,15 @@
         class="control-button start"
       >
         Start 2nd Half
+      </button>
+
+      <button
+        v-if="matchPeriod === 'Halftime'"
+        @click="showCancelHalftimeModal = true"
+        class="control-button rewind"
+        title="Roll back to first half if halftime was clicked by mistake"
+      >
+        Back to 1st Half
       </button>
 
       <button
@@ -398,6 +407,68 @@
       </div>
     </div>
 
+    <!-- Halftime Early-Click Warning Modal -->
+    <div
+      v-if="showHalftimeConfirmModal"
+      class="modal-overlay"
+      @click.self="showHalftimeConfirmModal = false"
+    >
+      <div class="modal-content">
+        <h3 class="modal-title">Halftime already?</h3>
+        <p class="confirm-text">
+          Only <strong>{{ formatClock(firstHalfElapsedSeconds) }}</strong> has
+          been played. Each half is set to
+          <strong>{{ matchState.half_duration ?? 45 }}:00</strong>.
+        </p>
+        <p class="confirm-subtext">
+          If this was a mistake, hit Cancel and keep playing — the clock keeps
+          running.
+        </p>
+        <div class="modal-actions">
+          <button
+            @click="showHalftimeConfirmModal = false"
+            class="cancel-button"
+          >
+            Cancel
+          </button>
+          <button @click="confirmHalftime" class="submit-button submit-yellow">
+            Yes, start halftime
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cancel Halftime (Back to First Half) Confirmation Modal -->
+    <div
+      v-if="showCancelHalftimeModal"
+      class="modal-overlay"
+      @click.self="showCancelHalftimeModal = false"
+    >
+      <div class="modal-content">
+        <h3 class="modal-title">Back to first half?</h3>
+        <p class="confirm-text">
+          The match clock will resume at
+          <strong>{{ formatClock(projectedResumeSeconds) }}</strong> game time
+          (counted from kickoff).
+        </p>
+        <p class="confirm-subtext">
+          Use this if halftime was clicked by mistake. Goals and cards are
+          unaffected.
+        </p>
+        <div class="modal-actions">
+          <button
+            @click="showCancelHalftimeModal = false"
+            class="cancel-button"
+          >
+            Cancel
+          </button>
+          <button @click="confirmCancelHalftime" class="submit-button">
+            Yes, roll back
+          </button>
+        </div>
+      </div>
+    </div>
+
     <!-- Reopen Match Confirmation Modal -->
     <div
       v-if="showReopenModal"
@@ -495,6 +566,54 @@ const showStartModal = ref(false);
 // End match / reopen confirmation modal state
 const showEndMatchModal = ref(false);
 const showReopenModal = ref(false);
+
+// Halftime guard + rollback modal state
+const EARLY_HALFTIME_GRACE_SECONDS = 120;
+const showHalftimeConfirmModal = ref(false);
+const showCancelHalftimeModal = ref(false);
+const firstHalfElapsedSeconds = ref(0);
+const projectedResumeSeconds = ref(0);
+
+function computeFirstHalfElapsed() {
+  if (!props.matchState?.kickoff_time) return 0;
+  const elapsedMs =
+    Date.now() - new Date(props.matchState.kickoff_time).getTime();
+  return Math.max(0, elapsedMs / 1000);
+}
+
+function formatClock(seconds) {
+  const total = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function clickHalftime() {
+  const elapsed = computeFirstHalfElapsed();
+  const halfDurationSeconds = (props.matchState?.half_duration ?? 45) * 60;
+  if (elapsed < halfDurationSeconds - EARLY_HALFTIME_GRACE_SECONDS) {
+    firstHalfElapsedSeconds.value = elapsed;
+    showHalftimeConfirmModal.value = true;
+    return;
+  }
+  emit('update-clock', 'start_halftime');
+}
+
+function confirmHalftime() {
+  showHalftimeConfirmModal.value = false;
+  emit('update-clock', 'start_halftime');
+}
+
+function confirmCancelHalftime() {
+  showCancelHalftimeModal.value = false;
+  emit('update-clock', 'cancel_halftime');
+}
+
+watch(showCancelHalftimeModal, newVal => {
+  if (newVal) {
+    projectedResumeSeconds.value = computeFirstHalfElapsed();
+  }
+});
 
 function confirmEndMatch() {
   showEndMatchModal.value = false;
@@ -817,6 +936,16 @@ function submitGoal() {
 
 .control-button.reopen:hover {
   background: #8e24aa;
+}
+
+.control-button.rewind {
+  background: transparent;
+  color: #ffc107;
+  border: 2px solid #ffc107;
+}
+
+.control-button.rewind:hover {
+  background: rgba(255, 193, 7, 0.12);
 }
 
 .control-button.goal {


### PR DESCRIPTION
Closes [SB-42](https://linear.app/silverbeer/issue/SB-42/live-match-guard-halftime-click-allow-rollback-to-first-half).

## Summary
Real-world UX issue: clicking **Halftime** 1 minute into a 35-min half leaves you stuck — only forward action is "Start 2nd Half", erasing the rest of the actual first half. Two fixes ship together:

1. **Confirm modal** when Halftime is clicked more than 2 minutes early. Shows the actual game-time elapsed so the operator can spot the misclick.
2. **"Back to 1st Half" rollback** action while in Halftime. Backend clears `halftime_start`; the clock — which is purely derived from timestamps in `useLiveMatch.js` — auto-resumes at `now - kickoff_time`, i.e. real game time including the seconds spent mistakenly in halftime. No extra clock math needed.

## What changed

**Backend**
- `backend/models/live_match.py` — `cancel_halftime` added to `valid_actions`.
- `backend/dao/match_dao.py` — handler sets `halftime_start = NULL` with guards (match must be in halftime, must not yet be in second half).
- `backend/app.py` — `cancel_halftime` accepted by the `/api/matches/{id}/live/clock` endpoint; logs a "Returned to first half" `status_change` event so the audit trail shows the recovery alongside the original "Halftime" event.

**Frontend**
- `frontend/src/components/live/LiveAdminControls.vue` — Halftime click now routes through `clickHalftime()` which gates on `elapsed < (half_duration * 60) - 120`. New "Back to 1st Half" button appears only when `matchPeriod === 'Halftime'`. Two new confirm modals reusing the existing modal styling.

## Why no event cleanup
Goal and card buttons are hidden during the Halftime period (`LiveAdminControls.vue:102-112`), so no stray events get attached to a "fake" period and need to be reversed. The rollback only fires from Halftime, never from Second Half.

## Permissions
Both actions inherit `require_match_management_permission` — same auth as Halftime/Second Half/End buttons today.

## Test plan
- [ ] Start a live match (any half_duration, e.g. 35 min).
- [ ] Click **Halftime** within the first 2 min → modal appears showing "Only X:XX has been played, halves are 35:00". Cancel → no state change.
- [ ] Click **Halftime** again, confirm → state moves to Halftime as today.
- [ ] In Halftime, click **Back to 1st Half** → confirm modal shows "clock will resume at X:XX game time". Confirm → period flips back to 1st Half, clock reads real elapsed since kickoff (including the seconds in fake halftime).
- [ ] Activity Stream shows two `status_change` events: "Halftime" and "Returned to first half".
- [ ] Click **Halftime** at or after `(half_duration - 2 min)` → no modal, button works as before (no friction for the normal path).
- [ ] Click **Start 2nd Half** while in Halftime — works unchanged.
- [ ] Once in 2nd Half, "Back to 1st Half" is **not** visible.

## Mobile browser verification (required)
Live scoring is overwhelmingly a phone-sideline activity, so the new modals need real-device coverage in addition to the laptop checks above.

- [ ] Walk through the full test plan on **iOS Safari** at iPhone 12 viewport (390×844).
- [ ] Walk through the full test plan on **Android Chrome** at Pixel 5 viewport (393×851).
- [ ] Halftime confirm modal renders centered, body text readable, both buttons fully visible (no horizontal scroll, no clipping under iOS Safari's bottom chrome).
- [ ] "Back to 1st Half" outlined button is visibly distinct from the green "Start 2nd Half" primary button at narrow widths — neither button truncates label.
- [ ] All buttons have ≥44px tap target (existing `.control-button` is `min-height: 48px` — confirm not regressed in mobile media queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
