### PR TITLE
fix(skill): include bracket fields in tournament matches output

### DIFF
--- a/.claude/skills/load-tournament-matches/scripts/mt.py
+++ b/.claude/skills/load-tournament-matches/scripts/mt.py
@@ -349,6 +349,11 @@ def tournament_matches(tournament_id: int = typer.Argument(...)) -> None:
             return {"id": side.get("id"), "name": side.get("name")}
         return None
 
+    def _age_group(ag: object) -> dict | None:
+        if isinstance(ag, dict):
+            return {"id": ag.get("id"), "name": ag.get("name")}
+        return None
+
     matches = [
         {
             "id": m.get("id"),
@@ -356,6 +361,15 @@ def tournament_matches(tournament_id: int = typer.Argument(...)) -> None:
             "scheduled_kickoff": m.get("scheduled_kickoff"),
             "match_status": m.get("match_status"),
             "tournament_round": m.get("tournament_round"),
+            # Bracket-position fields — required for Step 5 reconcile + the
+            # mandatory bracket sanity checks. Omitting these caused the
+            # 2026-05-28 MLS NEXT Cup U15 SF incident: existing matches
+            # reported group=None/order=None, so the next match was loaded
+            # the same way and silently dropped out of the bracket view
+            # (frontend filter is `tournament_group === selected`).
+            "tournament_group": m.get("tournament_group"),
+            "tournament_round_order": m.get("tournament_round_order"),
+            "age_group": _age_group(m.get("age_group")),
             "home_team": _team(m.get("home_team")),
             "away_team": _team(m.get("away_team")),
             "home_score": m.get("home_score"),


### PR DESCRIPTION
## Summary
`load-tournament-matches` skill's `mt.py tournament matches <id>` was projecting matches down to a fixed list of fields and silently dropping `tournament_group`, `tournament_round_order`, and `age_group`. Step 5 of the skill (reconcile + mandatory bracket sanity checks) reads those exact fields, so without them the sanity checks were no-ops.

## The incident this is from
2026-05-28 (today). I was adding the second U15 SF to the 2026 MLS NEXT Cup (Houston Rangers vs Cedar Stars Academy Bergen) ahead of the kickoff. Step 5 read the existing SF id=3165 via `tournament matches`, saw `group=None / order=None`, decided "match the existing convention", and created the new match with both fields null. Result: the match dropped out of the bracket UI (frontend filter is `m.tournament_group === selectedGroup`).

The existing SF actually had `group='Championship' / order=0` the whole time — the CLI just wasn't returning those fields. Verified by hitting `/api/tournaments/4` directly afterwards.

## Fix
Add the three fields to the projection in `tournament_matches()`:
- `tournament_group`
- `tournament_round_order`
- `age_group` (with the same `_age_group` helper pattern already used for `home_team` / `away_team`)

## Test plan
- [x] `mt.py tournament matches 4` against prod now returns `tournament_group`, `tournament_round_order`, `age_group` for the two U15 semifinals.
- [x] Houston Rangers vs Cedar Stars Bergen SF backfilled with the right bracket fields and is now visible on the bracket page.

## Why no automated test
The skill scripts don't have a unit test harness today (they're thin typer wrappers around `api_client`). Worth adding a smoke test, but that's a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)