### PR TITLE
feat(notifications): label team-follow rows with league + division (SB-65)

### DIFF
--- a/backend/dao/team_follow_dao.py
+++ b/backend/dao/team_follow_dao.py
@@ -61,7 +61,16 @@ class TeamFollowDAO(BaseDAO):
             return False
 
     def list_for_user(self, user_id: str) -> list[dict]:
-        """Return teams the user follows, joined with club info for display."""
+        """Return teams the user follows, joined with club + division + league
+        for display.
+
+        SB-65: the original projection returned only `team.name` and
+        `team.club.name`. For many MLS Next teams those two strings are
+        identical (the team name IS the club name), making the "Teams you
+        follow" list in the profile look like it's about clubs. Surfacing
+        `team.division.name` and the division's league disambiguates each
+        row (e.g. "IFA · Homegrown · Northeast").
+        """
         try:
             response = (
                 self.client.table(TABLE)
@@ -69,7 +78,11 @@ class TeamFollowDAO(BaseDAO):
                     "team_id, created_at, "
                     "team:teams!user_team_follows_team_id_fkey("
                     "id, name, age_group_id, "
-                    "club:clubs(id, name)"
+                    "club:clubs(id, name), "
+                    "division:divisions("
+                    "id, name, "
+                    "leagues!divisions_league_id_fkey(id, name)"
+                    ")"
                     ")"
                 )
                 .eq("user_id", user_id)

--- a/frontend/src/__tests__/components/NotificationsCard.spec.js
+++ b/frontend/src/__tests__/components/NotificationsCard.spec.js
@@ -26,10 +26,12 @@ vi.mock('@/composables/usePushNotifications', () => ({
   }),
 }));
 
-// Stub useTeamFollows — not under test here.
+// Stub useTeamFollows. SB-65 tests below populate `mockFollows` to verify
+// the new label rendering.
+let mockFollows;
 vi.mock('@/composables/useTeamFollows', () => ({
   useTeamFollows: () => ({
-    follows: computed(() => []),
+    follows: computed(() => mockFollows.value),
     refresh: vi.fn().mockResolvedValue(),
   }),
 }));
