### PR TITLE
feat(notifications): Follow team button on MatchesView My Club view (SB-56)

### DIFF
--- a/frontend/src/__tests__/components/FollowButton.spec.js
+++ b/frontend/src/__tests__/components/FollowButton.spec.js
@@ -205,3 +205,25 @@ describe('FollowButton aria-label', () => {
     ).toBe('Unfollow IFA');
   });
 });
+
+describe('FollowButton variant (SB-56)', () => {
+  it('defaults to the dark variant (sits on team-header gradient)', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    const wrapper = mountButton();
+    await flushPromises();
+
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.classes()).toContain('follow-button--dark');
+    expect(btn.classes()).not.toContain('follow-button--light');
+  });
+
+  it('applies the light variant class when variant="light"', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    const wrapper = mountButton({ variant: 'light' });
+    await flushPromises();
+
+    const btn = wrapper.find('[data-testid="follow-button"]');
+    expect(btn.classes()).toContain('follow-button--light');
+    expect(btn.classes()).not.toContain('follow-button--dark');
+  });
+});

--- a/frontend/src/__tests__/components/MatchesView.spec.js
+++ b/frontend/src/__tests__/components/MatchesView.spec.js
@@ -57,6 +57,16 @@ vi.mock('@/components/MatchEditModal.vue', () => ({
   },
 }));
 
+// Stub FollowButton (SB-56) — assert presence + props without wiring useTeamFollows.
+vi.mock('@/components/notifications/FollowButton.vue', () => ({
+  default: {
+    name: 'FollowButton',
+    props: ['teamId', 'teamName', 'variant'],
+    template:
+      '<button data-testid="follow-button-mock" :data-team-id="teamId" :data-team-name="teamName" :data-variant="variant">Follow</button>',
+  },
+}));
+
 // Mock API config
 vi.mock('@/config/api', () => ({
   getApiBaseUrl: () => 'http://localhost:8000',
@@ -667,6 +677,90 @@ describe('MatchesView', () => {
       // Should see league headers
       expect(wrapper.text()).toContain('HOMEGROWN');
       expect(wrapper.text()).toContain('ACADEMY');
+    });
+  });
+
+  // ===========================================================================
+  // TESTS: FOLLOW BUTTON (SB-56)
+  // ===========================================================================
+
+  describe('follow button (SB-56)', () => {
+    const selectClubAndTeam = async wrapper => {
+      await wrapper.find('[data-testid="my-club-tab"]').trigger('click');
+      await flushPromises();
+      // Age group filters teams; U14 (id=3) is needed so mock team #1
+      // (Blue Stars U14) appears in the team dropdown.
+      await wrapper.find('[data-testid="age-group-3"]').trigger('click');
+      await flushPromises();
+      await wrapper
+        .find('[data-testid="club-selector"]')
+        .find('option[value="1"]')
+        .setSelected();
+      await flushPromises();
+      await wrapper
+        .find('[data-testid="team-selector"]')
+        .find('option[value="1"]')
+        .setSelected();
+      await flushPromises();
+    };
+
+    it('does not render on All Matches tab', async () => {
+      setupMockApiResponses();
+      const wrapper = mountMatchesView();
+      await flushPromises();
+
+      // Default tab is All Matches.
+      expect(wrapper.find('[data-testid="follow-button-mock"]').exists()).toBe(
+        false
+      );
+    });
+
+    it('does not render on My Club tab when no team is selected', async () => {
+      setupMockApiResponses();
+      const wrapper = mountMatchesView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="my-club-tab"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="follow-button-mock"]').exists()).toBe(
+        false
+      );
+    });
+
+    it('renders next to the team header once a team is selected on My Club', async () => {
+      setupMockApiResponses();
+      const wrapper = mountMatchesView();
+      await flushPromises();
+
+      await selectClubAndTeam(wrapper);
+
+      const btn = wrapper.find('[data-testid="follow-button-mock"]');
+      expect(btn.exists()).toBe(true);
+    });
+
+    it('passes the selected team id (numeric) and name to FollowButton', async () => {
+      setupMockApiResponses();
+      const wrapper = mountMatchesView();
+      await flushPromises();
+
+      await selectClubAndTeam(wrapper);
+
+      const btn = wrapper.find('[data-testid="follow-button-mock"]');
+      // Selected team id from the mock factory is 1.
+      expect(btn.attributes('data-team-id')).toBe('1');
+      expect(btn.attributes('data-team-name')).toBe('Blue Stars U14');
+    });
+
+    it('uses the light variant so it reads on the page background', async () => {
+      setupMockApiResponses();
+      const wrapper = mountMatchesView();
+      await flushPromises();
+
+      await selectClubAndTeam(wrapper);
+
+      const btn = wrapper.find('[data-testid="follow-button-mock"]');
+      expect(btn.attributes('data-variant')).toBe('light');
     });
   });
 });

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -316,37 +316,45 @@
           </div>
         </div>
 
