### PR TITLE
feat(notifications): in-app Follow team button (SB-55)

### DIFF
--- a/frontend/src/__tests__/components/FollowButton.spec.js
+++ b/frontend/src/__tests__/components/FollowButton.spec.js
@@ -1,0 +1,207 @@
+/**
+ * FollowButton.vue tests (SB-55).
+ *
+ * Covers:
+ * - Hidden entirely when unauthenticated (v1 decision — no login funnel)
+ * - "Follow" label when not following, "Following" when following
+ * - Click toggles state optimistically
+ * - is-following class applied so the visual state is testable
+ * - Disabled while a toggle is in flight (no double-fire)
+ * - Mobile tap target — min-height 44px (covered via existing CSS; we just
+ *   assert the data-testid exists so the selector is stable for e2e too)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const isAuthenticatedRef = { value: true };
+const apiRequestMock = vi.fn();
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: isAuthenticatedRef,
+    apiRequest: apiRequestMock,
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+import FollowButton from '@/components/notifications/FollowButton.vue';
+import { _resetTeamFollowsForTest } from '@/composables/useTeamFollows';
+
+beforeEach(() => {
+  apiRequestMock.mockReset();
+  isAuthenticatedRef.value = true;
+  _resetTeamFollowsForTest();
+});
+
+const mountButton = (props = {}) =>
+  mount(FollowButton, {
+    props: { teamId: 42, teamName: 'Test FC', ...props },
+  });
+
+describe('FollowButton visibility', () => {
+  it('renders nothing when the user is not authenticated', async () => {
+    isAuthenticatedRef.value = false;
+    apiRequestMock.mockResolvedValue({ follows: [] });
+
+    const wrapper = mountButton();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="follow-button"]').exists()).toBe(false);
+    // No GET fired either (composable bails on unauth).
+    expect(apiRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the button when the user is authenticated', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    const wrapper = mountButton();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="follow-button"]').exists()).toBe(true);
+  });
+});
+
+describe('FollowButton label + state', () => {
+  it('shows "Follow" when not currently following the team', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    const wrapper = mountButton({ teamId: 42 });
+    await flushPromises();
+
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.text()).toContain('Follow');
+    expect(btn.classes()).not.toContain('is-following');
+    expect(btn.attributes('aria-pressed')).toBe('false');
+  });
+
+  it('shows "Following" when the user already follows the team', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 42, team: { name: 'Test FC' } }],
+    });
+    const wrapper = mountButton({ teamId: 42 });
+    await flushPromises();
+
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.text()).toContain('Following');
+    expect(btn.classes()).toContain('is-following');
+    expect(btn.attributes('aria-pressed')).toBe('true');
+  });
+});
+
+describe('FollowButton click', () => {
+  it('POSTs to /team-follows and flips to Following on success', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // initial GET
+    apiRequestMock.mockResolvedValueOnce({ team_id: 42, following: true }); // POST
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 42, team: {} }],
+    }); // refresh
+
+    const wrapper = mountButton({ teamId: 42 });
+    await flushPromises();
+
+    await wrapper.find('[data-testid="follow-button"]').trigger('click');
+    await flushPromises();
+
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      'http://test.example/api/users/me/team-follows',
+      { method: 'POST', body: JSON.stringify({ team_id: 42 }) }
+    );
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.text()).toContain('Following');
+    expect(btn.classes()).toContain('is-following');
+  });
+
+  it('DELETEs and flips back to Follow when already following', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 42, team: {} }],
+    });
+    apiRequestMock.mockResolvedValueOnce(null); // DELETE
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // refresh
+
+    const wrapper = mountButton({ teamId: 42 });
+    await flushPromises();
+
+    await wrapper.find('[data-testid="follow-button"]').trigger('click');
+    await flushPromises();
+
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      'http://test.example/api/users/me/team-follows/42',
+      { method: 'DELETE' }
+    );
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.text()).toContain('Follow');
+    expect(btn.classes()).not.toContain('is-following');
+  });
+
+  it('reverts to previous state when the toggle request fails', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    apiRequestMock.mockRejectedValueOnce(new Error('network'));
+
+    const wrapper = mountButton({ teamId: 42 });
+    await flushPromises();
+
+    await wrapper.find('[data-testid="follow-button"]').trigger('click');
+    await flushPromises();
+
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.text()).toContain('Follow');
+    expect(btn.classes()).not.toContain('is-following');
+  });
+
+  it('ignores rapid double-clicks (button disabled while in flight)', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    // POST resolves after a tick so the button is disabled in the window.
+    let resolvePost;
+    apiRequestMock.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolvePost = () => resolve({ team_id: 42, following: true });
+        })
+    );
+
+    const wrapper = mountButton({ teamId: 42 });
+    await flushPromises();
+
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    await btn.trigger('click');
+    // Second click while busy.
+    await btn.trigger('click');
+
+    expect(btn.attributes('disabled')).toBeDefined();
+    // Only 2 calls: initial GET + 1 POST (second click was suppressed).
+    expect(apiRequestMock).toHaveBeenCalledTimes(2);
+
+    // Drain the in-flight call so subsequent tests don't see a stray promise.
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // refresh after POST
+    resolvePost();
+    await flushPromises();
+  });
+});
+
+describe('FollowButton aria-label', () => {
+  it('reads "Follow {teamName}" when not following', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    const wrapper = mountButton({ teamId: 5, teamName: 'IFA' });
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="follow-button"]').attributes('aria-label')
+    ).toBe('Follow IFA');
+  });
+
+  it('reads "Unfollow {teamName}" when already following', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 5, team: {} }],
+    });
+    const wrapper = mountButton({ teamId: 5, teamName: 'IFA' });
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="follow-button"]').attributes('aria-label')
+    ).toBe('Unfollow IFA');
+  });
+});

--- a/frontend/src/__tests__/composables/useTeamFollows.spec.js
+++ b/frontend/src/__tests__/composables/useTeamFollows.spec.js
@@ -1,0 +1,239 @@
+/**
+ * useTeamFollows tests (SB-55).
+ *
+ * Singleton composable — module-level reactive state persists across calls.
+ * Reset via _resetTeamFollowsForTest between cases.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const isAuthenticatedRef = { value: true };
+const apiRequestMock = vi.fn();
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: isAuthenticatedRef,
+    apiRequest: apiRequestMock,
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+import {
+  useTeamFollows,
+  _resetTeamFollowsForTest,
+} from '@/composables/useTeamFollows';
+
+beforeEach(() => {
+  apiRequestMock.mockReset();
+  isAuthenticatedRef.value = true;
+  _resetTeamFollowsForTest();
+});
+
+describe('useTeamFollows.ensureLoaded', () => {
+  it('hits GET /team-follows once and populates followedTeamIds', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [
+        { team_id: 7, team: { name: 'A' } },
+        { team_id: 9, team: { name: 'B' } },
+      ],
+    });
+
+    const { ensureLoaded, isFollowing, loaded } = useTeamFollows();
+    await ensureLoaded();
+
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'http://test.example/api/users/me/team-follows'
+    );
+    expect(loaded.value).toBe(true);
+    expect(isFollowing(7)).toBe(true);
+    expect(isFollowing(9)).toBe(true);
+    expect(isFollowing(11)).toBe(false);
+  });
+
+  it('does not refetch when already loaded', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+
+    const a = useTeamFollows();
+    await a.ensureLoaded();
+    await a.ensureLoaded();
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent ensureLoaded calls into one fetch', async () => {
+    apiRequestMock.mockImplementationOnce(
+      () =>
+        new Promise(resolve => setTimeout(() => resolve({ follows: [] }), 5))
+    );
+
+    const a = useTeamFollows();
+    await Promise.all([a.ensureLoaded(), a.ensureLoaded(), a.ensureLoaded()]);
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the fetch when user is not authenticated', async () => {
+    isAuthenticatedRef.value = false;
+    const { ensureLoaded, loaded } = useTeamFollows();
+    await ensureLoaded();
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(loaded.value).toBe(true);
+  });
+});
+
+describe('useTeamFollows.follow', () => {
+  it('optimistically marks following + POSTs the team_id', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // initial GET
+    apiRequestMock.mockResolvedValueOnce({ team_id: 42, following: true }); // POST
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 42, team: { name: 'X' } }],
+    }); // background refresh
+
+    const { ensureLoaded, follow, isFollowing } = useTeamFollows();
+    await ensureLoaded();
+
+    const result = await follow(42);
+    expect(result).toEqual({ success: true });
+    expect(isFollowing(42)).toBe(true);
+
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      'http://test.example/api/users/me/team-follows',
+      { method: 'POST', body: JSON.stringify({ team_id: 42 }) }
+    );
+  });
+
+  it('reverts optimistic state and returns error when POST fails', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    apiRequestMock.mockRejectedValueOnce(new Error('boom'));
+
+    const { ensureLoaded, follow, isFollowing, error } = useTeamFollows();
+    await ensureLoaded();
+
+    const result = await follow(7);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('boom');
+    expect(isFollowing(7)).toBe(false);
+    expect(error.value).toBe('boom');
+  });
+
+  it('is idempotent — no second POST when already following', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 3, team: {} }],
+    });
+
+    const { ensureLoaded, follow } = useTeamFollows();
+    await ensureLoaded();
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+
+    await follow(3);
+    // Still only the initial GET — no POST fired.
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts string team ids and normalizes to number', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    apiRequestMock.mockResolvedValueOnce({ team_id: 5, following: true });
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 5, team: {} }],
+    });
+
+    const { ensureLoaded, follow, isFollowing } = useTeamFollows();
+    await ensureLoaded();
+    await follow('5');
+
+    expect(isFollowing(5)).toBe(true);
+    expect(isFollowing('5')).toBe(true);
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({ body: JSON.stringify({ team_id: 5 }) })
+    );
+  });
+});
+
+describe('useTeamFollows.unfollow', () => {
+  it('optimistically clears + DELETEs /team-follows/{id}', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 8, team: {} }],
+    });
+    apiRequestMock.mockResolvedValueOnce(null); // DELETE returns 204 → null
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // refresh
+
+    const { ensureLoaded, unfollow, isFollowing } = useTeamFollows();
+    await ensureLoaded();
+    expect(isFollowing(8)).toBe(true);
+
+    await unfollow(8);
+    expect(isFollowing(8)).toBe(false);
+
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      'http://test.example/api/users/me/team-follows/8',
+      { method: 'DELETE' }
+    );
+  });
+
+  it('restores state when DELETE fails', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 8, team: {} }],
+    });
+    apiRequestMock.mockRejectedValueOnce(new Error('nope'));
+
+    const { ensureLoaded, unfollow, isFollowing } = useTeamFollows();
+    await ensureLoaded();
+
+    const result = await unfollow(8);
+    expect(result.success).toBe(false);
+    expect(isFollowing(8)).toBe(true);
+  });
+
+  it('is a no-op when not currently following', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+
+    const { ensureLoaded, unfollow } = useTeamFollows();
+    await ensureLoaded();
+    await unfollow(99);
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1); // only initial GET
+  });
+});
+
+describe('useTeamFollows.toggle', () => {
+  it('follows then unfollows on successive calls', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    apiRequestMock.mockResolvedValueOnce({ team_id: 1, following: true });
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 1, team: {} }],
+    });
+    apiRequestMock.mockResolvedValueOnce(null);
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+
+    const { ensureLoaded, toggle, isFollowing } = useTeamFollows();
+    await ensureLoaded();
+
+    await toggle(1);
+    expect(isFollowing(1)).toBe(true);
+
+    await toggle(1);
+    expect(isFollowing(1)).toBe(false);
+  });
+});
+
+describe('useTeamFollows singleton behavior', () => {
+  it('shares state across multiple useTeamFollows() callers', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [{ team_id: 12, team: {} }],
+    });
+
+    const a = useTeamFollows();
+    await a.ensureLoaded();
+
+    const b = useTeamFollows();
+    expect(b.isFollowing(12)).toBe(true);
+    expect(b.follows.value).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/notifications/FollowButton.vue
+++ b/frontend/src/components/notifications/FollowButton.vue
@@ -1,0 +1,160 @@
+<template>
+  <button
+    v-if="visible"
+    type="button"
+    class="follow-button"
+    :class="{ 'is-following': following, 'is-busy': busy }"
+    :disabled="busy"
+    :aria-pressed="following"
+    :aria-label="
+      following
+        ? `Unfollow ${teamName || 'team'}`
+        : `Follow ${teamName || 'team'}`
+    "
+    data-testid="follow-button"
+    @click="onClick"
+  >
+    <svg
+      v-if="!following"
+      class="follow-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+      />
+    </svg>
+    <svg
+      v-else
+      class="follow-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M16.704 5.293a1 1 0 010 1.414l-7.5 7.5a1 1 0 01-1.414 0l-3.5-3.5a1 1 0 011.414-1.414L8.5 12.086l6.79-6.793a1 1 0 011.414 0z"
+        clip-rule="evenodd"
+      />
+    </svg>
+    <span class="follow-label">{{ label }}</span>
+  </button>
+</template>
+
+<script setup>
+import { computed, ref, onMounted } from 'vue';
+import { useAuthStore } from '../../stores/auth';
+import { useTeamFollows } from '../../composables/useTeamFollows';
+
+const props = defineProps({
+  teamId: { type: [Number, String], required: true },
+  teamName: { type: String, default: '' },
+});
+
+const authStore = useAuthStore();
+const { isFollowing, toggle, ensureLoaded, loaded } = useTeamFollows();
+
+const busy = ref(false);
+
+// Hide entirely when unauthenticated (v1 decision — no login funnel).
+const visible = computed(() => authStore.isAuthenticated.value);
+
+const following = computed(() => isFollowing(props.teamId));
+
+const label = computed(() => {
+  if (busy.value) return following.value ? 'Following…' : 'Following…';
+  return following.value ? 'Following' : 'Follow';
+});
+
+async function onClick() {
+  if (busy.value) return;
+  busy.value = true;
+  try {
+    await toggle(props.teamId);
+  } finally {
+    busy.value = false;
+  }
+}
+
+onMounted(() => {
+  if (visible.value && !loaded.value) ensureLoaded();
+});
+</script>
+
+<style scoped>
+.follow-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  min-height: 44px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  background: rgba(255, 255, 255, 0.95);
+  color: #1f2937;
+  border: 1.5px solid rgba(255, 255, 255, 0.95);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.05s ease;
+  /* Sit on the dark team-header gradient; keep it readable. */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.follow-button:hover:not(:disabled) {
+  background: white;
+  transform: translateY(-1px);
+}
+
+.follow-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.follow-button:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.follow-button.is-following {
+  background: rgba(16, 185, 129, 0.95);
+  border-color: rgba(16, 185, 129, 0.95);
+  color: white;
+}
+
+.follow-button.is-following:hover:not(:disabled) {
+  background: rgb(5, 150, 105);
+  border-color: rgb(5, 150, 105);
+}
+
+.follow-button.is-busy {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.follow-button:disabled {
+  cursor: not-allowed;
+}
+
+.follow-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.follow-label {
+  white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .follow-button {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+}
+</style>

--- a/frontend/src/components/notifications/NotificationsCard.vue
+++ b/frontend/src/components/notifications/NotificationsCard.vue
@@ -106,6 +106,7 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import { usePushNotifications } from '../../composables/usePushNotifications';
+import { useTeamFollows } from '../../composables/useTeamFollows';
 
 const {
   isSupported,
@@ -117,22 +118,19 @@ const {
   enable,
   disable,
   listSubscriptions,
-  listFollows,
   sendTest,
 } = usePushNotifications();
 
+// Shared singleton (SB-55): same `follows` reactive list every FollowButton mutates.
+const { follows, refresh: refreshFollows } = useTeamFollows();
+
 const subscriptions = ref([]);
-const follows = ref([]);
 const lastMessage = ref('');
 
 async function refresh() {
   if (!isSupported.value) return;
-  const [subs, follows_] = await Promise.all([
-    listSubscriptions(),
-    listFollows(),
-  ]);
+  const [subs] = await Promise.all([listSubscriptions(), refreshFollows()]);
   subscriptions.value = subs;
-  follows.value = follows_;
 }
 
 async function onEnable() {

--- a/frontend/src/components/profiles/TeamRosterPage.vue
+++ b/frontend/src/components/profiles/TeamRosterPage.vue
@@ -125,6 +125,12 @@
             </svg>
             {{ team.division.name }}
           </span>
+          <!-- Follow button (SB-55) -->
+          <FollowButton
+            v-if="team?.id"
+            :team-id="team.id"
+            :team-name="team.name || ''"
+          />
         </div>
 
         <!-- Player count -->
@@ -184,11 +190,13 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '@/config/api';
 import PlayerCard from './PlayerCard.vue';
+import FollowButton from '@/components/notifications/FollowButton.vue';
 
 export default {
   name: 'TeamRosterPage',
   components: {
     PlayerCard,
+    FollowButton,
   },
   emits: ['viewPlayer'],
   setup(props, { emit }) {

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -260,18 +260,6 @@ export function usePushNotifications() {
     }
   }
 
-  async function listFollows() {
-    try {
-      const data = await authStore.apiRequest(
-        `${getApiBaseUrl()}/api/users/me/team-follows`
-      );
-      return data?.follows || [];
-    } catch (err) {
-      lastError.value = err.message || String(err);
-      return [];
-    }
-  }
-
   return {
     // reactive state
     isSupported,
@@ -286,6 +274,5 @@ export function usePushNotifications() {
     disable,
     listSubscriptions,
     sendTest,
-    listFollows,
   };
 }

--- a/frontend/src/composables/useTeamFollows.js
+++ b/frontend/src/composables/useTeamFollows.js
@@ -1,0 +1,151 @@
+/**
+ * Team-follows composable (SB-55).
+ *
+ * Singleton reactive state shared by every FollowButton instance and the
+ * NotificationsCard "Teams you follow" list. Mirrors the useAuthStore
+ * pattern: module-level reactive state, useTeamFollows() returns the
+ * same refs every call.
+ *
+ * Backend endpoints (already shipped via SB-51, all idempotent):
+ *   GET    /api/users/me/team-follows           → { follows: [{ team_id, team, ... }] }
+ *   POST   /api/users/me/team-follows           → 201 { team_id, following: true }
+ *   DELETE /api/users/me/team-follows/{id}      → 204
+ */
+
+import { reactive, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+
+const state = reactive({
+  followedTeamIds: new Set(),
+  follows: [],
+  loaded: false,
+  loading: false,
+  error: null,
+});
+
+let inflightLoad = null;
+
+async function fetchFollows() {
+  const authStore = useAuthStore();
+  if (!authStore.isAuthenticated.value) {
+    state.followedTeamIds = new Set();
+    state.follows = [];
+    state.loaded = true;
+    return;
+  }
+
+  state.loading = true;
+  state.error = null;
+  try {
+    const data = await authStore.apiRequest(
+      `${getApiBaseUrl()}/api/users/me/team-follows`
+    );
+    const rows = data?.follows || [];
+    state.follows = rows;
+    state.followedTeamIds = new Set(rows.map(r => r.team_id));
+    state.loaded = true;
+  } catch (err) {
+    state.error = err.message || String(err);
+    state.followedTeamIds = new Set();
+    state.follows = [];
+  } finally {
+    state.loading = false;
+  }
+}
+
+export function useTeamFollows() {
+  const authStore = useAuthStore();
+
+  const ensureLoaded = () => {
+    if (state.loaded || state.loading) return inflightLoad || Promise.resolve();
+    inflightLoad = fetchFollows().finally(() => {
+      inflightLoad = null;
+    });
+    return inflightLoad;
+  };
+
+  const refresh = () => {
+    inflightLoad = fetchFollows().finally(() => {
+      inflightLoad = null;
+    });
+    return inflightLoad;
+  };
+
+  const isFollowing = teamId => state.followedTeamIds.has(Number(teamId));
+
+  const follow = async teamId => {
+    const id = Number(teamId);
+    if (state.followedTeamIds.has(id)) return { success: true };
+
+    // Optimistic
+    state.followedTeamIds.add(id);
+    state.error = null;
+    try {
+      await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/team-follows`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ team_id: id }),
+        }
+      );
+      // Refresh in background so the joined team/club data appears in
+      // NotificationsCard's "Teams you follow" list.
+      refresh();
+      return { success: true };
+    } catch (err) {
+      state.followedTeamIds.delete(id);
+      state.error = err.message || String(err);
+      return { success: false, error: state.error };
+    }
+  };
+
+  const unfollow = async teamId => {
+    const id = Number(teamId);
+    if (!state.followedTeamIds.has(id)) return { success: true };
+
+    // Optimistic
+    state.followedTeamIds.delete(id);
+    state.error = null;
+    try {
+      await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/team-follows/${id}`,
+        { method: 'DELETE' }
+      );
+      refresh();
+      return { success: true };
+    } catch (err) {
+      state.followedTeamIds.add(id);
+      state.error = err.message || String(err);
+      return { success: false, error: state.error };
+    }
+  };
+
+  const toggle = async teamId => {
+    return isFollowing(teamId) ? unfollow(teamId) : follow(teamId);
+  };
+
+  return {
+    follows: computed(() => state.follows),
+    followedTeamIds: computed(() => state.followedTeamIds),
+    loaded: computed(() => state.loaded),
+    loading: computed(() => state.loading),
+    error: computed(() => state.error),
+    ensureLoaded,
+    refresh,
+    isFollowing,
+    follow,
+    unfollow,
+    toggle,
+  };
+}
+
+// Test-only: reset module-level singleton between tests.
+export function _resetTeamFollowsForTest() {
+  state.followedTeamIds = new Set();
+  state.follows = [];
+  state.loaded = false;
+  state.loading = false;
+  state.error = null;
+  inflightLoad = null;
+}


### PR DESCRIPTION
Closes SB-55. PR 3 of the SB-44 mobile epic — the last user-facing piece of the push-notification stack.

## Summary
- New `FollowButton.vue` in `components/notifications/` — pill toggle ("Follow" → "✓ Following"), 44px tap target, optimistic update with revert on error, hidden when unauthenticated (v1 — no login funnel).
- New `useTeamFollows.js` composable — singleton reactive `Set<teamId>` mirroring the `useAuthStore` pattern. Every `FollowButton` instance + the `NotificationsCard` "Teams you follow" list share one source of truth, no prop-drilling.
- Mounted in `TeamRosterPage.vue` badges row, next to Age Group / Academy / Division.
- `NotificationsCard` now reads `follows` from the shared composable instead of fetching its own. Dead `listFollows` removed from `usePushNotifications`.

No backend changes — the endpoints from SB-51 (`POST` / `DELETE` / `GET /api/users/me/team-follows`) are already deployed and idempotent.

## Tests
- 23 new specs: 13 composable + 10 component.
- Coverage: optimistic update + revert on error, idempotent follow/unfollow, click suppression while a request is in flight, hidden when unauth, ARIA labels, singleton state sharing across multiple `useTeamFollows()` callers.
- Full suite: 368/368 ✅
- Lint: ✅

## Test plan
Per `feedback_mobile_first_ui.md` — both desktop and mobile required.

**Desktop (Mac Chrome)**
- [ ] Log in as a regular user. Open Profile → My Club.
- [ ] Switch via the Club Teams dropdown to a sibling team you don't follow → "Follow" pill visible in the badges row.
- [ ] Click → flips to "✓ Following" optimistically. DevTools shows `POST /api/users/me/team-follows` 201.
- [ ] Refresh the page → still shows "Following" (state persisted, re-fetched on mount).
- [ ] Click again → unfollows, DELETE 204.
- [ ] Open Profile → Notifications card → "Teams you follow" list reflects the follow/unfollow within the same session (shared composable).

**iPhone Safari (PWA, installed)**
- [ ] Same flow. Tap target feels comfortable (≥44px) and pill stays on the dark team header gradient without fighting it visually.
- [ ] After following a team currently in a live match, post a goal as admin → push arrives (end-to-end smoke).

**Pixel 10 (PWA)**
- [ ] Same flow on narrow viewport.

**Unauthenticated**
- [ ] Log out, navigate to a public team view if any → no Follow button anywhere, no broken state, no login prompt.

## Out of scope (v2+)
- Auto-suggest "follow your kid's team" on first login.
- Per-event "Notify me on" toggles (default today: all events).
- Notification count badge on the button (currently mute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)