### PR TITLE
feat(notifications): per-event push preferences (SB-57)

### DIFF
--- a/backend/api/push.py
+++ b/backend/api/push.py
@@ -12,6 +12,8 @@ Endpoints:
 - POST   /api/users/me/team-follows                      — follow {team_id}
 - GET    /api/users/me/team-follows                      — list follows + team/club
 - DELETE /api/users/me/team-follows/{team_id}            — unfollow
+- GET    /api/users/me/notification-preferences          — per-event opt-in flags (SB-57)
+- PUT    /api/users/me/notification-preferences          — update per-event opt-in flags (SB-57)
 - POST   /api/users/me/notifications/test                — send a test push
 """
 
@@ -25,9 +27,11 @@ from pydantic import BaseModel, Field
 
 from auth import get_current_user_required
 from dao.match_dao import SupabaseConnection
+from dao.notification_preferences_dao import NotificationPreferencesDAO
 from dao.push_send_log_dao import PushSendLogDAO
 from dao.push_subscription_dao import PushSubscriptionDAO
 from dao.team_follow_dao import TeamFollowDAO
+from notifications.preferences import EVENT_TYPES
 from notifications.web_push_sender import (
     get_public_key as get_vapid_public_key,
 )
@@ -67,6 +71,10 @@ def _follow_dao() -> TeamFollowDAO:
 
 def _log_dao() -> PushSendLogDAO:
     return PushSendLogDAO(_conn())
+
+
+def _prefs_dao() -> NotificationPreferencesDAO:
+    return NotificationPreferencesDAO(_conn())
 
 
 def _user_id(user: dict[str, Any]) -> str:
@@ -253,6 +261,49 @@ def unfollow_team(
     user_id = _user_id(current_user)
     _follow_dao().unfollow(user_id, team_id)  # idempotent
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Notification preferences (SB-57)
+# ---------------------------------------------------------------------------
+
+
+class NotificationPreferencesIn(BaseModel):
+    """Body of PUT /api/users/me/notification-preferences."""
+
+    preferences: dict[str, bool] = Field(
+        ...,
+        description=(
+            "Map of event_type → enabled. Unknown event types are ignored. "
+            f"Known event types: {', '.join(EVENT_TYPES)}."
+        ),
+    )
+
+
+@router.get("/users/me/notification-preferences")
+def get_notification_preferences(
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+) -> dict[str, dict[str, bool]]:
+    user_id = _user_id(current_user)
+    return {"preferences": _prefs_dao().get_preferences(user_id)}
+
+
+@router.put("/users/me/notification-preferences")
+def update_notification_preferences(
+    payload: NotificationPreferencesIn,
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+) -> dict[str, dict[str, bool]]:
+    # Reject unknown event types up front rather than silently dropping them —
+    # surfaces client bugs faster.
+    unknown = [k for k in payload.preferences if k not in EVENT_TYPES]
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown event types: {', '.join(unknown)}",
+        )
+    user_id = _user_id(current_user)
+    merged = _prefs_dao().set_preferences(user_id, payload.preferences)
+    return {"preferences": merged}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/dao/notification_preferences_dao.py
+++ b/backend/dao/notification_preferences_dao.py
@@ -1,0 +1,103 @@
+"""Notification Preferences DAO (SB-57).
+
+Per-user opt-in flags for push notification event types. Missing rows fall back
+to defaults from `backend/notifications/preferences.py`.
+
+`get_preferences_batch` is the dispatcher hot-path query — one SELECT covers
+every user about to receive a given event.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from dao.base_dao import BaseDAO
+from notifications.preferences import (
+    DEFAULT_PREFERENCES,
+    EVENT_TYPES,
+    merge_with_defaults,
+)
+
+logger = structlog.get_logger()
+
+TABLE = "user_notification_preferences"
+
+
+class NotificationPreferencesDAO(BaseDAO):
+    """Data access for user notification preferences."""
+
+    def get_preferences(self, user_id: str) -> dict[str, bool]:
+        """Return all 6 event-type flags for a user, defaults applied."""
+        try:
+            response = (
+                self.client.table(TABLE)
+                .select("event_type, enabled")
+                .eq("user_id", user_id)
+                .execute()
+            )
+            stored = {row["event_type"]: row["enabled"] for row in response.data or []}
+            return merge_with_defaults(stored)
+        except Exception:
+            logger.exception("notification_prefs_get_failed", user_id=user_id)
+            return dict(DEFAULT_PREFERENCES)
+
+    def set_preferences(
+        self, user_id: str, prefs: dict[str, bool]
+    ) -> dict[str, bool]:
+        """Upsert preferences for a user. Only known event types are persisted.
+
+        Returns the resulting merged state (so the caller can echo it back to
+        the client).
+        """
+        rows = [
+            {"user_id": user_id, "event_type": event_type, "enabled": bool(enabled)}
+            for event_type, enabled in prefs.items()
+            if event_type in EVENT_TYPES
+        ]
+        if not rows:
+            return self.get_preferences(user_id)
+        try:
+            self.client.table(TABLE).upsert(
+                rows, on_conflict="user_id,event_type"
+            ).execute()
+        except Exception:
+            logger.exception(
+                "notification_prefs_set_failed",
+                user_id=user_id,
+                event_types=list(prefs.keys()),
+            )
+            # Fall through to a fresh read so the client sees current truth.
+        return self.get_preferences(user_id)
+
+    def get_preferences_batch(
+        self, user_ids: list[str]
+    ) -> dict[str, dict[str, bool]]:
+        """Batch-fetch prefs for many users. Dispatcher hot-path.
+
+        Returns `{user_id: {event_type: enabled, ...}}` with defaults filled in
+        for any user that has no stored rows.
+        """
+        if not user_ids:
+            return {}
+        try:
+            response = (
+                self.client.table(TABLE)
+                .select("user_id, event_type, enabled")
+                .in_("user_id", user_ids)
+                .execute()
+            )
+            stored: dict[str, dict[str, bool]] = {}
+            for row in response.data or []:
+                stored.setdefault(row["user_id"], {})[row["event_type"]] = row[
+                    "enabled"
+                ]
+            return {
+                uid: merge_with_defaults(stored.get(uid)) for uid in user_ids
+            }
+        except Exception:
+            logger.exception(
+                "notification_prefs_batch_failed",
+                user_count=len(user_ids),
+            )
+            # Fallback: everyone gets defaults so we don't silently drop events.
+            return {uid: dict(DEFAULT_PREFERENCES) for uid in user_ids}

--- a/backend/notifications/dispatcher.py
+++ b/backend/notifications/dispatcher.py
@@ -26,8 +26,13 @@ from notifications.channel_resolver import (
     resolve_user_push_subscriptions,
 )
 from notifications.formatters import format_event
+from notifications.preferences import DEFAULT_PREFERENCES
 from notifications.web_push_sender import is_configured as push_is_configured
 from notifications.web_push_sender import send_push
+
+# NotificationPreferencesDAO is imported lazily inside `prefs_dao` to break
+# the circular import: notification_preferences_dao.py → notifications.preferences
+# → notifications/__init__ → dispatcher → notification_preferences_dao.py.
 
 logger = structlog.get_logger(__name__)
 
