### PR TITLE
feat(push): frontend opt-in + custom SW push handler (SB-47)

### DIFF
--- a/frontend/src/components/IosInstallTooltip.vue
+++ b/frontend/src/components/IosInstallTooltip.vue
@@ -39,32 +39,12 @@
 
 <script setup>
 import { ref, onMounted } from 'vue';
+import { isIosSafari, isStandalone } from '../utils/pwa';
 
 const STORAGE_KEY = 'mt.iosInstallTooltip.dismissedAt';
 const RESHOW_DAYS = 30;
 
 const shouldShow = ref(false);
-
-function isIosSafari() {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined')
-    return false;
-  const ua = navigator.userAgent;
-  const isIos =
-    /iPad|iPhone|iPod/.test(ua) ||
-    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-  if (!isIos) return false;
-  const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua);
-  return isSafari;
-}
-
-function isStandalone() {
-  if (typeof window === 'undefined') return false;
-  // navigator.standalone is iOS-Safari-specific; matchMedia covers other PWAs.
-  return (
-    window.matchMedia?.('(display-mode: standalone)').matches ||
-    window.navigator.standalone === true
-  );
-}
 
 function wasRecentlyDismissed() {
   try {

--- a/frontend/src/components/ProfileRouter.vue
+++ b/frontend/src/components/ProfileRouter.vue
@@ -43,6 +43,9 @@
 
       <!-- Fan Profile (default) -->
       <FanProfile v-else @logout="handleLogout" @navigate="handleSwitchTab" />
+
+      <!-- Notifications card (universal — every role gets the same surface) -->
+      <NotificationsCard />
     </div>
 
     <!-- Role Debug Info (only in development) -->
@@ -81,6 +84,7 @@ import ClubManagerProfile from './profiles/ClubManagerProfile.vue';
 import TeamManagerProfile from './profiles/TeamManagerProfile.vue';
 import PlayerProfile from './profiles/PlayerProfile.vue';
 import FanProfile from './profiles/FanProfile.vue';
+import NotificationsCard from './notifications/NotificationsCard.vue';
 
 export default {
   name: 'ProfileRouter',
@@ -90,6 +94,7 @@ export default {
     TeamManagerProfile,
     PlayerProfile,
     FanProfile,
+    NotificationsCard,
   },
   emits: ['logout', 'switch-tab'],
   setup(props, { emit }) {

--- a/frontend/src/components/notifications/NotificationsCard.vue
+++ b/frontend/src/components/notifications/NotificationsCard.vue
@@ -1,0 +1,432 @@
+<template>
+  <section class="notifications-card" data-testid="notifications-card">
+    <header class="notifications-header">
+      <h3>Notifications</h3>
+      <p class="notifications-subhead">
+        Get a push when a team you follow scores, kicks off, hits halftime, or
+        finishes.
+      </p>
+    </header>
+
+    <!-- iOS-not-standalone gate -->
+    <div v-if="isIosBlocked" class="notifications-banner banner-warn">
+      <strong>Install MT to your home screen first.</strong>
+      <span>
+        iOS requires the app to be installed before notifications can be
+        enabled. Use Share → "Add to Home Screen" in Safari, then come back
+        here.
+      </span>
+    </div>
+
+    <!-- Permission denied -->
+    <div v-else-if="isBlocked" class="notifications-banner banner-error">
+      <strong>Notifications blocked.</strong>
+      <span>
+        Open your browser's site settings for missingtable.com and allow
+        notifications, then refresh.
+      </span>
+    </div>
+
+    <!-- Unsupported browser -->
+    <div v-else-if="!isSupported" class="notifications-banner banner-muted">
+      <strong>Not supported on this browser.</strong>
+      <span>Try Chrome, Edge, Firefox, or Safari 16.4+.</span>
+    </div>
+
+    <!-- Main control: enable / enabled state -->
+    <div v-else class="notifications-body">
+      <button
+        v-if="!isEnabled"
+        class="enable-button"
+        :disabled="loading"
+        @click="onEnable"
+      >
+        {{ loading ? 'Enabling…' : 'Enable push notifications on this device' }}
+      </button>
+
+      <div v-else class="enabled-block">
+        <div class="enabled-pill">
+          <span class="enabled-dot" aria-hidden="true"></span>
+          Notifications enabled on this device
+        </div>
+        <button class="test-button" :disabled="loading" @click="onTest">
+          {{ loading ? 'Sending…' : 'Send test notification' }}
+        </button>
+      </div>
+
+      <p v-if="lastError" class="notifications-error">{{ lastError }}</p>
+      <p v-if="lastMessage" class="notifications-success">{{ lastMessage }}</p>
+    </div>
+
+    <!-- Manage devices -->
+    <div v-if="isSupported && subscriptions.length" class="manage-section">
+      <h4>Devices receiving notifications</h4>
+      <ul class="device-list">
+        <li v-for="sub in subscriptions" :key="sub.id" class="device-item">
+          <div>
+            <div class="device-label">
+              {{ sub.device_label || 'Unknown device' }}
+            </div>
+            <div class="device-meta">
+              Last seen {{ formatDate(sub.last_seen_at) }}
+            </div>
+          </div>
+          <button
+            class="revoke-button"
+            :disabled="loading"
+            @click="onRevoke(sub.id)"
+          >
+            Revoke
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Followed teams (read-only summary) -->
+    <div v-if="isSupported" class="follows-section">
+      <h4>Teams you follow</h4>
+      <p v-if="!follows.length" class="follows-empty">
+        You aren't following any teams yet. Open a team page and tap "Follow" to
+        start getting notifications for them.
+      </p>
+      <ul v-else class="follows-list">
+        <li v-for="f in follows" :key="f.team_id" class="follow-item">
+          <span class="follow-team">{{
+            f.team?.name || `Team #${f.team_id}`
+          }}</span>
+          <span v-if="f.team?.club?.name" class="follow-club">
+            {{ f.team.club.name }}
+          </span>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { usePushNotifications } from '../../composables/usePushNotifications';
+
+const {
+  isSupported,
+  isEnabled,
+  isBlocked,
+  isIosBlocked,
+  loading,
+  lastError,
+  enable,
+  disable,
+  listSubscriptions,
+  listFollows,
+  sendTest,
+} = usePushNotifications();
+
+const subscriptions = ref([]);
+const follows = ref([]);
+const lastMessage = ref('');
+
+async function refresh() {
+  if (!isSupported.value) return;
+  const [subs, follows_] = await Promise.all([
+    listSubscriptions(),
+    listFollows(),
+  ]);
+  subscriptions.value = subs;
+  follows.value = follows_;
+}
+
+async function onEnable() {
+  lastMessage.value = '';
+  const result = await enable();
+  if (result.success) {
+    lastMessage.value = 'Notifications are now enabled on this device.';
+    await refresh();
+  }
+}
+
+async function onTest() {
+  lastMessage.value = '';
+  const result = await sendTest();
+  if (result.success) {
+    const sent = result.data?.sent ?? 0;
+    const failed = result.data?.failed ?? 0;
+    lastMessage.value =
+      sent > 0
+        ? `Test sent to ${sent} device${sent === 1 ? '' : 's'}.`
+        : failed > 0
+          ? `Test failed on all ${failed} device${failed === 1 ? '' : 's'} — check the device-list status above.`
+          : 'No devices registered yet.';
+  }
+}
+
+async function onRevoke(subscriptionId) {
+  lastMessage.value = '';
+  const result = await disable(subscriptionId);
+  if (result.success) {
+    lastMessage.value = 'Device removed.';
+    await refresh();
+  }
+}
+
+function formatDate(iso) {
+  if (!iso) return 'unknown';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+onMounted(refresh);
+</script>
+
+<style scoped>
+.notifications-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px;
+  margin-top: 24px;
+}
+
+.notifications-header h3 {
+  margin: 0 0 4px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.notifications-subhead {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.notifications-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  margin-bottom: 12px;
+}
+
+.notifications-banner strong {
+  font-weight: 700;
+}
+
+.banner-warn {
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+
+.banner-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.banner-muted {
+  background: #f3f4f6;
+  color: #4b5563;
+  border: 1px solid #e5e7eb;
+}
+
+.notifications-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.enable-button {
+  background: #0257fe;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+  transition: background-color 0.15s ease;
+}
+
+.enable-button:hover:not(:disabled) {
+  background: #0047d4;
+}
+
+.enable-button:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+}
+
+.enabled-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.enabled-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  align-self: flex-start;
+}
+
+.enabled-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.18);
+}
+
+.test-button {
+  background: transparent;
+  color: #0257fe;
+  border: 1.5px solid #0257fe;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+  min-height: 40px;
+  transition: background-color 0.15s ease;
+}
+
+.test-button:hover:not(:disabled) {
+  background: rgba(2, 87, 254, 0.08);
+}
+
+.test-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.notifications-error {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: #991b1b;
+}
+
+.notifications-success {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: #065f46;
+}
+
+.manage-section,
+.follows-section {
+  margin-top: 20px;
+  border-top: 1px solid #f3f4f6;
+  padding-top: 16px;
+}
+
+.manage-section h4,
+.follows-section h4 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.device-list,
+.follows-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.device-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.device-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.device-meta {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 2px;
+}
+
+.revoke-button {
+  background: transparent;
+  color: #b91c1c;
+  border: 1.5px solid #b91c1c;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.revoke-button:hover:not(:disabled) {
+  background: rgba(185, 28, 28, 0.08);
+}
+
+.revoke-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.follows-empty {
+  margin: 0;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.follow-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.follow-team {
+  font-weight: 600;
+  color: #111827;
+}
+
+.follow-club {
+  font-size: 12px;
+  color: #6b7280;
+}
+</style>

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -1,0 +1,267 @@
+/**
+ * Push Notifications composable.
+ *
+ * Wraps the browser Push API + backend subscription registration. Exposes
+ * reactive state the NotificationsCard component subscribes to, plus
+ * imperative enable/disable/test helpers.
+ *
+ * The service worker is registered separately by usePwaUpdate.js (PR 2
+ * inherits the same registration). This composable only handles the
+ * subscription + opt-in flow on top of an already-registered SW.
+ */
+
+import { ref, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+import { isIosNonStandalone } from '../utils/pwa';
+
+const isSupported = ref(false);
+const permission = ref('default'); // 'default' | 'granted' | 'denied' | 'unsupported'
+let initialized = false;
+
+function detectSupport() {
+  if (typeof window === 'undefined') return false;
+  return (
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+function init() {
+  if (initialized) return;
+  initialized = true;
+  isSupported.value = detectSupport();
+  if (!isSupported.value) {
+    permission.value = 'unsupported';
+    return;
+  }
+  permission.value = Notification.permission;
+}
+
+/**
+ * Convert URL-safe base64 (what VAPID public keys are stored as) to the
+ * Uint8Array the browser's PushManager.subscribe() expects.
+ */
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = window.atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+function detectDeviceLabel() {
+  const ua = navigator.userAgent || '';
+  let device = 'Device';
+  if (/iPhone/.test(ua)) device = 'iPhone';
+  else if (/iPad/.test(ua)) device = 'iPad';
+  else if (/Pixel/.test(ua)) device = 'Pixel';
+  else if (/Android/.test(ua)) device = 'Android';
+  else if (/Macintosh/.test(ua)) device = 'Mac';
+  else if (/Windows/.test(ua)) device = 'Windows';
+
+  let browser = 'Browser';
+  if (/EdgiOS|Edg/.test(ua)) browser = 'Edge';
+  else if (/CriOS|Chrome/.test(ua)) browser = 'Chrome';
+  else if (/FxiOS|Firefox/.test(ua)) browser = 'Firefox';
+  else if (/Safari/.test(ua)) browser = 'Safari';
+
+  return `${device} • ${browser}`;
+}
+
+export function usePushNotifications() {
+  init();
+
+  const authStore = useAuthStore();
+  const loading = ref(false);
+  const lastError = ref(null);
+
+  const isEnabled = computed(
+    () => isSupported.value && permission.value === 'granted'
+  );
+  const isBlocked = computed(() => permission.value === 'denied');
+  const isIosBlocked = computed(
+    () => isSupported.value && isIosNonStandalone()
+  );
+
+  async function fetchVapidPublicKey() {
+    const resp = await fetch(`${getApiBaseUrl()}/api/push/vapid-public-key`);
+    if (resp.status === 503) {
+      throw new Error('Push notifications are not configured on the server.');
+    }
+    if (!resp.ok) {
+      throw new Error(`Failed to fetch VAPID key (HTTP ${resp.status})`);
+    }
+    const data = await resp.json();
+    return data.publicKey;
+  }
+
+  async function getRegistration() {
+    if (!('serviceWorker' in navigator)) {
+      throw new Error('Service worker not available.');
+    }
+    const reg = await navigator.serviceWorker.ready;
+    if (!reg) throw new Error('Service worker not ready.');
+    return reg;
+  }
+
+  /**
+   * End-to-end opt-in:
+   *   1. Request OS permission (no-op if already granted).
+   *   2. Fetch VAPID public key from backend.
+   *   3. Subscribe via PushManager.
+   *   4. POST subscription to backend.
+   */
+  async function enable(deviceLabel = null) {
+    lastError.value = null;
+    if (!isSupported.value) {
+      lastError.value = 'Push notifications are not supported on this browser.';
+      return { success: false, error: lastError.value };
+    }
+    if (isIosNonStandalone()) {
+      lastError.value =
+        'Install Missing Table to your home screen first, then enable notifications.';
+      return { success: false, error: lastError.value };
+    }
+
+    loading.value = true;
+    try {
+      const result = await Notification.requestPermission();
+      permission.value = result;
+      if (result !== 'granted') {
+        lastError.value =
+          result === 'denied'
+            ? 'Notifications were blocked. Open browser settings to re-enable.'
+            : 'Notification permission was not granted.';
+        return { success: false, error: lastError.value };
+      }
+
+      const vapidPublicKey = await fetchVapidPublicKey();
+      const registration = await getRegistration();
+
+      // If an old subscription exists (e.g. from a previous VAPID key), drop it.
+      const existing = await registration.pushManager.getSubscription();
+      if (existing) {
+        await existing.unsubscribe().catch(() => {});
+      }
+
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+      });
+
+      const subJson = subscription.toJSON();
+      const payload = {
+        endpoint: subJson.endpoint,
+        keys: {
+          p256dh: subJson.keys.p256dh,
+          auth: subJson.keys.auth,
+        },
+        device_label: deviceLabel || detectDeviceLabel(),
+        user_agent: navigator.userAgent.slice(0, 500),
+      };
+
+      const created = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/push-subscriptions`,
+        {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        }
+      );
+
+      return { success: true, subscription: created };
+    } catch (err) {
+      lastError.value = err.message || String(err);
+      return { success: false, error: lastError.value };
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function disable(subscriptionId) {
+    lastError.value = null;
+    loading.value = true;
+    try {
+      await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/push-subscriptions/${subscriptionId}`,
+        { method: 'DELETE' }
+      );
+      // Also clean up the OS-level subscription if it's the active one.
+      try {
+        const registration = await getRegistration();
+        const active = await registration.pushManager.getSubscription();
+        if (active) await active.unsubscribe();
+      } catch {
+        // ignore — backend revoke is the authoritative action.
+      }
+      return { success: true };
+    } catch (err) {
+      lastError.value = err.message || String(err);
+      return { success: false, error: lastError.value };
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function listSubscriptions() {
+    try {
+      const data = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/push-subscriptions`
+      );
+      return data?.subscriptions || [];
+    } catch (err) {
+      lastError.value = err.message || String(err);
+      return [];
+    }
+  }
+
+  async function sendTest() {
+    lastError.value = null;
+    loading.value = true;
+    try {
+      const data = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/notifications/test`,
+        { method: 'POST' }
+      );
+      return { success: true, data };
+    } catch (err) {
+      lastError.value = err.message || String(err);
+      return { success: false, error: lastError.value };
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function listFollows() {
+    try {
+      const data = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/team-follows`
+      );
+      return data?.follows || [];
+    } catch (err) {
+      lastError.value = err.message || String(err);
+      return [];
+    }
+  }
+
+  return {
+    // reactive state
+    isSupported,
+    permission,
+    isEnabled,
+    isBlocked,
+    isIosBlocked,
+    loading,
+    lastError,
+    // imperative
+    enable,
+    disable,
+    listSubscriptions,
+    sendTest,
+    listFollows,
+  };
+}

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -1,0 +1,154 @@
+/* eslint-env serviceworker */
+/**
+ * Missing Table service worker.
+ *
+ * Generated into dist/sw.js by vite-plugin-pwa in `injectManifest` mode. The
+ * plugin injects `self.__WB_MANIFEST` with the precache list at build time;
+ * the rest is hand-written so we can attach push + notificationclick handlers
+ * that `generateSW` doesn't allow.
+ *
+ * What this SW does:
+ *  1. Precaches the app shell (HTML, JS, CSS, icons).
+ *  2. Runtime-caches read-only API responses (standings, teams, etc.) with
+ *     stale-while-revalidate.
+ *  3. Runtime-caches Google Fonts cache-first.
+ *  4. Serves /index.html for SPA navigation requests when offline.
+ *  5. Receives Web Push messages and displays notifications.
+ *  6. Routes notification clicks to the live match view (or app root).
+ *
+ * Deliberately NOT done here:
+ *  - clientsClaim / skipWaiting on install — UpdateAvailablePrompt handles
+ *    new versions explicitly via user click, no surprise reloads.
+ */
+
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
+import { registerRoute, NavigationRoute } from 'workbox-routing';
+import { CacheFirst, StaleWhileRevalidate } from 'workbox-strategies';
+import { CacheableResponsePlugin } from 'workbox-cacheable-response';
+import { ExpirationPlugin } from 'workbox-expiration';
+
+// ---------------------------------------------------------------------------
+// Precache (app shell)
+// ---------------------------------------------------------------------------
+
+precacheAndRoute(self.__WB_MANIFEST);
+
+// SPA navigation fallback — any client-side route serves /index.html so the
+// Vue router can render the right view. /api/* is denylisted so we never
+// shadow real API responses.
+registerRoute(
+  new NavigationRoute(createHandlerBoundToURL('/index.html'), {
+    denylist: [/^\/api\//],
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Runtime caching
+// ---------------------------------------------------------------------------
+
+// Read-only reference + standings APIs. Stale-while-revalidate: serve cache
+// instantly, refresh in background, next render is fresh. NOT cached: auth,
+// writes, live-match state — those need to be live.
+registerRoute(
+  ({ url, request }) =>
+    request.method === 'GET' &&
+    /\/api\/(standings|teams|match-types|seasons|age-groups|divisions|leagues|tournaments|clubs)(\/|\?|$)/.test(
+      url.pathname + url.search
+    ),
+  new StaleWhileRevalidate({
+    cacheName: 'mt-reference-and-standings-v1',
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 * 7 }),
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+    ],
+  }),
+  'GET'
+);
+
+// Google Fonts — versioned URLs, rarely change, cache-first.
+registerRoute(
+  ({ url }) => /^https:\/\/fonts\.(googleapis|gstatic)\.com\/.*/.test(url.href),
+  new CacheFirst({
+    cacheName: 'google-fonts-v1',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 20,
+        maxAgeSeconds: 60 * 60 * 24 * 365,
+      }),
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+    ],
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Update flow
+// ---------------------------------------------------------------------------
+
+// When the page asks us to activate immediately (from UpdateAvailablePrompt's
+// reload button), do it. Otherwise wait for the next natural page load.
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Push notifications (SB-47)
+// ---------------------------------------------------------------------------
+
+self.addEventListener('push', event => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = { title: 'Missing Table', body: event.data?.text?.() ?? '' };
+  }
+
+  const {
+    title = 'Missing Table',
+    body = '',
+    icon = '/pwa/icon-192.png',
+    badge = '/pwa/icon-192.png',
+    tag,
+    data: payloadData,
+  } = data;
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon,
+      badge,
+      tag,
+      data: payloadData,
+      // Match events are time-sensitive — don't sit silent in the background.
+      requireInteraction: false,
+      renotify: false,
+    })
+  );
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const targetUrl = event.notification.data?.url || '/';
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then(windowClients => {
+        // If an MT window is already open, focus it and navigate inside.
+        const scope = self.registration.scope;
+        const existing = windowClients.find(client =>
+          client.url.startsWith(scope)
+        );
+        if (existing) {
+          existing.focus();
+          if ('navigate' in existing) {
+            return existing.navigate(targetUrl);
+          }
+          return;
+        }
+        // Otherwise open a new window/tab at the target URL.
+        return clients.openWindow(targetUrl);
+      })
+  );
+});

--- a/frontend/src/utils/pwa.js
+++ b/frontend/src/utils/pwa.js
@@ -1,0 +1,43 @@
+/**
+ * Shared PWA detection helpers.
+ *
+ * Used by both IosInstallTooltip (decides whether to show the iOS-specific
+ * install instructions) and NotificationsCard (decides whether to gate push
+ * opt-in behind "install to home screen first").
+ */
+
+export function isIosSafari() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+  const ua = navigator.userAgent;
+  const isIos =
+    /iPad|iPhone|iPod/.test(ua) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  if (!isIos) return false;
+  // Exclude in-app browsers (Chrome on iOS / Firefox on iOS / Edge on iOS)
+  // — they share WebKit but don't get the same PWA install affordances.
+  const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua);
+  return isSafari;
+}
+
+export function isStandalone() {
+  if (typeof window === 'undefined') return false;
+  // navigator.standalone is iOS-Safari-specific; matchMedia covers other PWAs.
+  return (
+    window.matchMedia?.('(display-mode: standalone)').matches ||
+    window.navigator.standalone === true
+  );
+}
+
+/**
+ * iOS Safari users that aren't yet running as a standalone PWA.
+ *
+ * On iOS, Web Push requires the site to be installed to the home screen
+ * AND iOS 16.4+. Browsers that aren't standalone can't subscribe even if
+ * the user grants notification permission. UI should surface "install first"
+ * instead of an enable button that silently fails.
+ */
+export function isIosNonStandalone() {
+  return isIosSafari() && !isStandalone();
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,11 +8,14 @@ export default defineConfig({
   plugins: [
     vue(),
     VitePWA({
-      // generateSW: Workbox generates the service worker for us. injectManifest
-      // mode is only needed if we want to ship custom SW code; for slice 3 the
-      // generated SW covers precache + runtime cache cleanly.
-      strategies: 'generateSW',
-      registerType: 'prompt', // shows our UpdateAvailablePrompt instead of auto-reloading
+      // injectManifest: we ship a hand-written SW (frontend/src/sw.js) that
+      // uses Workbox helpers for precache + runtime cache AND adds custom
+      // push + notificationclick event handlers. `generateSW` doesn't allow
+      // custom event handlers, hence the migration in SB-47.
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.js',
+      registerType: 'prompt', // UpdateAvailablePrompt handles new versions
       includeAssets: [
         'pwa/apple-touch-icon-180.png',
         'pwa/pwa-icon-master.png',
@@ -58,49 +61,13 @@ export default defineConfig({
           },
         ],
       },
-      workbox: {
+      injectManifest: {
         // Precache the build output (app shell). Workbox builds the manifest
-        // from these globs at build time.
+        // from these globs at build time and injects it into sw.js via
+        // self.__WB_MANIFEST.
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
-        // Don't try to precache the giant master icon source (only used for SB-45 swap).
+        // Don't precache the giant master icon source (only used for SB-45 swap).
         globIgnores: ['**/pwa/pwa-icon-master.png'],
-        // SPA fallback: any navigation request not matched by a precached file
-        // should serve /index.html (so client-side routes work offline).
-        navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api\//],
-        // Runtime caching for read-only API endpoints. Stale-while-revalidate:
-        // serve cache instantly, refresh in background, next render is fresh.
-        // Skipped: auth, write endpoints, live-match state (push keeps that fresh).
-        runtimeCaching: [
-          {
-            urlPattern: ({ url, request }) =>
-              request.method === 'GET' &&
-              /\/api\/(standings|teams|match-types|seasons|age-groups|divisions|leagues|tournaments|clubs)(\/|\?|$)/.test(
-                url.pathname + url.search
-              ),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: 'mt-reference-and-standings-v1',
-              expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 * 7 }, // 7 days
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-          {
-            // Google Fonts — cache-first since they're versioned URLs and rarely change.
-            urlPattern: /^https:\/\/fonts\.(googleapis|gstatic)\.com\/.*/,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'google-fonts-v1',
-              expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 365 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-        ],
-        // Don't take over the page immediately on first install — let it become
-        // the controller on the next nav. UpdateAvailablePrompt handles new
-        // versions explicitly.
-        clientsClaim: false,
-        skipWaiting: false,
       },
       devOptions: {
         // Don't enable the SW in `vite dev` by default. SW + HMR fight each


### PR DESCRIPTION
Closes [SB-47](https://linear.app/silverbeer/issue/SB-47). PR 2 of the push notifications work for [SB-44](https://linear.app/silverbeer/issue/SB-44).

## Summary
With SB-51 (backend) deployed and SB-50 (VAPID secrets) active, this PR lets users actually opt in and receive notifications. Three pieces:

1. **SW migration** from `generateSW` → `injectManifest` so we can ship a hand-written `src/sw.js` with custom `push` + `notificationclick` handlers (Workbox's auto-generated SW doesn't support these).
2. **Profile-page notifications card** mounted in `ProfileRouter.vue` so all 5 role profiles get the same surface.
3. **Push opt-in flow** (`usePushNotifications` composable): permission prompt → VAPID public-key fetch → `PushManager.subscribe()` → POST to `/api/users/me/push-subscriptions`.

## What changed

### Service worker
- `frontend/vite.config.js` — `strategies: 'injectManifest'`, `srcDir: 'src'`, `filename: 'sw.js'`.
- **`frontend/src/sw.js`** — new hand-written SW. Replicates all prior behavior (precache app shell, SWR for reference/standings APIs, cache-first Google Fonts, SPA navigation fallback, SKIP_WAITING channel for `UpdateAvailablePrompt`). Adds:
  - **`push` handler**: parses JSON payload, displays notification with `title`/`body`/`icon`/`tag`. Uses `tag` to collapse consecutive same-type events for one match.
  - **`notificationclick` handler**: focuses an existing MT window and navigates to `data.url`, or opens a new tab.

### Composable
- `frontend/src/composables/usePushNotifications.js` — wraps Push API + backend registration. Reactive `isSupported`/`isEnabled`/`isBlocked`/`isIosBlocked`/`loading`/`lastError`. Imperative `enable`/`disable`/`sendTest`/`listSubscriptions`/`listFollows`.

### Shared helpers
- `frontend/src/utils/pwa.js` — extracted `isIosSafari` / `isStandalone` / `isIosNonStandalone` from `IosInstallTooltip` so both components share one source of truth.

### Component
- **`frontend/src/components/notifications/NotificationsCard.vue`** — notification preferences UI. Permission states:
  - **iOS Safari not standalone** → amber "Install MT to home screen first" gate (iOS won't allow subscription otherwise)
  - **Permission denied** → red "Open browser settings to re-enable" with no nag
  - **Unsupported browser** → muted info
  - **Default** → primary "Enable" button
  - **Enabled** → green pill + "Send test notification" button
  Plus a manage-devices list (revoke per row) and a read-only followed-teams summary (the actual follow toggle lives on team pages — PR 3).

### Mount
- `frontend/src/components/ProfileRouter.vue` — imports `NotificationsCard` and renders it once after the per-role profile so admin, club_manager, team_manager, player, and fan all get the same notification surface.

## Test plan

Per `feedback_mobile_first_ui.md`, both desktop and mobile.

**Desktop (Mac Chrome — fastest end-to-end)**
- [ ] Build outputs `dist/sw.js` (via injectManifest, no warnings)
- [ ] DevTools → Application → Service Workers shows the new SW activated (after `UpdateAvailablePrompt` reload, since the old SW persists by design)
- [ ] Profile tab shows the Notifications card. State: "Enable push notifications on this device"
- [ ] Click Enable → browser permission prompt → grant → state flips to "Notifications enabled on this device". A subscription row appears in `push_subscriptions` (verify via Supabase)
- [ ] Click "Send test notification" → notification appears within ~2 sec. Click it → page focuses
- [ ] Manage devices list shows the registered device with a Revoke button. Click → device removed from the table
- [ ] Goal flow: as admin, start a live match for a team the test account follows (manual `INSERT INTO user_team_follows` for now since PR 3 ships the UI) → post a goal → push lands on the device. **Click notification → opens the live match view**

**Pixel 10 (via chrome://inspect)**
- [ ] After installing the new build, the Notifications card appears in Profile
- [ ] Enable → permission prompt → grant → enabled state
- [ ] Test notification arrives
- [ ] Goal notification arrives end-to-end

**iOS Simulator + a kid's iPhone (real device only — Simulator can't actually receive push)**
- [ ] On iOS Safari without standalone: card shows the "install first" amber warn (not the enable button)
- [ ] After installing to home screen and re-opening from icon: the warn disappears, Enable button appears
- [ ] Enable + grant → standard flow; test push arrives on the real iPhone

## Risks
1. **Update prompt for every existing PWA user on first deploy after this change** — the SW is a different file (generated → hand-written), so every active SW will trigger `UpdateAvailablePrompt`. Expected; communicate if release notes are public.
2. **Push only arrives if SB-50's VAPID secrets are populated** — verify `curl https://api.missingtable.com/api/push/vapid-public-key` returns 200 before testing. 503 = still dormant.
3. **iOS gating depends on browser UA sniffing** — if Apple changes iOS Safari UA in the future, `isIosSafari` may need an update. Captured in `utils/pwa.js` for centralized maintenance.

## What's NOT in this PR
- Follow-team button on team pages (**PR 3** — the user-facing way to add follows. Until that ships, follows must be inserted manually via SQL or the API for testing).
- Per-event toggles (v2 — firehose-on-followed-team in v1).
- Card events (skipped in v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)