+        <!-- My Club team header — always shown when a team is selected, even if no matches yet. -->
+        <div
+          v-if="selectedViewTab === 'myclub' && selectedTeam"
+          class="mb-4"
+          data-testid="my-club-team-header"
+        >
+          <div class="flex flex-wrap items-center gap-3 mb-2">
+            <h3 class="text-lg font-semibold">
+              Matches for {{ getSelectedTeamName() }}
+            </h3>
+            <FollowButton
+              :team-id="Number(selectedTeam)"
+              :team-name="getSelectedTeamName()"
+              variant="light"
+            />
+          </div>
+
+          <!-- League Information -->
+          <div
+            v-if="selectedTeamLeagueInfo"
+            class="inline-flex items-center space-x-2 px-3 py-1 bg-brand-50 border border-brand-200 rounded-md text-sm"
+          >
+            <span class="font-medium text-brand-800">League:</span>
+            <span class="text-brand-700"
+              >{{ selectedTeamLeagueInfo.league }} -
+              {{ selectedTeamLeagueInfo.division }} ({{
+                selectedTeamLeagueInfo.ageGroup
+              }})</span
+            >
+            <span class="text-brand-600">• {{ selectedSeasonName }}</span>
+          </div>
+        </div>
+
         <!-- Display Filtered Matches -->
         <div v-if="sortedGames.length > 0">
-          <div class="mb-4">
-            <!-- All Matches: Show week range -->
-            <div v-if="selectedViewTab === 'all'">
-              <h3 class="text-lg font-semibold mb-2" data-testid="week-range">
-                {{ weekRangeDisplay }}
-              </h3>
-            </div>
-
-            <!-- My Club: Show team name and league info -->
-            <div v-else>
-              <h3 class="text-lg font-semibold mb-2">
-                Matches for {{ getSelectedTeamName() }}
-              </h3>
-
-              <!-- League Information -->
-              <div
-                v-if="selectedTeamLeagueInfo"
-                class="inline-flex items-center space-x-2 px-3 py-1 bg-brand-50 border border-brand-200 rounded-md text-sm"
-              >
-                <span class="font-medium text-brand-800">League:</span>
-                <span class="text-brand-700"
-                  >{{ selectedTeamLeagueInfo.league }} -
-                  {{ selectedTeamLeagueInfo.division }} ({{
-                    selectedTeamLeagueInfo.ageGroup
-                  }})</span
-                >
-                <span class="text-brand-600">• {{ selectedSeasonName }}</span>
-              </div>
-            </div>
+          <div v-if="selectedViewTab === 'all'" class="mb-4">
+            <h3 class="text-lg font-semibold mb-2" data-testid="week-range">
+              {{ weekRangeDisplay }}
+            </h3>
           </div>
 
           <!-- Season Summary Stats - Only show on My Club tab when a team is selected -->
@@ -2017,6 +2025,7 @@ import { getApiBaseUrl } from '../config/api';
 import MatchEditModal from '@/components/MatchEditModal.vue';
 import MatchDetailView from '@/components/MatchDetailView.vue';
 import ClubLogo from '@/components/shared/ClubLogo.vue';