@@ -84,6 +89,8 @@ class Notifier:
         self._team_follow_dao: TeamFollowDAO | None = None
         self._push_sub_dao: PushSubscriptionDAO | None = None
         self._push_log_dao: PushSendLogDAO | None = None
+        # NotificationPreferencesDAO; typed via local import to avoid the cycle.
+        self._prefs_dao = None
         # Lazy-imported default sender so tests can swap without importing httpx.
         self._send_fn = send_fn
         # Push sender override for tests.
@@ -124,6 +131,16 @@ class Notifier:
         if self._push_log_dao is None:
             self._push_log_dao = PushSendLogDAO(self.connection)
         return self._push_log_dao
+
+    @property
+    def prefs_dao(self):
+        if self._prefs_dao is None:
+            from dao.notification_preferences_dao import (
+                NotificationPreferencesDAO,
+            )
+
+            self._prefs_dao = NotificationPreferencesDAO(self.connection)
+        return self._prefs_dao
 
     @property
     def send_fn(self):
@@ -229,10 +246,13 @@ class Notifier:
     def _send_push_fanout(
         self, event_type: str, match: dict, content: str
     ) -> None:
-        """Push to every user following either team. Card events skipped in v1."""
-        if event_type in {"yellow_card", "red_card"}:
-            return  # not in v1; reduce notification volume
+        """Push to every user following either team, gated by per-user preferences.
 
+        Pre-SB-57, yellow_card/red_card were hard-skipped here; now they fire
+        only for users who opted in. Defaults preserve prior behavior (cards
+        off, everything else on) so existing followers see no change until
+        they touch the prefs UI.
+        """
         if not push_is_configured():
             return  # VAPID env unset — dormant; SB-50 activates this
 
@@ -246,16 +266,26 @@ class Notifier:
         if not subscriptions:
             return
 
+        # One batch query for the entire fanout instead of N per subscription.
+        user_ids = sorted({sub.get("user_id") for sub in subscriptions if sub.get("user_id")})
+        prefs_by_user = self.prefs_dao.get_preferences_batch(user_ids)
+
         payload = _build_push_payload(event_type, match, content)
 
         push_sent = 0
         push_failed = 0
         push_expired = 0
+        push_skipped_pref = 0
         for sub in subscriptions:
+            user_id = sub.get("user_id")
+            user_prefs = prefs_by_user.get(user_id, DEFAULT_PREFERENCES)
+            if not user_prefs.get(event_type, True):
+                push_skipped_pref += 1
+                continue
             result = self._push_send_fn(sub, payload)
             self.push_log_dao.log(
                 subscription_id=sub.get("id"),
-                user_id=sub.get("user_id"),
+                user_id=user_id,
                 match_id=match_id,
                 event_type=event_type,
                 status=result.status,
@@ -278,6 +308,7 @@ class Notifier:
             sent=push_sent,
             failed=push_failed,
             expired=push_expired,
+            skipped_pref=push_skipped_pref,
         )
 
 

--- a/backend/notifications/preferences.py
+++ b/backend/notifications/preferences.py
@@ -1,0 +1,43 @@
+"""User notification preference defaults (SB-57).
+
+The `user_notification_preferences` table stores per-user opt-in flags for each
+push notification event type. Missing rows fall back to these defaults — so
+existing users keep the current behavior with zero migration backfill.
+
+Defaults intentionally mirror the pre-SB-57 behavior:
+  - kickoff/goal/halftime/fulltime → ON (the events that fire today).
+  - yellow_card/red_card           → OFF (previously hard-coded skip in
+                                          dispatcher.py).
+
+Keeping defaults in code (not in the DB CHECK / DEFAULT clause) means we can
+adjust them later without a migration.
+"""
+
+from __future__ import annotations
+
+EVENT_TYPES: tuple[str, ...] = (
+    "kickoff",
+    "goal",
+    "halftime",
+    "fulltime",
+    "yellow_card",
+    "red_card",
+)
+
+DEFAULT_PREFERENCES: dict[str, bool] = {
+    "kickoff": True,
+    "goal": True,
+    "halftime": True,
+    "fulltime": True,
+    "yellow_card": False,
+    "red_card": False,
+}
+
+
+def merge_with_defaults(stored: dict[str, bool] | None) -> dict[str, bool]:
+    """Return a complete prefs dict, with `stored` overriding defaults."""
+    return {**DEFAULT_PREFERENCES, **(stored or {})}
+
+
+def validate_event_type(event_type: str) -> bool:
+    return event_type in EVENT_TYPES