@@ -69,6 +71,7 @@ beforeEach(() => {
   setPreferenceMock = vi.fn().mockResolvedValue({ success: true });
   setCardsMock = vi.fn().mockResolvedValue({ success: true });
   ensureLoadedMock = vi.fn().mockResolvedValue();
+  mockFollows = ref([]);
 });
 
 describe('NotificationsCard preferences section (SB-57)', () => {
@@ -147,5 +150,128 @@ describe('NotificationsCard preferences section (SB-57)', () => {
     await flushPromises();
 
     expect(ensureLoadedMock).toHaveBeenCalled();
+  });
+});
+
+describe('NotificationsCard "Teams you follow" labels (SB-65)', () => {
+  it('renders "team · league · division" when all fields are present', async () => {
+    mockFollows.value = [
+      {
+        team_id: 19,
+        team: {
+          id: 19,
+          name: 'IFA',
+          club: { id: 1, name: 'IFA' },
+          division: {
+            id: 1,
+            name: 'Northeast',
+            leagues: { id: 1, name: 'Homegrown' },
+          },
+        },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const primary = wrapper.find('[data-testid="follow-label-primary"]');
+    expect(primary.text()).toBe('IFA · Homegrown · Northeast');
+  });
+
+  it('shows the "Showing all age groups" subtitle on every follow row', async () => {
+    mockFollows.value = [
+      {
+        team_id: 19,
+        team: {
+          id: 19,
+          name: 'IFA',
+          club: { id: 1, name: 'IFA' },
+          division: {
+            id: 1,
+            name: 'Northeast',
+            leagues: { id: 1, name: 'Homegrown' },
+          },
+        },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="follow-label-sub"]').text()).toBe(
+      'Showing all age groups'
+    );
+  });
+
+  it('falls back gracefully when league + division join data is missing', async () => {
+    mockFollows.value = [
+      {
+        team_id: 99,
+        team: {
+          id: 99,
+          name: 'Mystery Team',
+          club: { id: 99, name: 'Mystery Team' },
+          // No division field — backend was unable to join it.
+        },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const primary = wrapper.find('[data-testid="follow-label-primary"]');
+    expect(primary.text()).toBe('Mystery Team');
+    // No "undefined" leaks.
+    expect(primary.text()).not.toMatch(/undefined/);
+  });
+
+  it('suppresses the redundant club name on the right when it duplicates the team name', async () => {
+    mockFollows.value = [
+      {
+        team_id: 19,
+        team: {
+          id: 19,
+          name: 'IFA',
+          club: { id: 1, name: 'IFA' },
+          division: {
+            id: 1,
+            name: 'Northeast',
+            leagues: { id: 1, name: 'Homegrown' },
+          },
+        },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    // IFA / IFA looked duplicative before SB-65. Now the club tag is hidden
+    // when it would be redundant.
+    const item = wrapper.find('[data-testid="follow-item-19"]');
+    expect(item.findAll('.follow-club').length).toBe(0);
+  });
+
+  it('keeps the club name on the right when it differs from the team name', async () => {
+    mockFollows.value = [
+      {
+        team_id: 7,
+        team: {
+          id: 7,
+          name: 'Bayside U14',
+          club: { id: 5, name: 'Bayside FC' },
+          division: {
+            id: 1,
+            name: 'Northeast',
+            leagues: { id: 1, name: 'Homegrown' },
+          },
+        },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const item = wrapper.find('[data-testid="follow-item-7"]');
+    expect(item.find('.follow-club').text()).toBe('Bayside FC');
   });
 });

--- a/frontend/src/components/notifications/NotificationsCard.vue
+++ b/frontend/src/components/notifications/NotificationsCard.vue
@@ -165,11 +165,26 @@
         start getting notifications for them.
       </p>
       <ul v-else class="follows-list">
-        <li v-for="f in follows" :key="f.team_id" class="follow-item">
-          <span class="follow-team">{{
-            f.team?.name || `Team #${f.team_id}`
-          }}</span>
-          <span v-if="f.team?.club?.name" class="follow-club">
+        <li
+          v-for="f in follows"
+          :key="f.team_id"
+          class="follow-item"
+          :data-testid="`follow-item-${f.team_id}`"
+        >
+          <div class="follow-item-main">
+            <span class="follow-team" data-testid="follow-label-primary">{{
+              followPrimaryLabel(f)
+            }}</span>
+            <span class="follow-item-sub" data-testid="follow-label-sub">
+              Showing all age groups
+            </span>
+          </div>
+          <span
+            v-if="
+              f.team?.club?.name && f.team.club.name !== (f.team?.name || '')
+            "
+            class="follow-club"
+          >
             {{ f.team.club.name }}
           </span>
         </li>
@@ -230,6 +245,19 @@ async function onTogglePref(eventType, enabled) {
 
 async function onToggleCards(enabled) {
   await setCards(enabled);
+}
+
+// SB-65: disambiguate follow rows. For MLS Next teams the team name often
+// equals the club name (e.g. "IFA / IFA"), making the list look like it's
+// about clubs. Append the league + division when we have them.
+function followPrimaryLabel(f) {
+  const name = f.team?.name || `Team #${f.team_id}`;
+  const league = f.team?.division?.leagues?.name;
+  const division = f.team?.division?.name;
+  const parts = [name];
+  if (league) parts.push(league);
+  if (division) parts.push(division);
+  return parts.join(' · ');
 }
 
 async function onEnable() {
@@ -567,20 +595,38 @@ onMounted(refresh);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
+  gap: 12px;
+  padding: 10px 12px;
   background: #f9fafb;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   font-size: 14px;
 }
 
+.follow-item-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
 .follow-team {
   font-weight: 600;
   color: #111827;
+  /* Allow the primary label (which now includes league + division) to wrap
+     on narrow viewports instead of overflowing. */
+  word-break: break-word;
+}
+
+.follow-item-sub {
+  font-size: 12px;
+  color: #6b7280;
+  font-weight: 400;
 }
 
 .follow-club {
   font-size: 12px;
-  color: #6b7280;
+  color: #9ca3af;
+  flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
Closes [SB-65](https://linear.app/silverbeer/issue/SB-65/label-fix-show-league-division-on-each-teams-you-follow-row).

First slice of the 3-ticket follow-disambiguation story. The other two ([SB-63](https://linear.app/silverbeer/issue/SB-63) club follows, [SB-64](https://linear.app/silverbeer/issue/SB-64) per-age mutes within club follows) sit in backlog waiting on this surface to be honest first.

## The problem this fixes
The "Teams you follow" list rendered each row as \`team.name / team.club.name\` — but for MLS Next teams those two strings are often identical (e.g. \`IFA / IFA\`), so the list looked like it was about clubs. It isn't: in MT's schema, a team is one row per \`(club, league, division)\`, and IFA has 7 of them (Homegrown · Northeast, Academy · New England, Futsal · Bracket A/B, etc.). Following "IFA" only covers Homegrown · Northeast — surprises every user who tries it.

## What changes

**Backend** — \`TeamFollowDAO.list_for_user\` (\`backend/dao/team_follow_dao.py\`) extends its embedded select to include the team's division and the division's league. Single query, one extra embedded relation. Same shape, just richer.

**Frontend** — \`NotificationsCard.vue\` "Teams you follow":
- Primary line is now \`{team} · {league} · {division}\` (e.g. \`IFA · Homegrown · Northeast\`).
- New small subtitle "**Showing all age groups**" — honest disclosure that today's team follow doesn't filter by age. This is what [SB-64](https://linear.app/silverbeer/issue/SB-64) eventually solves via mute toggles within club follows.
- Suppresses the right-side club tag when it'd duplicate the team name (the \`IFA / IFA\` case).
- Falls back gracefully to just \`team.name\` when join data is missing — no \`undefined · undefined\` leaks.
- Reflows the row to a flex column for the main label so the longer text wraps cleanly on a 390px iPhone viewport.

## Tests
- **Frontend**: 5 new specs covering the label render with full join data, the subtitle, the missing-join fallback, redundant-club suppression, and the non-redundant club case → 407/407 ✅
- **Backend**: existing unit suite passes unchanged → 294/294 ✅
- **Lint**: ✅

## Test plan
- [ ] After deploy, open **Profile → Notifications card → Teams you follow**.
- [ ] Each existing follow row reads e.g. \`IFA · Homegrown · Northeast\` with a small "Showing all age groups" line under it.
- [ ] Rows where the team name differs from the club name (e.g. a team named "Bayside U14" under "Bayside FC") still show the club tag on the right; matching ones (IFA / IFA) don't.
- [ ] Mobile (iPhone Safari standalone PWA + Pixel 10): label wraps cleanly, no horizontal scroll.
- [ ] No regression on the SB-57 prefs section or the "Manage devices" section.

## Out of scope
- Adding per-age-group filtering to the team-follow row (data model change — [SB-64](https://linear.app/silverbeer/issue/SB-64) handles via club follow + mutes).
- Adding club follows ([SB-63](https://linear.app/silverbeer/issue/SB-63)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)