+import FollowButton from '@/components/notifications/FollowButton.vue';
 
 export default {
   name: 'MatchesView',
@@ -2024,6 +2033,7 @@ export default {
     MatchEditModal,
     MatchDetailView,
     ClubLogo,
+    FollowButton,
   },
   props: {
     initialAgeGroupId: { type: Number, default: null },

--- a/frontend/src/components/notifications/FollowButton.vue
+++ b/frontend/src/components/notifications/FollowButton.vue
@@ -3,7 +3,10 @@
     v-if="visible"
     type="button"
     class="follow-button"
-    :class="{ 'is-following': following, 'is-busy': busy }"
+    :class="[
+      `follow-button--${variant}`,
+      { 'is-following': following, 'is-busy': busy },
+    ]"
     :disabled="busy"
     :aria-pressed="following"
     :aria-label="
@@ -52,6 +55,13 @@ import { useTeamFollows } from '../../composables/useTeamFollows';
 const props = defineProps({
   teamId: { type: [Number, String], required: true },
   teamName: { type: String, default: '' },
+  // 'dark' = sits on dark/colored team-header gradient (default, SB-55 placement).
+  // 'light' = sits on a normal light page background (SB-56 placement on MatchesView).
+  variant: {
+    type: String,
+    default: 'dark',
+    validator: v => ['dark', 'light'].includes(v),
+  },
 });
 
 const authStore = useAuthStore();
@@ -95,29 +105,50 @@ onMounted(() => {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.01em;
-  background: rgba(255, 255, 255, 0.95);
-  color: #1f2937;
-  border: 1.5px solid rgba(255, 255, 255, 0.95);
   cursor: pointer;
   transition:
     background-color 0.15s ease,
     color 0.15s ease,
+    border-color 0.15s ease,
     transform 0.05s ease;
-  /* Sit on the dark team-header gradient; keep it readable. */
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-}
-
-.follow-button:hover:not(:disabled) {
-  background: white;
-  transform: translateY(-1px);
 }
 
 .follow-button:active:not(:disabled) {
   transform: translateY(0);
 }
 
-.follow-button:focus-visible {
+/* Dark variant — sits on the team-header gradient (SB-55). */
+.follow-button--dark {
+  background: rgba(255, 255, 255, 0.95);
+  color: #1f2937;
+  border: 1.5px solid rgba(255, 255, 255, 0.95);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.follow-button--dark:hover:not(:disabled) {
+  background: white;
+  transform: translateY(-1px);
+}
+
+.follow-button--dark:focus-visible {
   outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* Light variant — sits on normal page background (SB-56 on MatchesView). */
+.follow-button--light {
+  background: white;
+  color: #0257fe;
+  border: 1.5px solid #0257fe;
+}
+
+.follow-button--light:hover:not(:disabled) {
+  background: rgba(2, 87, 254, 0.08);
+  transform: translateY(-1px);
+}
+
+.follow-button--light:focus-visible {
+  outline: 2px solid #0257fe;
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
Closes SB-56. Follow-up to #409 (SB-55), which merged earlier today.

## Summary
- Mount `FollowButton` next to the "Matches for {team}" header in `MatchesView.vue` (My Club view), restructured into a flex row.
- Extract the team header out of the `v-if="sortedGames.length > 0"` branch so it (and the follow button) render even when the selected team has no scheduled matches yet — preseason teams and not-yet-scraped fixtures stay followable.
- Add a `variant` prop to `FollowButton`: `dark` (default, SB-55's team-header gradient placement) and `light` (white-background pages like MatchesView). Light variant uses brand-blue outline for contrast.

## Why this surface (not LeagueTable + new TeamDetailView)
The Matches → My Club view already has unrestricted Select Club + Select Team dropdowns visible to any authenticated user. It's the natural discovery surface for "browse any team, in any club, at any age group" — exactly the multi-club follow shape from the SB-56 spec (e.g. parent of IFA U14 HG wants to follow IFA U15 HG and NER U14 HG). No new component, no new backend, no LeagueTable behavior changes.

## Tests
- 7 new specs: 5 in `MatchesView.spec.js` (mount/absence per tab+state, prop wiring) + 2 in `FollowButton.spec.js` (variant classes).
- Full suite: 375/375 ✅ (up from SB-55's 368).
- Lint: ✅

## Test plan
Per `feedback_mobile_first_ui.md` — desktop + mobile both required.

**Desktop (Mac Chrome)** on http://localhost:8080
- [ ] Log in as a fan (NOT a player). Click **Matches** → **My Club**.
- [ ] Pick an age group (e.g. U14), then Select Club = a club you do NOT belong to.
- [ ] Select Team → "Follow" pill appears next to "Matches for {team}".
- [ ] Click → POST 201, flips to "✓ Following".
- [ ] Repeat for a second + third club/team (the IFA U14 + IFA U15 + NER U14 HG multi-club pattern).
- [ ] Open Profile → Notifications card → all followed teams appear in "Teams you follow" (shared composable, live-sync).
- [ ] Pick a team with no scheduled matches → header + Follow button still render. Click works.

**iPhone Safari (PWA) + Pixel 10**
- [ ] Same flow, narrow viewport. Tap target ≥44px. Pill doesn't crowd the team-name header.
- [ ] Follow a team in an active live match → admin posts a goal → push arrives.

**Regression sanity**
- [ ] **All Matches** sub-tab unchanged — no follow button there.
- [ ] LeagueTable team-name tap still routes to Scores filter (unchanged).
- [ ] `TeamRosterPage` button from SB-55 still works (dark variant default preserved on the gradient header).

## Related follow-up tickets filed today
- **SB-57** — per-event notification preferences (toggles for goal/kickoff/halftime/fulltime/cards). With SB-56 multiplying follow counts, fans need volume controls before fatigue sets in.
- **SB-58** — match-scraper triggers push on final/updated scores. Today the scraper silently writes scores; this would close the biggest perceived gap ("notifications don't really work" for non-live-scored matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)