--- a/backend/tests/integration/api/test_notification_preferences_api.py
+++ b/backend/tests/integration/api/test_notification_preferences_api.py
@@ -1,0 +1,143 @@
+"""API contract tests for the per-event notification preferences endpoints (SB-57).
+
+The DAO is patched so these are pure FastAPI contract tests — verifying
+auth, validation, and response shape without round-tripping through the DB.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+from auth import get_current_user_required
+from notifications.preferences import DEFAULT_PREFERENCES, EVENT_TYPES
+
+pytestmark = [pytest.mark.unit, pytest.mark.api]
+
+
+def _fake_user(user_id: str = "u-prefs-1") -> dict:
+    return {
+        "user_id": user_id,
+        "username": "prefs_tester",
+        "role": "club_fan",
+        "email": "prefs@example.com",
+        "team_id": None,
+        "club_id": None,
+        "display_name": "Prefs Tester",
+    }
+
+
+@contextmanager
+def _as_user(user: dict):
+    app.dependency_overrides[get_current_user_required] = lambda: user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_current_user_required, None)
+
+
+@contextmanager
+def _patched_prefs_dao(dao_mock: MagicMock):
+    with patch("api.push._prefs_dao", return_value=dao_mock):
+        yield
+
+
+class TestGetPreferences:
+    def test_returns_full_dict_with_defaults_applied(self):
+        dao = MagicMock()
+        dao.get_preferences.return_value = dict(DEFAULT_PREFERENCES)
+
+        with _as_user(_fake_user()), _patched_prefs_dao(dao):
+            with TestClient(app) as client:
+                resp = client.get("/api/users/me/notification-preferences")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body["preferences"].keys()) == set(EVENT_TYPES)
+        assert body["preferences"]["yellow_card"] is False
+        assert body["preferences"]["goal"] is True
+
+    def test_passes_user_id_to_dao(self):
+        dao = MagicMock()
+        dao.get_preferences.return_value = dict(DEFAULT_PREFERENCES)
+
+        with _as_user(_fake_user(user_id="abc-123")), _patched_prefs_dao(dao):
+            with TestClient(app) as client:
+                client.get("/api/users/me/notification-preferences")
+
+        dao.get_preferences.assert_called_once_with("abc-123")
+
+    def test_unauthenticated_returns_401(self):
+        # No dependency override → real auth dependency runs → 401.
+        with TestClient(app) as client:
+            resp = client.get("/api/users/me/notification-preferences")
+        assert resp.status_code in (401, 403)
+
+
+class TestPutPreferences:
+    def test_updates_and_returns_merged_state(self):
+        dao = MagicMock()
+        # After upsert, the DAO returns the new merged state.
+        merged = {**DEFAULT_PREFERENCES, "goal": False, "yellow_card": True}
+        dao.set_preferences.return_value = merged
+
+        with _as_user(_fake_user()), _patched_prefs_dao(dao):
+            with TestClient(app) as client:
+                resp = client.put(
+                    "/api/users/me/notification-preferences",
+                    json={"preferences": {"goal": False, "yellow_card": True}},
+                )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["preferences"]["goal"] is False
+        assert body["preferences"]["yellow_card"] is True
+
+        dao.set_preferences.assert_called_once()
+        call_args = dao.set_preferences.call_args
+        # First arg: user_id; second: prefs dict.
+        assert call_args.args[1] == {"goal": False, "yellow_card": True}
+
+    def test_unknown_event_type_returns_422(self):
+        dao = MagicMock()
+
+        with _as_user(_fake_user()), _patched_prefs_dao(dao):
+            with TestClient(app) as client:
+                resp = client.put(
+                    "/api/users/me/notification-preferences",
+                    json={"preferences": {"goal": True, "bogus_event": False}},
+                )
+
+        assert resp.status_code == 422
+        assert "bogus_event" in resp.text
+        dao.set_preferences.assert_not_called()
+
+    def test_empty_preferences_is_a_no_op_but_returns_current_state(self):
+        dao = MagicMock()
+        dao.set_preferences.return_value = dict(DEFAULT_PREFERENCES)
+
+        with _as_user(_fake_user()), _patched_prefs_dao(dao):
+            with TestClient(app) as client:
+                resp = client.put(
+                    "/api/users/me/notification-preferences",
+                    json={"preferences": {}},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["preferences"] == DEFAULT_PREFERENCES
+        # Still called the DAO; DAO is responsible for the "no rows → fall through" behavior.
+        dao.set_preferences.assert_called_once()
+
+    def test_missing_preferences_field_returns_422(self):
+        with _as_user(_fake_user()):
+            with TestClient(app) as client:
+                resp = client.put(
+                    "/api/users/me/notification-preferences",
+                    json={},
+                )
+        assert resp.status_code == 422

--- a/backend/tests/unit/test_dispatcher_preferences.py
+++ b/backend/tests/unit/test_dispatcher_preferences.py
@@ -1,0 +1,207 @@
+"""Dispatcher preference-filter tests (SB-57).
+
+Verifies that `Notifier._send_push_fanout` respects per-user opt-in flags:
+  - Cards default OFF → no push for users with no prefs row.
+  - Cards opted ON → push sent.
+  - Goal opted OFF → push skipped even though it's a default-on event.
+  - The hard-coded yellow/red short-circuit is gone — every event type
+    flows through the same prefs gate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from notifications.dispatcher import Notifier
+from notifications.preferences import DEFAULT_PREFERENCES
+from notifications.web_push_sender import SendResult
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend]
+
+
+def _send_ok(_sub, _payload):
+    return SendResult(status="sent", http_status=201)
+
+
+def _make_notifier(
+    subscriptions: list[dict], prefs_by_user: dict[str, dict[str, bool]]
+) -> tuple[Notifier, MagicMock]:
+    """Wire up a Notifier whose resolve_user_push_subscriptions returns
+    the given list and whose prefs_dao.get_preferences_batch returns the
+    given dict. push_log_dao + push_sub_dao are mocked so nothing hits
+    the DB.
+    """
+    push_send_fn = MagicMock(side_effect=_send_ok)
+    notifier = Notifier(push_send_fn=push_send_fn)
+
+    # Stub out the bits that would hit the DB or env.
+    notifier._prefs_dao = MagicMock()
+    notifier._prefs_dao.get_preferences_batch.return_value = prefs_by_user
+    notifier._push_log_dao = MagicMock()
+    notifier._push_sub_dao = MagicMock()
+    notifier._team_follow_dao = MagicMock()
+
+    return notifier, push_send_fn
+
+
+@pytest.fixture
+def match_payload() -> dict:
+    return {
+        "id": 12345,
+        "home_team_id": 1,
+        "away_team_id": 2,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _force_push_configured(monkeypatch):
+    """Pretend VAPID is configured so the fanout doesn't short-circuit."""
+    monkeypatch.setattr(
+        "notifications.dispatcher.push_is_configured", lambda: True
+    )
+
+
+def _patch_resolver(monkeypatch, subs):
+    monkeypatch.setattr(
+        "notifications.dispatcher.resolve_user_push_subscriptions",
+        lambda *_args, **_kwargs: subs,
+    )
+
+
+class TestCardsRespectPreferences:
+    def test_yellow_card_skipped_for_user_with_defaults(
+        self, monkeypatch, match_payload
+    ):
+        subs = [
+            {"id": "sub-1", "user_id": "u-default", "endpoint": "https://x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u-default": dict(DEFAULT_PREFERENCES)}
+        )
+
+        notifier._send_push_fanout("yellow_card", match_payload, "Yellow card!\nFoo Bar")
+
+        # Default has yellow_card=False → no send.
+        push_send_fn.assert_not_called()
+
+    def test_yellow_card_sent_when_opted_in(self, monkeypatch, match_payload):
+        subs = [
+            {"id": "sub-1", "user_id": "u-yes", "endpoint": "https://x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u-yes": {**DEFAULT_PREFERENCES, "yellow_card": True}}
+        )
+
+        notifier._send_push_fanout("yellow_card", match_payload, "Yellow card!\nFoo Bar")
+
+        push_send_fn.assert_called_once()
+
+    def test_red_card_treated_the_same(self, monkeypatch, match_payload):
+        subs = [
+            {"id": "sub-1", "user_id": "u-red", "endpoint": "https://x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u-red": {**DEFAULT_PREFERENCES, "red_card": True}}
+        )
+
+        notifier._send_push_fanout("red_card", match_payload, "Red card!\nFoo Bar")
+
+        push_send_fn.assert_called_once()
+
+
+class TestDefaultOnEventsRespectOptOut:
+    def test_goal_skipped_when_user_opted_out(self, monkeypatch, match_payload):
+        subs = [
+            {"id": "sub-1", "user_id": "u-noisy", "endpoint": "https://x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u-noisy": {**DEFAULT_PREFERENCES, "goal": False}}
+        )
+
+        notifier._send_push_fanout("goal", match_payload, "GOAL!\nFoo Bar")
+
+        push_send_fn.assert_not_called()
+
+    def test_kickoff_fires_with_defaults(self, monkeypatch, match_payload):
+        subs = [
+            {"id": "sub-1", "user_id": "u-default", "endpoint": "https://x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u-default": dict(DEFAULT_PREFERENCES)}
+        )
+
+        notifier._send_push_fanout("kickoff", match_payload, "KICKOFF\nFoo Bar")
+
+        push_send_fn.assert_called_once()
+
+
+class TestMixedFanout:
+    def test_two_users_one_opted_out(self, monkeypatch, match_payload):
+        subs = [
+            {"id": "sub-A", "user_id": "u-on", "endpoint": "https://a", "p256dh_key": "k", "auth_key": "a"},
+            {"id": "sub-B", "user_id": "u-off", "endpoint": "https://b", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs,
+            {
+                "u-on": dict(DEFAULT_PREFERENCES),
+                "u-off": {**DEFAULT_PREFERENCES, "goal": False},
+            },
+        )
+
+        notifier._send_push_fanout("goal", match_payload, "GOAL!\nFoo")
+
+        assert push_send_fn.call_count == 1
+        sent_sub = push_send_fn.call_args.args[0]
+        assert sent_sub["id"] == "sub-A"
+
+    def test_user_with_no_prefs_row_uses_defaults(
+        self, monkeypatch, match_payload
+    ):
+        """A user who never touched prefs should keep current behavior — goal
+        fires, cards don't. The dispatcher gets DEFAULT_PREFERENCES back from
+        the DAO for unknown users."""
+        subs = [
+            {"id": "sub-new", "user_id": "u-new", "endpoint": "https://x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        # Simulate the batch DAO behavior: missing user → defaults filled in.
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u-new": dict(DEFAULT_PREFERENCES)}
+        )
+
+        notifier._send_push_fanout("fulltime", match_payload, "FT\nFoo")
+        assert push_send_fn.call_count == 1
+
+        push_send_fn.reset_mock()
+        notifier._send_push_fanout("red_card", match_payload, "Red\nFoo")
+        push_send_fn.assert_not_called()
+
+
+class TestNoFanoutWhenPushUnconfigured:
+    def test_short_circuits_when_vapid_unset(
+        self, monkeypatch, match_payload
+    ):
+        monkeypatch.setattr(
+            "notifications.dispatcher.push_is_configured", lambda: False
+        )
+        subs = [
+            {"id": "sub", "user_id": "u", "endpoint": "x", "p256dh_key": "k", "auth_key": "a"},
+        ]
+        _patch_resolver(monkeypatch, subs)
+        notifier, push_send_fn = _make_notifier(
+            subs, {"u": dict(DEFAULT_PREFERENCES)}
+        )
+
+        notifier._send_push_fanout("goal", match_payload, "GOAL\nFoo")
+        push_send_fn.assert_not_called()
+        # And no batch query when nothing's getting sent.
+        notifier._prefs_dao.get_preferences_batch.assert_not_called()

--- a/backend/tests/unit/test_notification_preferences_dao.py
+++ b/backend/tests/unit/test_notification_preferences_dao.py
@@ -1,0 +1,166 @@
+"""Unit tests for NotificationPreferencesDAO (SB-57).
+
+Uses a mocked Supabase client. The DAO's value is in the merge-with-defaults
+logic and the batch-fetch shape — not in the SQL, which the migration's
+CHECK constraint and RLS policies already validate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dao.notification_preferences_dao import NotificationPreferencesDAO
+from notifications.preferences import DEFAULT_PREFERENCES
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend, pytest.mark.dao]
+
+
+def _make_dao() -> tuple[NotificationPreferencesDAO, MagicMock, MagicMock]:
+    """Build a DAO whose `client.table(...)` returns a fluent chainable mock."""
+    table_mock = MagicMock()
+    client_mock = MagicMock()
+    client_mock.table.return_value = table_mock
+    connection_holder = MagicMock()
+    connection_holder.get_client.return_value = client_mock
+
+    # Bypass BaseDAO's SupabaseConnection isinstance check by constructing
+    # the object directly and assigning the fields we need.
+    dao = NotificationPreferencesDAO.__new__(NotificationPreferencesDAO)
+    dao.connection_holder = connection_holder
+    dao.client = client_mock
+    return dao, client_mock, table_mock
+
+
+def _stub_select_returns(table_mock: MagicMock, rows: list[dict]) -> None:
+    """Wire up a chain like `.table(T).select(C).eq(...).execute()`."""
+    execute_mock = MagicMock()
+    execute_mock.data = rows
+    table_mock.select.return_value.eq.return_value.execute.return_value = execute_mock
+    table_mock.select.return_value.in_.return_value.execute.return_value = execute_mock
+
+
+class TestGetPreferences:
+    def test_returns_defaults_when_no_rows_stored(self):
+        dao, _client, table = _make_dao()
+        _stub_select_returns(table, [])
+
+        prefs = dao.get_preferences("user-1")
+
+        assert prefs == DEFAULT_PREFERENCES
+        # Returns a copy, not the module-level dict reference.
+        assert prefs is not DEFAULT_PREFERENCES
+
+    def test_stored_rows_override_defaults(self):
+        dao, _client, table = _make_dao()
+        _stub_select_returns(
+            table,
+            [
+                {"event_type": "goal", "enabled": False},
+                {"event_type": "yellow_card", "enabled": True},
+            ],
+        )
+
+        prefs = dao.get_preferences("user-1")
+
+        assert prefs["goal"] is False  # overridden
+        assert prefs["yellow_card"] is True  # overridden
+        assert prefs["kickoff"] is True  # default
+        assert prefs["red_card"] is False  # default
+        # All known event types are present.
+        assert set(prefs.keys()) == set(DEFAULT_PREFERENCES.keys())
+
+    def test_returns_defaults_on_query_error(self):
+        dao, _client, table = _make_dao()
+        table.select.return_value.eq.return_value.execute.side_effect = RuntimeError(
+            "db down"
+        )
+
+        prefs = dao.get_preferences("user-1")
+
+        assert prefs == DEFAULT_PREFERENCES
+
+
+class TestSetPreferences:
+    def test_upserts_only_known_event_types(self):
+        dao, _client, table = _make_dao()
+        upsert_mock = MagicMock()
+        upsert_mock.execute.return_value = MagicMock(data=[])
+        table.upsert.return_value = upsert_mock
+        # Subsequent get_preferences read after the set.
+        _stub_select_returns(table, [{"event_type": "goal", "enabled": False}])
+
+        result = dao.set_preferences(
+            "user-1", {"goal": False, "not_a_real_event": True}
+        )
+
+        # Only goal made it into the upsert payload.
+        upsert_args = table.upsert.call_args
+        rows = upsert_args.args[0]
+        assert len(rows) == 1
+        assert rows[0] == {"user_id": "user-1", "event_type": "goal", "enabled": False}
+        # on_conflict targets the composite PK.
+        assert upsert_args.kwargs.get("on_conflict") == "user_id,event_type"
+        # Result reflects the post-upsert read.
+        assert result["goal"] is False
+
+    def test_no_rows_no_upsert(self):
+        dao, _client, table = _make_dao()
+        _stub_select_returns(table, [])
+
+        # All keys unknown → nothing upserted, falls through to a read.
+        result = dao.set_preferences("user-1", {"junk": True})
+
+        table.upsert.assert_not_called()
+        assert result == DEFAULT_PREFERENCES
+
+    def test_coerces_truthy_values_to_bool(self):
+        dao, _client, table = _make_dao()
+        table.upsert.return_value.execute.return_value = MagicMock(data=[])
+        _stub_select_returns(table, [])
+
+        dao.set_preferences("user-1", {"goal": 1, "kickoff": ""})  # truthy/falsy
+
+        rows = table.upsert.call_args.args[0]
+        as_dict = {r["event_type"]: r["enabled"] for r in rows}
+        assert as_dict == {"goal": True, "kickoff": False}
+
+
+class TestGetPreferencesBatch:
+    def test_empty_user_list_returns_empty_dict(self):
+        dao, _client, table = _make_dao()
+
+        result = dao.get_preferences_batch([])
+
+        assert result == {}
+        table.select.assert_not_called()
+
+    def test_fills_defaults_for_users_with_no_rows(self):
+        dao, _client, table = _make_dao()
+        _stub_select_returns(
+            table,
+            [
+                {"user_id": "u1", "event_type": "goal", "enabled": False},
+            ],
+        )
+
+        result = dao.get_preferences_batch(["u1", "u2"])
+
+        assert result["u1"]["goal"] is False
+        assert result["u1"]["kickoff"] is True  # default
+        # u2 has no stored rows → entirely default.
+        assert result["u2"] == DEFAULT_PREFERENCES
+        # Defensive: returned dicts must include every known event type.
+        for prefs in result.values():
+            assert set(prefs.keys()) == set(DEFAULT_PREFERENCES.keys())
+
+    def test_returns_defaults_for_all_on_query_error(self):
+        dao, _client, table = _make_dao()
+        table.select.return_value.in_.return_value.execute.side_effect = (
+            RuntimeError("db down")
+        )
+
+        result = dao.get_preferences_batch(["u1", "u2"])
+
+        assert result == {"u1": DEFAULT_PREFERENCES, "u2": DEFAULT_PREFERENCES}

--- a/frontend/src/__tests__/components/NotificationsCard.spec.js
+++ b/frontend/src/__tests__/components/NotificationsCard.spec.js
@@ -1,0 +1,151 @@
+/**
+ * NotificationsCard.vue — focused tests for the SB-57 preferences section.
+ *
+ * The rest of the card (enable/disable, devices, follows) is exercised
+ * via manual + smoke tests; here we only validate the new "What to notify
+ * me about" toggles wire through to useNotificationPreferences correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref, computed } from 'vue';
+
+// Stub usePushNotifications so the component can mount without browser APIs.
+vi.mock('@/composables/usePushNotifications', () => ({
+  usePushNotifications: () => ({
+    isSupported: ref(true),
+    isEnabled: ref(true),
+    isBlocked: ref(false),
+    isIosBlocked: ref(false),
+    loading: ref(false),
+    lastError: ref(null),
+    enable: vi.fn(),
+    disable: vi.fn(),
+    listSubscriptions: vi.fn().mockResolvedValue([]),
+    sendTest: vi.fn(),
+  }),
+}));
+
+// Stub useTeamFollows — not under test here.
+vi.mock('@/composables/useTeamFollows', () => ({
+  useTeamFollows: () => ({
+    follows: computed(() => []),
+    refresh: vi.fn().mockResolvedValue(),
+  }),
+}));
+
+// Stub useNotificationPreferences with a controllable mock.
+let mockPrefs;
+let setPreferenceMock;
+let setCardsMock;
+let ensureLoadedMock;
+
+vi.mock('@/composables/useNotificationPreferences', () => ({
+  useNotificationPreferences: () => ({
+    preferences: computed(() => mockPrefs.value),
+    cardsEnabled: computed(
+      () => mockPrefs.value.yellow_card || mockPrefs.value.red_card
+    ),
+    loaded: ref(true),
+    loading: ref(false),
+    error: ref(null),
+    ensureLoaded: ensureLoadedMock,
+    setPreference: setPreferenceMock,
+    setCards: setCardsMock,
+  }),
+}));
+
+import NotificationsCard from '@/components/notifications/NotificationsCard.vue';
+
+beforeEach(() => {
+  mockPrefs = ref({
+    kickoff: true,
+    goal: true,
+    halftime: true,
+    fulltime: true,
+    yellow_card: false,
+    red_card: false,
+  });
+  setPreferenceMock = vi.fn().mockResolvedValue({ success: true });
+  setCardsMock = vi.fn().mockResolvedValue({ success: true });
+  ensureLoadedMock = vi.fn().mockResolvedValue();
+});
+
+describe('NotificationsCard preferences section (SB-57)', () => {
+  it('renders all five toggles when push is supported', async () => {
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="pref-toggle-kickoff"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('[data-testid="pref-toggle-goal"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('[data-testid="pref-toggle-halftime"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('[data-testid="pref-toggle-fulltime"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('[data-testid="pref-toggle-cards"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('reflects current preferences as checkbox state', async () => {
+    mockPrefs.value = {
+      kickoff: true,
+      goal: false,
+      halftime: true,
+      fulltime: true,
+      yellow_card: true,
+      red_card: false,
+    };
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="pref-toggle-goal"]').element.checked
+    ).toBe(false);
+    expect(
+      wrapper.find('[data-testid="pref-toggle-kickoff"]').element.checked
+    ).toBe(true);
+    // Cards toggle is true because yellow_card is true.
+    expect(
+      wrapper.find('[data-testid="pref-toggle-cards"]').element.checked
+    ).toBe(true);
+  });
+
+  it('toggling an individual event calls setPreference', async () => {
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const goalToggle = wrapper.find('[data-testid="pref-toggle-goal"]');
+    await goalToggle.setValue(false);
+    await flushPromises();
+
+    expect(setPreferenceMock).toHaveBeenCalledWith('goal', false);
+  });
+
+  it('toggling cards calls setCards once for both event types', async () => {
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const cardsToggle = wrapper.find('[data-testid="pref-toggle-cards"]');
+    await cardsToggle.setValue(true);
+    await flushPromises();
+
+    expect(setCardsMock).toHaveBeenCalledWith(true);
+    // Each event isn't separately toggled — that's the whole point of the
+    // combined UI control.
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it('calls ensureLoaded on mount so the section hydrates', async () => {
+    mount(NotificationsCard);
+    await flushPromises();
+
+    expect(ensureLoadedMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/composables/useNotificationPreferences.spec.js
+++ b/frontend/src/__tests__/composables/useNotificationPreferences.spec.js
@@ -1,0 +1,226 @@
+/**
+ * useNotificationPreferences tests (SB-57).
+ *
+ * Singleton composable. Reset via _resetNotificationPreferencesForTest
+ * between cases so module-level state doesn't leak.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const isAuthenticatedRef = { value: true };
+const apiRequestMock = vi.fn();
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: isAuthenticatedRef,
+    apiRequest: apiRequestMock,
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+import {
+  useNotificationPreferences,
+  _resetNotificationPreferencesForTest,
+  DEFAULT_PREFERENCES,
+} from '@/composables/useNotificationPreferences';
+
+beforeEach(() => {
+  apiRequestMock.mockReset();
+  isAuthenticatedRef.value = true;
+  _resetNotificationPreferencesForTest();
+});
+
+describe('useNotificationPreferences.ensureLoaded', () => {
+  it('hits GET once and populates preferences with defaults merged over stored', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      preferences: { ...DEFAULT_PREFERENCES, goal: false, yellow_card: true },
+    });
+
+    const { ensureLoaded, preferences, loaded } = useNotificationPreferences();
+    await ensureLoaded();
+
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'http://test.example/api/users/me/notification-preferences'
+    );
+    expect(loaded.value).toBe(true);
+    expect(preferences.value.goal).toBe(false);
+    expect(preferences.value.yellow_card).toBe(true);
+    expect(preferences.value.kickoff).toBe(true);
+  });
+
+  it('does not refetch when already loaded', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES });
+
+    const a = useNotificationPreferences();
+    await a.ensureLoaded();
+    await a.ensureLoaded();
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent ensureLoaded calls', async () => {
+    apiRequestMock.mockImplementationOnce(
+      () =>
+        new Promise(resolve =>
+          setTimeout(() => resolve({ preferences: DEFAULT_PREFERENCES }), 5)
+        )
+    );
+
+    const a = useNotificationPreferences();
+    await Promise.all([a.ensureLoaded(), a.ensureLoaded(), a.ensureLoaded()]);
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns defaults without a network call when unauthenticated', async () => {
+    isAuthenticatedRef.value = false;
+    const { ensureLoaded, preferences, loaded } = useNotificationPreferences();
+    await ensureLoaded();
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(loaded.value).toBe(true);
+    expect(preferences.value).toEqual(DEFAULT_PREFERENCES);
+  });
+});
+
+describe('useNotificationPreferences.setPreference', () => {
+  it('optimistically updates + PUTs the new value, replaces with server echo', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES }); // initial GET
+    apiRequestMock.mockResolvedValueOnce({
+      preferences: { ...DEFAULT_PREFERENCES, goal: false },
+    }); // PUT
+
+    const { ensureLoaded, setPreference, preferences } =
+      useNotificationPreferences();
+    await ensureLoaded();
+
+    const result = await setPreference('goal', false);
+
+    expect(result.success).toBe(true);
+    expect(preferences.value.goal).toBe(false);
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      'http://test.example/api/users/me/notification-preferences',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ preferences: { goal: false } }),
+      }
+    );
+  });
+
+  it('reverts the optimistic change when the PUT fails', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES });
+    apiRequestMock.mockRejectedValueOnce(new Error('boom'));
+
+    const { ensureLoaded, setPreference, preferences, error } =
+      useNotificationPreferences();
+    await ensureLoaded();
+
+    const result = await setPreference('goal', false);
+
+    expect(result.success).toBe(false);
+    expect(preferences.value.goal).toBe(true); // reverted
+    expect(error.value).toBe('boom');
+  });
+
+  it('is idempotent — no PUT when the value already matches', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES });
+
+    const { ensureLoaded, setPreference } = useNotificationPreferences();
+    await ensureLoaded();
+    expect(apiRequestMock).toHaveBeenCalledTimes(1);
+
+    // goal is already true by default — re-setting to true is a no-op.
+    const result = await setPreference('goal', true);
+    expect(result.success).toBe(true);
+    expect(apiRequestMock).toHaveBeenCalledTimes(1); // still just the initial GET
+  });
+
+  it('rejects unknown event types', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES });
+    const { ensureLoaded, setPreference } = useNotificationPreferences();
+    await ensureLoaded();
+
+    const result = await setPreference('bogus', true);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Unknown event_type/);
+    expect(apiRequestMock).toHaveBeenCalledTimes(1); // no PUT fired
+  });
+});
+
+describe('useNotificationPreferences.setCards', () => {
+  it('updates yellow_card + red_card together in a single PUT', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES });
+    apiRequestMock.mockResolvedValueOnce({
+      preferences: {
+        ...DEFAULT_PREFERENCES,
+        yellow_card: true,
+        red_card: true,
+      },
+    });
+
+    const { ensureLoaded, setCards, preferences } =
+      useNotificationPreferences();
+    await ensureLoaded();
+
+    await setCards(true);
+
+    expect(preferences.value.yellow_card).toBe(true);
+    expect(preferences.value.red_card).toBe(true);
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          preferences: { yellow_card: true, red_card: true },
+        }),
+      })
+    );
+  });
+
+  it('cardsEnabled reflects either-yellow-or-red as true', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      preferences: {
+        ...DEFAULT_PREFERENCES,
+        yellow_card: true,
+        red_card: false,
+      },
+    });
+
+    const { ensureLoaded, cardsEnabled } = useNotificationPreferences();
+    await ensureLoaded();
+
+    expect(cardsEnabled.value).toBe(true);
+  });
+
+  it('reverts both flags when the PUT fails', async () => {
+    apiRequestMock.mockResolvedValueOnce({ preferences: DEFAULT_PREFERENCES });
+    apiRequestMock.mockRejectedValueOnce(new Error('nope'));
+
+    const { ensureLoaded, setCards, preferences } =
+      useNotificationPreferences();
+    await ensureLoaded();
+
+    await setCards(true);
+
+    expect(preferences.value.yellow_card).toBe(false);
+    expect(preferences.value.red_card).toBe(false);
+  });
+});
+
+describe('useNotificationPreferences singleton', () => {
+  it('shares state across multiple callers', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      preferences: { ...DEFAULT_PREFERENCES, goal: false },
+    });
+
+    const a = useNotificationPreferences();
+    await a.ensureLoaded();
+
+    const b = useNotificationPreferences();
+    expect(b.preferences.value.goal).toBe(false);
+  });
+});

--- a/frontend/src/components/notifications/NotificationsCard.vue
+++ b/frontend/src/components/notifications/NotificationsCard.vue
@@ -82,6 +82,81 @@
       </ul>
     </div>
 
+    <!-- Notification preferences (SB-57) -->
+    <div v-if="isSupported" class="preferences-section">
+      <h4>What to notify me about</h4>
+      <ul class="preferences-list">
+        <li class="preference-item">
+          <label class="preference-label">
+            <input
+              type="checkbox"
+              class="preference-checkbox"
+              :checked="preferences.kickoff"
+              :disabled="!preferencesLoaded"
+              data-testid="pref-toggle-kickoff"
+              @change="onTogglePref('kickoff', $event.target.checked)"
+            />
+            <span class="preference-name">Kickoff</span>
+          </label>
+        </li>
+        <li class="preference-item">
+          <label class="preference-label">
+            <input
+              type="checkbox"
+              class="preference-checkbox"
+              :checked="preferences.goal"
+              :disabled="!preferencesLoaded"
+              data-testid="pref-toggle-goal"
+              @change="onTogglePref('goal', $event.target.checked)"
+            />
+            <span class="preference-name">Goals</span>
+          </label>
+        </li>
+        <li class="preference-item">
+          <label class="preference-label">
+            <input
+              type="checkbox"
+              class="preference-checkbox"
+              :checked="preferences.halftime"
+              :disabled="!preferencesLoaded"
+              data-testid="pref-toggle-halftime"
+              @change="onTogglePref('halftime', $event.target.checked)"
+            />
+            <span class="preference-name">Halftime</span>
+          </label>
+        </li>
+        <li class="preference-item">
+          <label class="preference-label">
+            <input
+              type="checkbox"
+              class="preference-checkbox"
+              :checked="preferences.fulltime"
+              :disabled="!preferencesLoaded"
+              data-testid="pref-toggle-fulltime"
+              @change="onTogglePref('fulltime', $event.target.checked)"
+            />
+            <span class="preference-name">Fulltime</span>
+          </label>
+        </li>
+        <li class="preference-item">
+          <label class="preference-label">
+            <input
+              type="checkbox"
+              class="preference-checkbox"
+              :checked="cardsEnabled"
+              :disabled="!preferencesLoaded"
+              data-testid="pref-toggle-cards"
+              @change="onToggleCards($event.target.checked)"
+            />
+            <span class="preference-name">Cards (yellow + red)</span>
+          </label>
+        </li>
+      </ul>
+      <p v-if="preferencesError" class="notifications-error">
+        Couldn't save preference: {{ preferencesError }}
+      </p>
+    </div>
+
     <!-- Followed teams (read-only summary) -->
     <div v-if="isSupported" class="follows-section">
       <h4>Teams you follow</h4>
@@ -107,6 +182,7 @@
 import { ref, onMounted } from 'vue';
 import { usePushNotifications } from '../../composables/usePushNotifications';
 import { useTeamFollows } from '../../composables/useTeamFollows';
+import { useNotificationPreferences } from '../../composables/useNotificationPreferences';
 
 const {
   isSupported,
@@ -124,13 +200,36 @@ const {
 // Shared singleton (SB-55): same `follows` reactive list every FollowButton mutates.
 const { follows, refresh: refreshFollows } = useTeamFollows();
 
+// Per-event preferences (SB-57).
+const {
+  preferences,
+  cardsEnabled,
+  loaded: preferencesLoaded,
+  error: preferencesError,
+  ensureLoaded: ensurePreferencesLoaded,
+  setPreference,
+  setCards,
+} = useNotificationPreferences();
+
 const subscriptions = ref([]);
 const lastMessage = ref('');
 
 async function refresh() {
   if (!isSupported.value) return;
-  const [subs] = await Promise.all([listSubscriptions(), refreshFollows()]);
+  const [subs] = await Promise.all([
+    listSubscriptions(),
+    refreshFollows(),
+    ensurePreferencesLoaded(),
+  ]);
   subscriptions.value = subs;
+}
+
+async function onTogglePref(eventType, enabled) {
+  await setPreference(eventType, enabled);
+}
+
+async function onToggleCards(enabled) {
+  await setCards(enabled);
 }
 
 async function onEnable() {
@@ -332,10 +431,67 @@ onMounted(refresh);
 }
 
 .manage-section,
-.follows-section {
+.follows-section,
+.preferences-section {
   margin-top: 20px;
   border-top: 1px solid #f3f4f6;
   padding-top: 16px;
+}
+
+/* Notification preferences (SB-57) */
+.preferences-section h4 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.preferences-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.preference-item {
+  padding: 0;
+}
+
+.preference-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  min-height: 44px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.preference-label:hover {
+  background: #f9fafb;
+}
+
+.preference-checkbox {
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  cursor: pointer;
+  accent-color: #0257fe;
+  flex-shrink: 0;
+}
+
+.preference-checkbox:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.preference-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #111827;
 }
 
 .manage-section h4,

--- a/frontend/src/composables/useNotificationPreferences.js
+++ b/frontend/src/composables/useNotificationPreferences.js
@@ -1,0 +1,192 @@
+/**
+ * Notification-preferences composable (SB-57).
+ *
+ * Singleton reactive state for per-event push opt-in flags. Mirrors the
+ * useTeamFollows.js pattern from SB-55 — module-level reactive state, every
+ * call to useNotificationPreferences() returns the same refs.
+ *
+ * Backend (idempotent, lazy-default on the server):
+ *   GET /api/users/me/notification-preferences   → { preferences: {event_type: bool, ...} }
+ *   PUT /api/users/me/notification-preferences   body: { preferences: {...} } → same shape
+ *
+ * Defaults must mirror backend/notifications/preferences.py so the UI can
+ * render correctly before the first GET completes.
+ */
+
+import { reactive, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+
+export const EVENT_TYPES = Object.freeze([
+  'kickoff',
+  'goal',
+  'halftime',
+  'fulltime',
+  'yellow_card',
+  'red_card',
+]);
+
+export const DEFAULT_PREFERENCES = Object.freeze({
+  kickoff: true,
+  goal: true,
+  halftime: true,
+  fulltime: true,
+  yellow_card: false,
+  red_card: false,
+});
+
+const state = reactive({
+  preferences: { ...DEFAULT_PREFERENCES },
+  loaded: false,
+  loading: false,
+  error: null,
+});
+
+let inflightLoad = null;
+
+async function fetchPreferences() {
+  const authStore = useAuthStore();
+  if (!authStore.isAuthenticated.value) {
+    state.preferences = { ...DEFAULT_PREFERENCES };
+    state.loaded = true;
+    return;
+  }
+
+  state.loading = true;
+  state.error = null;
+  try {
+    const data = await authStore.apiRequest(
+      `${getApiBaseUrl()}/api/users/me/notification-preferences`
+    );
+    state.preferences = {
+      ...DEFAULT_PREFERENCES,
+      ...(data?.preferences || {}),
+    };
+    state.loaded = true;
+  } catch (err) {
+    state.error = err.message || String(err);
+    state.preferences = { ...DEFAULT_PREFERENCES };
+  } finally {
+    state.loading = false;
+  }
+}
+
+export function useNotificationPreferences() {
+  const authStore = useAuthStore();
+
+  const ensureLoaded = () => {
+    if (state.loaded || state.loading) return inflightLoad || Promise.resolve();
+    inflightLoad = fetchPreferences().finally(() => {
+      inflightLoad = null;
+    });
+    return inflightLoad;
+  };
+
+  const refresh = () => {
+    inflightLoad = fetchPreferences().finally(() => {
+      inflightLoad = null;
+    });
+    return inflightLoad;
+  };
+
+  const setPreference = async (eventType, enabled) => {
+    if (!EVENT_TYPES.includes(eventType)) {
+      return { success: false, error: `Unknown event_type: ${eventType}` };
+    }
+    const prev = state.preferences[eventType];
+    if (prev === enabled) return { success: true };
+
+    // Optimistic
+    state.preferences = { ...state.preferences, [eventType]: enabled };
+    state.error = null;
+    try {
+      const data = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/notification-preferences`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ preferences: { [eventType]: enabled } }),
+        }
+      );
+      // Backend echoes the merged state — trust it over the optimistic guess
+      // in case other devices changed prefs in parallel.
+      if (data?.preferences) {
+        state.preferences = {
+          ...DEFAULT_PREFERENCES,
+          ...data.preferences,
+        };
+      }
+      return { success: true };
+    } catch (err) {
+      state.preferences = { ...state.preferences, [eventType]: prev };
+      state.error = err.message || String(err);
+      return { success: false, error: state.error };
+    }
+  };
+
+  // Combined cards toggle — sets yellow_card and red_card together.
+  // Backend stores them separately so SB-58/future per-card prefs stay
+  // possible without a schema change.
+  const setCards = async enabled => {
+    const prevYellow = state.preferences.yellow_card;
+    const prevRed = state.preferences.red_card;
+    if (prevYellow === enabled && prevRed === enabled) {
+      return { success: true };
+    }
+
+    state.preferences = {
+      ...state.preferences,
+      yellow_card: enabled,
+      red_card: enabled,
+    };
+    state.error = null;
+    try {
+      const data = await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/notification-preferences`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            preferences: { yellow_card: enabled, red_card: enabled },
+          }),
+        }
+      );
+      if (data?.preferences) {
+        state.preferences = {
+          ...DEFAULT_PREFERENCES,
+          ...data.preferences,
+        };
+      }
+      return { success: true };
+    } catch (err) {
+      state.preferences = {
+        ...state.preferences,
+        yellow_card: prevYellow,
+        red_card: prevRed,
+      };
+      state.error = err.message || String(err);
+      return { success: false, error: state.error };
+    }
+  };
+
+  return {
+    preferences: computed(() => state.preferences),
+    cardsEnabled: computed(
+      () => state.preferences.yellow_card || state.preferences.red_card
+    ),
+    loaded: computed(() => state.loaded),
+    loading: computed(() => state.loading),
+    error: computed(() => state.error),
+    ensureLoaded,
+    refresh,
+    setPreference,
+    setCards,
+  };
+}
+
+// Test-only: reset module-level singleton between tests.
+export function _resetNotificationPreferencesForTest() {
+  state.preferences = { ...DEFAULT_PREFERENCES };
+  state.loaded = false;
+  state.loading = false;
+  state.error = null;
+  inflightLoad = null;
+}

--- a/supabase-local/migrations/20260527010000_add_user_notification_preferences.sql
+++ b/supabase-local/migrations/20260527010000_add_user_notification_preferences.sql
@@ -1,0 +1,67 @@
+-- Per-event push notification preferences (SB-57).
+--
+-- Today the push pipeline is all-or-nothing per followed team. Fans following
+-- multiple teams (especially after SB-56 widened the follow surface) get every
+-- kickoff/goal/halftime/fulltime for every team. Cards are globally muted via
+-- a hard-coded skip in the dispatcher.
+--
+-- This table lets users opt in/out per event type. Missing rows fall back to
+-- code-level defaults (see backend/notifications/preferences.py), so existing
+-- users get current behavior with zero backfill — only users who explicitly
+-- toggle anything ever have rows here.
+--
+-- Composite primary key (user_id, event_type) keeps the schema extensible:
+-- new event types (e.g. score_update from SB-58) just need new rows, not a
+-- migration.
+
+CREATE TABLE public.user_notification_preferences (
+    user_id    uuid    NOT NULL REFERENCES public.user_profiles(id) ON DELETE CASCADE,
+    event_type text    NOT NULL,
+    enabled    boolean NOT NULL DEFAULT true,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, event_type),
+    CONSTRAINT user_notification_preferences_event_type_check
+        CHECK (event_type IN ('kickoff', 'goal', 'halftime', 'fulltime', 'yellow_card', 'red_card'))
+);
+
+CREATE INDEX idx_user_notification_preferences_user
+    ON public.user_notification_preferences(user_id);
+
+ALTER TABLE public.user_notification_preferences ENABLE ROW LEVEL SECURITY;
+
+-- Users see and manage only their own preferences.
+CREATE POLICY user_notification_preferences_user_select
+    ON public.user_notification_preferences FOR SELECT
+    USING (user_id = auth.uid());
+
+CREATE POLICY user_notification_preferences_user_insert
+    ON public.user_notification_preferences FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY user_notification_preferences_user_update
+    ON public.user_notification_preferences FOR UPDATE
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY user_notification_preferences_user_delete
+    ON public.user_notification_preferences FOR DELETE
+    USING (user_id = auth.uid());
+
+-- Admins read all for support debugging.
+CREATE POLICY user_notification_preferences_admin_all
+    ON public.user_notification_preferences FOR ALL
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.user_profiles up
+            WHERE up.id = auth.uid() AND up.role = 'admin'
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.user_profiles up
+            WHERE up.id = auth.uid() AND up.role = 'admin'
+        )
+    );
+
+COMMENT ON TABLE public.user_notification_preferences IS
+    'Per-user per-event-type push notification opt-in flags. Missing rows mean "use default".';


### PR DESCRIPTION
Closes SB-57. Replaces the hard-coded "cards always off" rule in the dispatcher with per-user opt-in flags for every event type. With SB-55 + SB-56 (PR #410, pending merge) expanding the follow surface, this ships the volume control before notification fatigue arrives.

## Decisions (from planning)
- **One combined "Cards" toggle** in the UI (sets both `yellow_card` and `red_card`). Schema keeps them separate so SB-58/future granularity is possible without a migration.
- **Cards default OFF** — preserves the pre-SB-57 dispatcher behavior. Zero existing follower gets a surprise notification on deploy.
- **Defaults in code, not in DB** — adjusting defaults later won't require a migration.

## Schema
New migration `supabase-local/migrations/20260527010000_add_user_notification_preferences.sql`:
- Composite PK `(user_id, event_type)`, single `enabled boolean`, CHECK constraint on the 6 known event types.
- RLS mirrors `push_subscriptions` (user owns their rows; admins read all).
- Lazy row creation — missing rows fall through to `DEFAULT_PREFERENCES` in `backend/notifications/preferences.py`. No backfill needed.

## Backend
- **`NotificationPreferencesDAO`** mirrors `TeamFollowDAO`'s shape. `get_preferences_batch(user_ids)` is the dispatcher hot-path — one SELECT per event, defaults filled for users without rows.
- **`GET` / `PUT /api/users/me/notification-preferences`** endpoints in `push.py`. PUT validates against the known event_type enum (422 on unknown).
- **Dispatcher refactor** (`backend/notifications/dispatcher.py`): the hard-coded yellow/red short-circuit is gone. Every event flows through a per-user pref check; one batch query for the whole fanout. DAO is lazy-imported inside the property to break the cycle `dao → notifications.preferences → notifications/__init__ → dispatcher → dao`.

## Frontend
- **`useNotificationPreferences.js`** — singleton composable mirroring `useTeamFollows.js`. Optimistic update with revert on error. `setCards` convenience wraps the combined toggle.
- **`NotificationsCard.vue`** — new "What to notify me about" section between Manage devices and Teams you follow. Five checkboxes (Kickoff / Goals / Halftime / Fulltime / Cards). Tap targets ≥44px per `feedback_mobile_first_ui.md`.

## Tests
- Backend: **24 new** — 17 unit (DAO + dispatcher) + 7 API contract. ✅
- Frontend: **17 new** (12 composable + 5 component) → full suite **385/385**. ✅
- Lint: ✅

## Test plan
Per `feedback_mobile_first_ui.md` — desktop + mobile both required.

**Desktop (Mac Chrome)** on http://localhost:8080
- [ ] Profile → Notifications card → see new "What to notify me about" section between Manage devices and Teams you follow.
- [ ] Defaults render correctly: Kickoff/Goals/Halftime/Fulltime checked, Cards unchecked.
- [ ] Toggle Goals OFF → admin posts a goal in a live match for a followed team → no push arrives.
- [ ] Toggle Cards ON → admin posts a yellow or red card → push arrives.
- [ ] Refresh the page → toggles reflect the saved state.
- [ ] Open the same user in a second browser → flipping a toggle in one window is visible after a refresh in the other (per-user, not per-device).

**iPhone Safari (PWA) + Pixel 10**
- [ ] All five checkboxes are easy to tap on a narrow viewport (≥44px each).
- [ ] Toggling Cards mid-match — admin posts a card → push lands on phone.

**Regression sanity**
- [ ] Existing users with no prefs row still get goal/kickoff/halftime/fulltime pushes as before.
- [ ] Existing users with no prefs row still don't get card pushes.
- [ ] `_send_push_fanout` batch query fires at most once per event (check logs for `notifications.push_dispatched` with the new `skipped_pref` field).

## Migration
Local: \`cd supabase-local && npx supabase db reset\` (or \`./scripts/db_tools.sh migrate local\`)
Prod: \`./scripts/db_tools.sh migrate prod\` after merge.

## Related
- **SB-55** (PR #409, merged) — built the FollowButton + composable.
- **SB-56** (PR #410, pending merge) — added the My Club follow surface. Once it ships, this PR's volume controls protect fans from the fatigue that follow expansion would otherwise create.
- **SB-58** — scraper-triggered final-score notifications. When it ships, just add `score_update` to the event_type CHECK and `DEFAULT_PREFERENCES` and it picks up the prefs system for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)