### PR TITLE
fix(admin): real per-season match counts on Seasons page (SB-61)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2008,6 +2008,24 @@ async def get_seasons(current_user: dict[str, Any] = Depends(get_current_user_re
         ) from e
 
 
+@app.get("/api/seasons/match-counts")
+async def get_season_match_counts(current_user: dict[str, Any] = Depends(require_admin)):
+    """Per-season match counts for the Admin → Seasons page (SB-61).
+
+    Replaces the previous client-side approach of fetching all matches via
+    /api/matches and counting them in the browser — which silently capped at
+    Supabase's 1000-row default and showed bogus counts.
+    """
+    try:
+        return season_dao.get_match_counts_by_season()
+    except Exception as e:
+        logger.error(f"Error retrieving season match counts: {e!s}", exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Database connection failed. Please check Supabase connection.",
+        ) from e
+
+
 @app.get("/api/current-season")
 async def get_current_season(current_user: dict[str, Any] = Depends(get_current_user_required)):
     """Get the current active season."""

--- a/backend/dao/season_dao.py
+++ b/backend/dao/season_dao.py
@@ -123,6 +123,68 @@ class SeasonDAO(BaseDAO):
             logger.info("No current season found", error=str(e))
             return None
 
+    # Cache key lives in the `matches:` namespace so it's invalidated by
+    # MATCHES_CACHE_PATTERN whenever any match is created/updated/deleted.
+    @dao_cache("matches:counts_by_season")
+    def get_match_counts_by_season(self) -> list[dict]:
+        """Return [{season_id, match_count}] for every season.
+
+        Backs the Admin → Seasons page (SB-61). The previous client-side
+        approach fetched all matches from /api/matches and filtered by
+        season_id, which silently capped at Supabase's 1000-row default and
+        showed bogus counts (always 1000 for the current season, 0 for
+        everything older).
+
+        One row per season; missing seasons (no matches) still appear with
+        match_count=0 — the seasons list is the source of truth, the count
+        is just a join.
+        """
+        try:
+            # PostgREST embedded resource with count: one round-trip for
+            # every season and its match count. Falls back to N+1 if the
+            # embedded count isn't accepted.
+            response = (
+                self.client.table("seasons")
+                .select("id, matches(count)")
+                .execute()
+            )
+            counts = []
+            for row in response.data or []:
+                # `matches` comes back as a list of {count: N} when the
+                # embedded count modifier is honored.
+                matches_field = row.get("matches") or []
+                if isinstance(matches_field, list) and matches_field:
+                    match_count = matches_field[0].get("count") or 0
+                else:
+                    match_count = 0
+                counts.append({"season_id": row["id"], "match_count": match_count})
+            return counts
+        except Exception:
+            logger.exception("Error querying match counts by season; falling back to N+1")
+            # Fallback: count per season individually. Seasons are few (<10
+            # in practice), so the extra round-trips are fine.
+            try:
+                seasons = (
+                    self.client.table("seasons").select("id").execute().data or []
+                )
+                counts = []
+                for season in seasons:
+                    sid = season["id"]
+                    resp = (
+                        self.client.table("matches")
+                        .select("id", count="exact")
+                        .eq("season_id", sid)
+                        .limit(0)
+                        .execute()
+                    )
+                    counts.append(
+                        {"season_id": sid, "match_count": resp.count or 0}
+                    )
+                return counts
+            except Exception:
+                logger.exception("Error in N+1 fallback for season match counts")
+                return []
+
     @dao_cache("seasons:active")
     def get_active_seasons(self) -> list[dict]:
         """Get active seasons (current and future) for scheduling new matches."""

--- a/backend/tests/unit/dao/test_season_match_counts.py
+++ b/backend/tests/unit/dao/test_season_match_counts.py
@@ -1,0 +1,161 @@
+"""Unit tests for SeasonDAO.get_match_counts_by_season (SB-61).
+
+Uses a mocked Supabase client. The DAO's value is the data-shape parsing of
+PostgREST's embedded-count response + the N+1 fallback when the embedded
+path fails.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dao.season_dao import SeasonDAO
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend, pytest.mark.dao]
+
+
+def _make_dao() -> tuple[SeasonDAO, MagicMock]:
+    """Build a SeasonDAO whose `client.table(...)` is a chainable mock."""
+    client_mock = MagicMock()
+    connection_holder = MagicMock()
+    connection_holder.get_client.return_value = client_mock
+
+    dao = SeasonDAO.__new__(SeasonDAO)
+    dao.connection_holder = connection_holder
+    dao.client = client_mock
+    return dao, client_mock
+
+
+class TestEmbeddedCountPath:
+    def test_parses_postgrest_embedded_count_into_flat_rows(self):
+        dao, client = _make_dao()
+        client.table.return_value.select.return_value.execute.return_value = MagicMock(
+            data=[
+                {"id": 1, "matches": [{"count": 1437}]},
+                {"id": 2, "matches": [{"count": 980}]},
+                {"id": 3, "matches": [{"count": 0}]},
+            ]
+        )
+
+        counts = dao.get_match_counts_by_season()
+
+        assert counts == [
+            {"season_id": 1, "match_count": 1437},
+            {"season_id": 2, "match_count": 980},
+            {"season_id": 3, "match_count": 0},
+        ]
+        client.table.assert_called_with("seasons")
+
+    def test_treats_missing_matches_array_as_zero(self):
+        dao, client = _make_dao()
+        client.table.return_value.select.return_value.execute.return_value = MagicMock(
+            data=[
+                {"id": 1, "matches": []},
+                {"id": 2},  # field omitted entirely
+                {"id": 3, "matches": [{}]},  # count missing on the inner dict
+            ]
+        )
+
+        counts = dao.get_match_counts_by_season()
+
+        assert counts == [
+            {"season_id": 1, "match_count": 0},
+            {"season_id": 2, "match_count": 0},
+            {"season_id": 3, "match_count": 0},
+        ]
+
+    def test_empty_response_returns_empty_list(self):
+        dao, client = _make_dao()
+        client.table.return_value.select.return_value.execute.return_value = MagicMock(
+            data=[]
+        )
+
+        assert dao.get_match_counts_by_season() == []
+
+
+class TestFallbackPath:
+    def test_falls_back_to_per_season_count_when_embedded_fails(self):
+        dao, client = _make_dao()
+
+        # First call: seasons.select("id, matches(count)").execute() raises.
+        # Second call: seasons.select("id").execute() returns the season list.
+        # Third+: matches.select("id", count="exact")... returns per-season counts.
+        seasons_select = MagicMock()
+        seasons_select.execute.side_effect = [
+            RuntimeError("embedded count not supported"),  # primary path fails
+            MagicMock(data=[{"id": 1}, {"id": 2}]),  # fallback fetches seasons
+        ]
+
+        per_season_calls = []
+
+        def matches_table_side_effect(name):
+            if name == "seasons":
+                client.table.side_effect = None  # only first call uses this side_effect
+                return MagicMock(select=MagicMock(return_value=seasons_select))
+            if name == "matches":
+                m = MagicMock()
+                # .select("id", count="exact").eq("season_id", N).limit(0).execute()
+                eq_chain = MagicMock()
+                count_result = MagicMock()
+                count_result.count = 100 + len(per_season_calls)
+                per_season_calls.append(count_result.count)
+                eq_chain.limit.return_value.execute.return_value = count_result
+                m.select.return_value.eq.return_value = eq_chain
+                return m
+            return MagicMock()
+
+        # First call to client.table is for the embedded path.
+        primary_select = MagicMock()
+        primary_select.execute.side_effect = RuntimeError("embedded count not supported")
+        client.table.return_value.select.return_value = primary_select
+
+        # Reset table side effects for the fallback so each table() call returns the right mock.
+        seasons_after_fallback = MagicMock()
+        seasons_after_fallback.select.return_value.execute.return_value = MagicMock(
+            data=[{"id": 1}, {"id": 2}]
+        )
+
+        matches_mock_1 = MagicMock()
+        c1 = MagicMock()
+        c1.count = 1437
+        matches_mock_1.select.return_value.eq.return_value.limit.return_value.execute.return_value = c1
+
+        matches_mock_2 = MagicMock()
+        c2 = MagicMock()
+        c2.count = 980
+        matches_mock_2.select.return_value.eq.return_value.limit.return_value.execute.return_value = c2
+
+        # client.table call sequence:
+        # 1. table("seasons") for the embedded path (raises on execute)
+        # 2. table("seasons") for the fallback list
+        # 3. table("matches") for season 1's count
+        # 4. table("matches") for season 2's count
+        first_seasons = MagicMock()
+        first_seasons.select.return_value.execute.side_effect = RuntimeError("nope")
+
+        client.table.side_effect = [
+            first_seasons,
+            seasons_after_fallback,
+            matches_mock_1,
+            matches_mock_2,
+        ]
+
+        counts = dao.get_match_counts_by_season()
+
+        assert counts == [
+            {"season_id": 1, "match_count": 1437},
+            {"season_id": 2, "match_count": 980},
+        ]
+
+    def test_returns_empty_list_if_both_paths_fail(self):
+        dao, client = _make_dao()
+        # Embedded path raises; fallback seasons select also raises.
+        first_seasons = MagicMock()
+        first_seasons.select.return_value.execute.side_effect = RuntimeError("a")
+        fallback_seasons = MagicMock()
+        fallback_seasons.select.return_value.execute.side_effect = RuntimeError("b")
+        client.table.side_effect = [first_seasons, fallback_seasons]
+
+        assert dao.get_match_counts_by_season() == []

--- a/frontend/src/__tests__/components/AdminSeasons.spec.js
+++ b/frontend/src/__tests__/components/AdminSeasons.spec.js
@@ -1,0 +1,119 @@
+/**
+ * AdminSeasons.vue — match counts column (SB-61).
+ *
+ * Pre-SB-61 this component fetched /api/matches (capped at Supabase's 1000-row
+ * default) and counted client-side, so the current season displayed exactly
+ * 1000 and older seasons displayed 0. The fix moves counting to a new
+ * /api/seasons/match-counts admin endpoint and renames the column.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import AdminSeasons from '@/components/admin/AdminSeasons.vue';
+
+let mockAuthStore;
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => mockAuthStore }));
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://localhost:8000',
+}));
+
+const SEASONS = [
+  {
+    id: 1,
+    name: '2025-2026',
+    start_date: '2025-09-01',
+    end_date: '2026-06-30',
+  },
+  {
+    id: 2,
+    name: '2024-2025',
+    start_date: '2024-09-01',
+    end_date: '2025-06-30',
+  },
+  {
+    id: 3,
+    name: '2023-2024',
+    start_date: '2023-09-01',
+    end_date: '2024-06-30',
+  },
+];
+
+const MATCH_COUNTS = [
+  { season_id: 1, match_count: 1437 },
+  { season_id: 2, match_count: 980 },
+  { season_id: 3, match_count: 412 },
+];
+
+const mountSeasons = (overrides = {}) => {
+  const apiRequest = vi.fn(url => {
+    if (url.endsWith('/api/seasons')) {
+      return Promise.resolve(overrides.seasons ?? SEASONS);
+    }
+    if (url.endsWith('/api/seasons/match-counts')) {
+      return Promise.resolve(overrides.matchCounts ?? MATCH_COUNTS);
+    }
+    return Promise.resolve([]);
+  });
+  mockAuthStore = { apiRequest };
+  return mount(AdminSeasons);
+};
+
+describe('AdminSeasons match counts (SB-61)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Matches Count" column header (not "Games Count")', async () => {
+    const wrapper = mountSeasons();
+    await flushPromises();
+
+    const header = wrapper.find('[data-testid="matches-count-header"]');
+    expect(header.exists()).toBe(true);
+    expect(header.text()).toBe('Matches Count');
+    expect(wrapper.text()).not.toContain('Games Count');
+  });
+
+  it('hits the per-season counts endpoint instead of /api/matches', async () => {
+    const wrapper = mountSeasons();
+    await flushPromises();
+
+    const calls = mockAuthStore.apiRequest.mock.calls.map(c => c[0]);
+    expect(calls.some(u => u.endsWith('/api/seasons/match-counts'))).toBe(true);
+    // The legacy fat fetch must not happen — it was the cap bug.
+    expect(calls.some(u => u.endsWith('/api/matches'))).toBe(false);
+    void wrapper;
+  });
+
+  it('renders the count returned for each season', async () => {
+    const wrapper = mountSeasons();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="matches-count-1"]').text()).toBe('1437');
+    expect(wrapper.find('[data-testid="matches-count-2"]').text()).toBe('980');
+    expect(wrapper.find('[data-testid="matches-count-3"]').text()).toBe('412');
+  });
+
+  it('shows 0 for a season the endpoint omitted', async () => {
+    const wrapper = mountSeasons({
+      matchCounts: [{ season_id: 1, match_count: 5 }],
+    });
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="matches-count-1"]').text()).toBe('5');
+    expect(wrapper.find('[data-testid="matches-count-2"]').text()).toBe('0');
+    expect(wrapper.find('[data-testid="matches-count-3"]').text()).toBe('0');
+  });
+
+  it('disables Delete when a season has matches', async () => {
+    const wrapper = mountSeasons();
+    await flushPromises();
+
+    const deleteButtons = wrapper
+      .findAll('button')
+      .filter(b => b.text() === 'Delete');
+    // All three seasons in fixture data have non-zero counts.
+    for (const btn of deleteButtons) {
+      expect(btn.attributes('disabled')).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/components/admin/AdminSeasons.vue
+++ b/frontend/src/components/admin/AdminSeasons.vue
@@ -50,8 +50,9 @@
             </th>
             <th
               class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              data-testid="matches-count-header"
             >
-              Games Count
+              Matches Count
             </th>
             <th
               class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
@@ -83,8 +84,11 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
               {{ formatDate(season.end_date) }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-              {{ getGamesCount(season.id) }}
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"
+              :data-testid="`matches-count-${season.id}`"
+            >
+              {{ getMatchesCount(season.id) }}
             </td>
             <td
               class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"
@@ -98,9 +102,10 @@
               <button
                 @click="deleteSeason(season)"
                 class="text-red-600 hover:text-red-900"
-                :disabled="getGamesCount(season.id) > 0"
+                :disabled="getMatchesCount(season.id) > 0"
                 :class="{
-                  'opacity-50 cursor-not-allowed': getGamesCount(season.id) > 0,
+                  'opacity-50 cursor-not-allowed':
+                    getMatchesCount(season.id) > 0,
                 }"
               >
                 Delete
@@ -203,7 +208,10 @@ export default {
   setup() {
     const authStore = useAuthStore();
     const seasons = ref([]);
-    const games = ref([]);
+    // Map of season_id → match_count from /api/seasons/match-counts.
+    // Replaces the prior approach of fetching all matches and filtering
+    // client-side (capped at Supabase's 1000-row default — see SB-61).
+    const matchCountsBySeasonId = ref({});
     const loading = ref(true);
     const formLoading = ref(false);
     const error = ref(null);
@@ -234,22 +242,24 @@ export default {
       }
     };
 
-    const fetchGames = async () => {
+    const fetchMatchCounts = async () => {
       try {
         const response = await authStore.apiRequest(
-          `${getApiBaseUrl()}/api/matches`,
-          {
-            method: 'GET',
-          }
+          `${getApiBaseUrl()}/api/seasons/match-counts`,
+          { method: 'GET' }
         );
-        games.value = response;
+        const map = {};
+        for (const row of response || []) {
+          map[row.season_id] = row.match_count ?? 0;
+        }
+        matchCountsBySeasonId.value = map;
       } catch (err) {
-        console.error('Error fetching games:', err);
+        console.error('Error fetching match counts:', err);
       }
     };
 
-    const getGamesCount = seasonId => {
-      return games.value.filter(game => game.season_id === seasonId).length;
+    const getMatchesCount = seasonId => {
+      return matchCountsBySeasonId.value[seasonId] ?? 0;
     };
 
     const isCurrentSeason = season => {
@@ -309,8 +319,8 @@ export default {
     };
 
     const deleteSeason = async season => {
-      if (getGamesCount(season.id) > 0) {
-        error.value = 'Cannot delete season with associated games';
+      if (getMatchesCount(season.id) > 0) {
+        error.value = 'Cannot delete season with associated matches';
         return;
       }
 
@@ -346,7 +356,7 @@ export default {
     };
 
     onMounted(async () => {
-      await Promise.all([fetchSeasons(), fetchGames()]);
+      await Promise.all([fetchSeasons(), fetchMatchCounts()]);
     });
 
     return {
@@ -357,7 +367,7 @@ export default {
       showAddModal,
       showEditModal,
       formData,
-      getGamesCount,
+      getMatchesCount,
       isCurrentSeason,
       formatDate,
       createSeason,


### PR DESCRIPTION
Closes [SB-61](https://linear.app/silverbeer/issue/SB-61/admin-seasons-page-matches-count-capped-at-1000-label-says-games).

## What this fixes
Admin → League Setup → Seasons was showing:

| Season | Was | Now |
|---|---|---|
| 2025-2026 (Current) | **1000** (Supabase's row cap, not real) | The real count |
| 2024-2025 | 0 | The real count |
| 2023-2024 | 0 | The real count |

Root cause: `AdminSeasons.vue:237-249` called `/api/matches` with no filters → DAO returned at most 1000 rows (Supabase's default) → client-side filter counted them per season → only the most-recent season had any survivors.

## Changes

**Backend**
- New admin-only `GET /api/seasons/match-counts` returning `[{season_id, match_count}]`.
- `SeasonDAO.get_match_counts_by_season()` uses PostgREST's embedded resource count (`seasons.select("id, matches(count)")`) with an N+1 fallback if the embedded path fails.
- Cache key `matches:counts_by_season` lives in the `matches:` namespace so any match write invalidates it via the existing `MATCHES_CACHE_PATTERN`.

**Frontend**
- `AdminSeasons.vue` switched from `fetchGames`/`getGamesCount` (fetching all matches) to `fetchMatchCounts`/`getMatchesCount` (fetching counts only).
- Column header renamed `Games Count` → `Matches Count` per CLAUDE.md terminology.
- Delete-guard copy updated to `Cannot delete season with associated matches`.

## Tests
- **Backend**: 5 unit tests covering the embedded path, missing/null `matches` field, the N+1 fallback when embedded fails, and total-failure mode → 294/294 ✅
- **Frontend**: 5 component specs covering header rename, endpoint usage (and that `/api/matches` is NOT called), per-season count rendering, missing-season fallback to 0, and Delete disabled when count > 0 → 402/402 ✅
- **Lint**: ✅

## Test plan (manual)
- [ ] After deploy, load Admin → Seasons on missingtable.com.
- [ ] Column header reads "Matches Count".
- [ ] 2025-2026 shows the real count (not exactly 1000).
- [ ] 2024-2025 and 2023-2024 show their real counts (non-zero).
- [ ] Network tab: one request to `/api/seasons/match-counts`, no request to `/api/matches`.
- [ ] Page-load size drops dramatically (was ~25 MB of match payload, now a few hundred bytes).

## Notes
- Out of scope: the underlying `/api/matches` 1000-row cap remains for non-admin pages. Worth a separate audit ticket if other surfaces silently hit it.
- Out of scope: renaming `include_game_count` on `/api/teams` and similar legacy "game" naming. Worth doing but scope creep here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)