### PR TITLE
hotfix: disambiguate user_profiles → teams join after SB-51 migration

### DIFF
--- a/backend/dao/player_dao.py
+++ b/backend/dao/player_dao.py
@@ -35,12 +35,23 @@ class PlayerDAO(BaseDAO):
             User profile dict with team data, or None if not found
         """
         try:
+            # Explicit FK names required: SB-51's user_team_follows table created
+            # a many-to-many path between user_profiles and teams in addition to
+            # the direct team_id FK, which makes PostgREST throw PGRST201 unless
+            # we name the relationship we want. Same hint needed for `clubs`
+            # because user_profiles has both a direct club_id FK and a path via
+            # teams.club_id (also detected as ambiguous).
             response = (
                 self.client.table("user_profiles")
                 .select("""
                 *,
-                team:teams(id, name, city, club:clubs(id, name, primary_color, secondary_color, logo_url)),
-                club:clubs(id, name, primary_color, secondary_color, logo_url)
+                team:teams!user_profiles_team_id_fkey(
+                    id, name, city,
+                    club:clubs(id, name, primary_color, secondary_color, logo_url)
+                ),
+                club:clubs!user_profiles_club_id_fkey(
+                    id, name, primary_color, secondary_color, logo_url
+                )
             """)
                 .eq("id", user_id)
                 .execute()
@@ -150,11 +161,12 @@ class PlayerDAO(BaseDAO):
             List of user profile dicts
         """
         try:
+            # Explicit FK name: see comment in get_user_profile_with_relationships.
             response = (
                 self.client.table("user_profiles")
                 .select("""
                 *,
-                team:teams(id, name, city)
+                team:teams!user_profiles_team_id_fkey(id, name, city)
             """)
                 .order("created_at", desc=True)
                 .execute()
@@ -615,7 +627,7 @@ class PlayerDAO(BaseDAO):
                 profile_photo_slot,
                 team_id,
                 created_at,
-                team:teams(id, name, club_id)
+                team:teams!user_profiles_team_id_fkey(id, name, club_id)
                 """,
                     count="exact",
                 )


### PR DESCRIPTION
**Severity: prod broken — every authenticated user appears as \`team-fan\` in the UI right now, including admins.**

Closes SB-54. Caused by PR #405 (SB-51).

## Root cause

PR #405's migration added \`user_team_follows (user_id → user_profiles, team_id → teams)\` — a second PostgREST-detectable relationship between \`user_profiles\` and \`teams\` on top of the existing direct \`user_profiles.team_id → teams.id\` FK.

\`player_dao.get_user_profile_with_relationships\` does \`.select("*, team:teams(...), club:clubs(...)").eq("id", user_id)\` and started failing with:
\`\`\`
PGRST201: Could not embed because more than one relationship was found
Hint: teams!user_profiles_team_id_fkey OR teams!user_team_follows
\`\`\`

The DAO's bare \`except\` swallows the error and returns None. \`/api/auth/me\`:
\`\`\`python
profile = player_dao.get_user_profile_with_relationships(user_id) or {}
role = profile.get("role", "team-fan")  # ← fallback fires, every user becomes team-fan
\`\`\`

## Fix

Add explicit \`!fk_name\` hint to the three affected queries in \`backend/dao/player_dao.py\`:
- \`get_user_profile_with_relationships\` (line 39) — fixes /api/auth/me
- \`get_all_user_profiles\` (line 154)
- \`get_player_listing\` (line ~618)

Also disambiguated the \`clubs\` join (similar ambiguity: direct \`club_id\` FK vs indirect via \`teams.club_id\`).

Other DAOs (match_dao, team_dao, roster_dao) already used explicit FK syntax — only player_dao was exposed.

## Verification after merge + deploy
\`\`\`bash
# Should return role: admin for tom
curl -s "https://api.missingtable.com/api/auth/me" \\
  -H "Authorization: Bearer <tom-jwt>" | jq '.user.profile.role'
\`\`\`

Also check backend logs go silent on the PGRST201 errors:
\`\`\`bash
kubectl logs -n missing-table -l app=missing-table-backend --tail=200 | grep PGRST201
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)