### PR TITLE
fix(push): gate enabled-pill on backend subscription confirmation (SB-52)

### DIFF
--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -17,6 +17,13 @@ import { isIosNonStandalone } from '../utils/pwa';
 
 const isSupported = ref(false);
 const permission = ref('default'); // 'default' | 'granted' | 'denied' | 'unsupported'
+// `null` = unknown (haven't asked backend yet), `true` = backend has at least
+// one subscription for this user, `false` = backend has none. We need this
+// because Notification.permission flips to 'granted' the instant the user
+// clicks Allow — but the actual end-to-end registration (subscribe + POST)
+// may still fail downstream. Using permission alone for the "enabled" pill
+// caused SB-52 (UI looked enabled while backend had nothing).
+const hasBackendSubscription = ref(null);
 let initialized = false;
 
 function detectSupport() {
@@ -80,8 +87,15 @@ export function usePushNotifications() {
   const loading = ref(false);
   const lastError = ref(null);
 
+  // "Enabled" means the full chain landed: browser permission granted AND
+  // the backend confirmed it has a subscription for this user/device. Using
+  // permission alone caused SB-52 (pill showed enabled while backend had nothing
+  // because the prior POST silently failed).
   const isEnabled = computed(
-    () => isSupported.value && permission.value === 'granted'
+    () =>
+      isSupported.value &&
+      permission.value === 'granted' &&
+      hasBackendSubscription.value === true
   );
   const isBlocked = computed(() => permission.value === 'denied');
   const isIosBlocked = computed(
@@ -173,6 +187,7 @@ export function usePushNotifications() {
         }
       );
 
+      hasBackendSubscription.value = true;
       return { success: true, subscription: created };
     } catch (err) {
       lastError.value = err.message || String(err);
@@ -198,6 +213,7 @@ export function usePushNotifications() {
       } catch {
         // ignore — backend revoke is the authoritative action.
       }
+      hasBackendSubscription.value = false;
       return { success: true };
     } catch (err) {
       lastError.value = err.message || String(err);
@@ -212,9 +228,17 @@ export function usePushNotifications() {
       const data = await authStore.apiRequest(
         `${getApiBaseUrl()}/api/users/me/push-subscriptions`
       );
-      return data?.subscriptions || [];
+      const subs = data?.subscriptions || [];
+      // This is the authoritative truth-source for whether the backend has
+      // a subscription for this user. Sync the reactive flag so the UI
+      // doesn't trust permission alone.
+      hasBackendSubscription.value = subs.length > 0;
+      return subs;
     } catch (err) {
       lastError.value = err.message || String(err);
+      // On fetch failure, assume no backend subscription so the UI shows
+      // Enable instead of a misleading enabled pill.
+      hasBackendSubscription.value = false;
       return [];
     }
   }


### PR DESCRIPTION
Closes [SB-52](https://linear.app/silverbeer/issue/SB-52). Follow-up to [SB-47](https://linear.app/silverbeer/issue/SB-47) (PR #406, already merged).

## The bug

When the backend POST to register a push subscription fails for any reason (today: prod migration hadn't been applied yet), \`Notification.permission\` still flips to \`'granted'\` the instant the user clicks Allow on the OS prompt. The pill was bound to \`permission\` alone, so the UI showed:

- ✅ "Notifications enabled on this device"
- ✅ "Send test notification" button
- ❌ Enable button hidden (because \`isEnabled === true\`)

…while the backend had no record of the device. The user had no UI path to retry the registration. Caught in real-world testing right after PR #406 deployed.

## The fix

Add reactive \`hasBackendSubscription\` (initial \`null\` = unknown). \`isEnabled\` now requires **both** \`permission === 'granted'\` **AND** \`hasBackendSubscription === true\`.

State transitions:
- \`listSubscriptions()\` sets it to \`subs.length > 0\` (authoritative truth-source).
- \`enable()\` sets it \`true\` on successful backend POST.
- \`disable()\` sets it \`false\` on successful backend DELETE.
- On initial fetch failure, sets it \`false\` so the UI shows "Enable" instead of a misleading enabled pill.

## Trade-off

Brief flicker on first load while \`listSubscriptions\` resolves — the Enable button appears for a moment, then flips to the enabled pill for already-subscribed users. Worth it; the alternative (showing pill while unknown) is what caused this bug.

## Files
- \`frontend/src/composables/usePushNotifications.js\` — only file changed.

## Test plan
- [ ] Fresh user (no backend subscription): permission already granted from earlier failed attempt → page loads → "Enable push notifications" button shows (not pill). Click → flow completes → pill shows.
- [ ] Existing user (backend has subscription): page loads → brief flicker → pill shows. No regression.
- [ ] Revoke + re-enable round trip works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)