### PR TITLE
fix(tournament): improve standings + header rendering on mobile

### DIFF
--- a/frontend/src/__tests__/components/TournamentStandings.spec.js
+++ b/frontend/src/__tests__/components/TournamentStandings.spec.js
@@ -1,0 +1,114 @@
+/**
+ * TournamentStandings.vue Tests
+ *
+ * Covers the standings computation (points, GD, PK-shootout wins,
+ * regulation-only GF/GA, tiebreak sorting) and the head-to-head cross-table,
+ * plus the mobile-responsive column behavior: the GF/GA columns are dropped on
+ * phones (`hidden sm:table-cell`) so the essential MP/W/D/L/GD/PTS set fits
+ * without horizontal scrolling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TournamentStandings from '@/components/TournamentStandings.vue';
+
+const team = (id, name) => ({ id, name });
+
+// Completed match factory. PK scores optional (only valid on a draw).
+const mkMatch = (id, home, away, hs, as, extra = {}) => ({
+  id,
+  home_team: home,
+  away_team: away,
+  home_score: hs,
+  away_score: as,
+  home_penalty_score: null,
+  away_penalty_score: null,
+  match_status: 'completed',
+  match_date: '2026-06-05',
+  tournament_round: 'group_stage',
+  tournament_group: 'Bracket A',
+  ...extra,
+});
+
+const A = team(1, 'Team Alpha');
+const B = team(2, 'Team Bravo');
+const C = team(3, 'Team Charlie');
+
+describe('TournamentStandings', () => {
+  it('shows the empty-state when there are no matches', () => {
+    const wrapper = mount(TournamentStandings, { props: { matches: [] } });
+    expect(wrapper.text()).toContain('No group-stage matches in this bracket');
+  });
+
+  it('computes points, GD and orders teams by points then GD', () => {
+    // A beats B 3-1; A draws C 2-2; B beats C 1-0.
+    // A: W1 D1 -> 4 pts, GF5 GA3 GD+2
+    // B: W1 L1 -> 3 pts, GF2 GA3 GD-1
+    // C: D1 L1 -> 1 pt,  GF2 GA3 GD-1
+    const matches = [
+      mkMatch(1, A, B, 3, 1),
+      mkMatch(2, A, C, 2, 2),
+      mkMatch(3, B, C, 1, 0),
+    ];
+    const wrapper = mount(TournamentStandings, { props: { matches } });
+
+    // The h2h table is a separate <table>, so scope to the first one.
+    const standingsRows = wrapper.findAll('table')[0].findAll('tbody tr');
+
+    // Three teams ranked, leader is Team Alpha (4 pts).
+    expect(standingsRows).toHaveLength(3);
+    expect(standingsRows[0].text()).toContain('Team Alpha');
+    // Last cell of the leader row is PTS = 4.
+    const leaderCells = standingsRows[0].findAll('td');
+    expect(leaderCells[leaderCells.length - 1].text()).toBe('4');
+  });
+
+  it('counts a PK-shootout win as a win but keeps GF/GA at regulation', () => {
+    // A and B draw 1-1 in regulation; A wins 4-3 on penalties.
+    const matches = [
+      mkMatch(1, A, B, 1, 1, {
+        home_penalty_score: 4,
+        away_penalty_score: 3,
+      }),
+    ];
+    const wrapper = mount(TournamentStandings, { props: { matches } });
+    const standingsRows = wrapper.findAll('table')[0].findAll('tbody tr');
+
+    // A should be first with 3 points (PK win), B second with 0.
+    expect(standingsRows[0].text()).toContain('Team Alpha');
+    const aCells = standingsRows[0].findAll('td');
+    // PTS column (last) = 3 for the shootout winner.
+    expect(aCells[aCells.length - 1].text()).toBe('3');
+    // GD column (second-to-last) is 0 — regulation was a draw.
+    expect(aCells[aCells.length - 2].text()).toBe('0');
+  });
+
+  it('drops GF/GA columns on mobile via hidden sm:table-cell', () => {
+    const matches = [mkMatch(1, A, B, 2, 0)];
+    const wrapper = mount(TournamentStandings, { props: { matches } });
+
+    const headers = wrapper.findAll('table')[0].findAll('thead th');
+    const byLabel = Object.fromEntries(
+      headers.map(h => [h.text(), h.classes().join(' ')])
+    );
+
+    // GF and GA are mobile-hidden; MP / GD / PTS always visible.
+    expect(byLabel['GF']).toContain('hidden');
+    expect(byLabel['GF']).toContain('sm:table-cell');
+    expect(byLabel['GA']).toContain('hidden');
+    expect(byLabel['PTS']).not.toContain('hidden');
+    expect(byLabel['MP']).not.toContain('hidden');
+    expect(byLabel['GD']).not.toContain('hidden');
+  });
+
+  it('renders the head-to-head result from the row team perspective', () => {
+    // A beat B 3-1. In B's row vs A's column the score is shown from B's
+    // perspective: 1-3.
+    const matches = [mkMatch(1, A, B, 3, 1)];
+    const wrapper = mount(TournamentStandings, { props: { matches } });
+
+    const h2hTable = wrapper.findAll('table')[1];
+    expect(h2hTable.text()).toContain('3-1');
+    expect(h2hTable.text()).toContain('1-3');
+  });
+});

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -93,19 +93,21 @@
       <div v-if="selected">
         <!-- Header card -->
         <div
-          class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6"
+          class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 sm:p-6 mb-6"
         >
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div class="flex items-start gap-4 min-w-0 flex-1">
+          <div
+            class="flex flex-wrap items-start justify-between gap-3 sm:gap-4"
+          >
+            <div class="flex items-start gap-3 sm:gap-4 min-w-0 flex-1">
               <img
                 v-if="selected.logo_url"
                 :src="selected.logo_url"
                 :alt="`${selected.name} logo`"
-                class="w-32 h-32 sm:w-36 sm:h-36 rounded-md object-contain bg-white border border-gray-100 shrink-0"
+                class="w-14 h-14 sm:w-24 sm:h-24 md:w-32 md:h-32 rounded-md object-contain bg-white border border-gray-100 shrink-0"
                 data-testid="tournament-logo"
               />
               <div class="min-w-0 flex-1">
-                <h2 class="text-2xl font-bold text-gray-900">
+                <h2 class="text-xl sm:text-2xl font-bold text-gray-900">
                   {{ selected.name }}
                 </h2>
                 <div
@@ -136,9 +138,13 @@
                 </p>
               </div>
             </div>
-            <div class="flex flex-col items-end gap-3">
-              <div class="text-right text-sm text-gray-500">
-                <div class="text-2xl font-bold text-gray-800">
+            <div
+              class="flex flex-row sm:flex-col items-center sm:items-end justify-between gap-3 w-full sm:w-auto"
+            >
+              <div
+                class="flex items-baseline gap-1.5 sm:block sm:text-right text-sm text-gray-500"
+              >
+                <div class="text-xl sm:text-2xl font-bold text-gray-800">
                   {{ selected.matches?.length ?? 0 }}
                 </div>
                 <div>matches tracked</div>

--- a/frontend/src/components/TournamentStandings.vue
+++ b/frontend/src/components/TournamentStandings.vue
@@ -13,15 +13,20 @@
       <div
         class="overflow-x-auto bg-white rounded-lg border border-gray-200 mb-6"
       >
-        <table class="min-w-full text-sm">
+        <table class="min-w-full text-xs sm:text-sm">
           <thead class="bg-gray-50 text-gray-600">
             <tr>
-              <th class="px-2 py-2 w-8 text-center font-semibold">#</th>
-              <th class="px-3 py-2 text-left font-semibold">Team</th>
+              <th class="px-1.5 sm:px-2 py-2 w-7 text-center font-semibold">
+                #
+              </th>
+              <th class="px-2 sm:px-3 py-2 text-left font-semibold">Team</th>
               <th
                 v-for="col in STAT_COLS"
                 :key="col.key"
-                class="px-2 py-2 text-center font-semibold w-12"
+                :class="[
+                  'px-1.5 sm:px-2 py-2 text-center font-semibold w-9 sm:w-12',
+                  col.mobileHidden ? 'hidden sm:table-cell' : '',
+                ]"
               >
                 {{ col.label }}
               </th>
@@ -36,22 +41,32 @@
                 'border-t border-gray-100',
               ]"
             >
-              <td class="px-2 py-2 text-center text-gray-500 tabular-nums">
+              <td
+                class="px-1.5 sm:px-2 py-2 text-center text-gray-500 tabular-nums"
+              >
                 {{ idx + 1 }}
               </td>
               <td
                 :class="[
-                  'px-3 py-2 truncate',
+                  'px-2 sm:px-3 py-2',
                   idx === 0 ? 'font-semibold text-gray-900' : 'text-gray-800',
                 ]"
               >
-                {{ row.team.name }}
+                <!-- Inner block truncates reliably; max-width on a <td> alone
+                     is ignored in auto table layout. -->
+                <div
+                  class="truncate max-w-[40vw] sm:max-w-[240px]"
+                  :title="row.team.name"
+                >
+                  {{ row.team.name }}
+                </div>
               </td>
               <td
                 v-for="col in STAT_COLS"
                 :key="col.key"
                 :class="[
-                  'px-2 py-2 text-center tabular-nums',
+                  'px-1.5 sm:px-2 py-2 text-center tabular-nums',
+                  col.mobileHidden ? 'hidden sm:table-cell' : '',
                   col.key === 'pts'
                     ? 'font-bold text-gray-900'
                     : 'text-gray-700',
@@ -66,26 +81,31 @@
 
       <!-- Head-to-head cross-table -->
       <div>
-        <h3
-          class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2"
-        >
-          Head-to-head
-        </h3>
+        <div class="flex items-baseline justify-between mb-2">
+          <h3
+            class="text-xs font-semibold text-gray-400 uppercase tracking-wider"
+          >
+            Head-to-head
+          </h3>
+          <span class="text-xs text-gray-400 sm:hidden">swipe →</span>
+        </div>
         <div class="overflow-x-auto bg-white rounded-lg border border-gray-200">
-          <table class="min-w-full text-sm">
+          <table class="min-w-full text-xs sm:text-sm">
             <thead class="bg-gray-50 text-gray-600">
               <tr>
                 <th
-                  class="px-3 py-2 text-left font-semibold sticky left-0 bg-gray-50 z-10"
-                  style="min-width: 180px"
+                  class="px-2 sm:px-3 py-2 text-left font-semibold sticky left-0 bg-gray-50 z-10 min-w-[104px] sm:min-w-[180px]"
                 ></th>
                 <th
                   v-for="team in bracketTeams"
                   :key="`hdr-${team.id}`"
-                  class="px-3 py-2 text-center font-semibold"
-                  style="min-width: 110px"
+                  class="px-2 sm:px-3 py-2 text-center font-semibold min-w-[64px] sm:min-w-[110px]"
                 >
-                  {{ team.name }}
+                  <span
+                    class="block truncate max-w-[56px] sm:max-w-[96px] mx-auto"
+                    :title="team.name"
+                    >{{ team.name }}</span
+                  >
                 </th>
               </tr>
             </thead>
@@ -96,15 +116,20 @@
                 class="border-t border-gray-100"
               >
                 <td
-                  class="px-3 py-2 font-medium text-gray-800 sticky left-0 bg-white z-10"
+                  class="px-2 sm:px-3 py-2 font-medium text-gray-800 sticky left-0 bg-white z-10"
                 >
-                  {{ rowTeam.name }}
+                  <div
+                    class="truncate max-w-[88px] sm:max-w-[164px]"
+                    :title="rowTeam.name"
+                  >
+                    {{ rowTeam.name }}
+                  </div>
                 </td>
                 <td
                   v-for="colTeam in bracketTeams"
                   :key="`cell-${rowTeam.id}-${colTeam.id}`"
                   :class="[
-                    'px-3 py-2 text-center tabular-nums',
+                    'px-2 sm:px-3 py-2 text-center tabular-nums',
                     rowTeam.id === colTeam.id
                       ? 'bg-gray-100 text-gray-300'
                       : 'text-gray-700',
@@ -132,14 +157,17 @@ const props = defineProps({
   matches: { type: Array, required: true },
 });
 
-// Columns shown in the standings table, in order.
+// Columns shown in the standings table, in order. `mobileHidden` columns
+// (raw goals for/against) are dropped on phones so the essential MP / W / D /
+// L / GD / PTS set fits without horizontal scrolling — GD still summarizes
+// the goal difference. They reappear at the `sm` breakpoint.
 const STAT_COLS = [
   { key: 'mp', label: 'MP' },
   { key: 'w', label: 'W' },
   { key: 'd', label: 'D' },
   { key: 'l', label: 'L' },
-  { key: 'gf', label: 'GF' },
-  { key: 'ga', label: 'GA' },
+  { key: 'gf', label: 'GF', mobileHidden: true },
+  { key: 'ga', label: 'GA', mobileHidden: true },
   { key: 'gd', label: 'GD' },
   { key: 'pts', label: 'PTS' },
 ];


### PR DESCRIPTION
## Summary

The tournament page (e.g. NAC / National Academy Championships) rendered poorly on phones. This makes the **standings view** and **header card** mobile-friendly.

### Standings table (`TournamentStandings.vue`)
- **Dropped GF/GA on mobile** (`hidden sm:table-cell`) so the essential **#, Team, MP, W, D, L, GD, PTS** set fits without horizontal scrolling — previously PTS was pushed off-screen. GF/GA reappear at the `sm` breakpoint. GD still summarizes goal difference.
- **Reliable team-name truncation** — `truncate` was on the `<td>`, which auto-layout tables ignore, so long names ("FC Greater Boston Bolts") expanded the column and forced horizontal scroll. Moved truncation to an inner bounded `<div>`; full name available on hover via `title`.
- Tighter mobile spacing (`px-1.5 sm:px-2`, `text-xs sm:text-sm`).

### Head-to-head cross-table
- Narrower mobile cells, truncated headers, and a subtle **"swipe →"** hint so the horizontal scroll is discoverable.

### Header card (`TournamentMatchCenter.vue`)
- **Logo shrunk** from a fixed 128px to responsive `56 → 96 → 128px` so it no longer crushes the title on a phone.
- Reduced padding and title size on mobile; match-count + view toggle now sit on one tidy full-width row on mobile.

### Tests
- New `TournamentStandings.spec.js` (5 tests) — the component had **no coverage**. Covers points/GD/sorting, PK-shootout wins (counted as a win, GF/GA stay at regulation), head-to-head perspective, and the mobile column-hiding guard.

The **Bracket view** (fixed 1080px horizontal-scroll grid) is unchanged — it has no bracket rounds for NAC and is out of scope here.

## Test plan
- `cd frontend && npm run test:run` → **373 pass, 0 fail**
- `cd frontend && npm run lint` → clean
- Manual: view a group-stage tournament (NAC) on a phone / narrow viewport — standings fit with no sideways scroll for points; header logo no longer dominates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)