### PR TITLE
feat(matches): live realtime updates on MatchesView + MatchDetailView (SB-66)

### DIFF
--- a/frontend/src/__tests__/components/MatchDetailView.spec.js
+++ b/frontend/src/__tests__/components/MatchDetailView.spec.js
@@ -44,6 +44,15 @@ vi.mock('html2canvas', () => ({
   ),
 }));
 
+// SB-66: stub the realtime subscription so the component can mount without
+// a live Supabase channel. Tests don't exercise the realtime path.
+vi.mock('@/composables/useMatchRealtime', () => ({
+  subscribeToMatch: vi.fn(() => ({
+    unsubscribe: vi.fn(),
+    isConnected: () => false,
+  })),
+}));
+
 /**
  * Helper to mount MatchDetailView with default options
  */

--- a/frontend/src/__tests__/components/MatchesView.spec.js
+++ b/frontend/src/__tests__/components/MatchesView.spec.js
@@ -72,6 +72,14 @@ vi.mock('@/config/api', () => ({
   getApiBaseUrl: () => 'http://localhost:8000',
 }));
 
+// SB-66: stub realtime so MatchesView mounts without a live channel.
+vi.mock('@/composables/useMatchRealtime', () => ({
+  subscribeToMatch: vi.fn(() => ({
+    unsubscribe: vi.fn(),
+    isConnected: () => false,
+  })),
+}));
+
 /**
  * Helper to mount MatchesView with default options
  */

--- a/frontend/src/__tests__/composables/useMatchRealtime.spec.js
+++ b/frontend/src/__tests__/composables/useMatchRealtime.spec.js
@@ -1,0 +1,124 @@
+/**
+ * useMatchRealtime tests (SB-66).
+ *
+ * The composable is a thin wrapper around Supabase Realtime. Tests mock
+ * the supabase client to verify channel setup, callback dispatch, and
+ * unsubscribe lifecycle without hitting any network.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock is hoisted, so the factory has to construct its own mocks.
+// We use vi.hoisted to share the mock instances back to the test scope.
+const { mockChannel, supabaseMock } = vi.hoisted(() => {
+  const channel = {
+    on: vi.fn(),
+    subscribe: vi.fn(),
+  };
+  return {
+    mockChannel: channel,
+    supabaseMock: {
+      channel: vi.fn(() => channel),
+      removeChannel: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/config/supabase', () => ({
+  supabase: supabaseMock,
+}));
+
+import { subscribeToMatch } from '@/composables/useMatchRealtime';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockChannel.on.mockReturnValue(mockChannel);
+  mockChannel.subscribe.mockReturnValue(mockChannel);
+});
+
+describe('subscribeToMatch — channel setup', () => {
+  it('creates a channel named match-row:{matchId}', () => {
+    subscribeToMatch(42, () => {});
+    expect(supabaseMock.channel).toHaveBeenCalledWith('match-row:42');
+  });
+
+  it('registers an UPDATE listener on the matches table for that id', () => {
+    subscribeToMatch(42, () => {});
+    expect(mockChannel.on).toHaveBeenCalledWith(
+      'postgres_changes',
+      expect.objectContaining({
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'matches',
+        filter: 'id=eq.42',
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('subscribes to the channel', () => {
+    subscribeToMatch(42, () => {});
+    expect(mockChannel.subscribe).toHaveBeenCalled();
+  });
+});
+
+describe('subscribeToMatch — callback', () => {
+  it('fires the user callback with payload.new on UPDATE', () => {
+    const onUpdate = vi.fn();
+    subscribeToMatch(42, onUpdate);
+
+    // Pull the listener that was passed to .on() and invoke it as Supabase would.
+    const listener = mockChannel.on.mock.calls[0][2];
+    listener({ new: { id: 42, home_score: 2, away_score: 1 } });
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      id: 42,
+      home_score: 2,
+      away_score: 1,
+    });
+  });
+
+  it('does nothing on a payload with no `new` field', () => {
+    const onUpdate = vi.fn();
+    subscribeToMatch(42, onUpdate);
+
+    const listener = mockChannel.on.mock.calls[0][2];
+    listener({}); // malformed payload
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('subscribeToMatch — lifecycle', () => {
+  it('unsubscribe() removes the channel from supabase', () => {
+    const handle = subscribeToMatch(42, () => {});
+    handle.unsubscribe();
+    expect(supabaseMock.removeChannel).toHaveBeenCalledWith(mockChannel);
+  });
+
+  it('isConnected() reflects SUBSCRIBED status', () => {
+    const handle = subscribeToMatch(42, () => {});
+    // Pull the status callback handed to .subscribe()
+    const subscribeStatusCb = mockChannel.subscribe.mock.calls[0][0];
+
+    expect(handle.isConnected()).toBe(false);
+    subscribeStatusCb('SUBSCRIBED');
+    expect(handle.isConnected()).toBe(true);
+    subscribeStatusCb('CLOSED');
+    expect(handle.isConnected()).toBe(false);
+  });
+});
+
+describe('subscribeToMatch — input validation', () => {
+  it('throws when matchId is null', () => {
+    expect(() => subscribeToMatch(null, () => {})).toThrow(/matchId/);
+  });
+
+  it('throws when matchId is undefined', () => {
+    expect(() => subscribeToMatch(undefined, () => {})).toThrow(/matchId/);
+  });
+
+  it('throws when onUpdate is not a function', () => {
+    expect(() => subscribeToMatch(42, null)).toThrow(/onUpdate/);
+  });
+});

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -717,6 +717,7 @@
 
 <script>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { subscribeToMatch } from '@/composables/useMatchRealtime';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../config/api';
 import html2canvas from 'html2canvas';
@@ -954,11 +955,44 @@ export default {
       }
     });
 
+    // ── SB-66: Realtime updates ──
+    // Subscribe whenever a match is loaded so score/status changes posted
+    // from another device land here without a manual refresh. The Supabase
+    // payload only carries raw matches-table columns, so refresh by
+    // re-fetching to keep joined display fields fresh too.
+    let matchRealtimeHandle = null;
+
+    function ensureMatchRealtime(matchId) {
+      if (matchRealtimeHandle) {
+        matchRealtimeHandle.unsubscribe();
+        matchRealtimeHandle = null;
+      }
+      if (matchId == null) return;
+      matchRealtimeHandle = subscribeToMatch(matchId, () => {
+        // Re-fetch on any change so joined data (teams, club, events) stays
+        // consistent. Cheap because /api/matches/{id} is keyed and tiny.
+        fetchMatch();
+      });
+    }
+
+    watch(
+      () => props.matchId,
+      newId => ensureMatchRealtime(newId),
+      { immediate: false }
+    );
+
     onMounted(() => {
       fetchMatch();
+      ensureMatchRealtime(props.matchId);
     });
 
-    onUnmounted(() => clearInterval(countdownTimer));
+    onUnmounted(() => {
+      clearInterval(countdownTimer);
+      if (matchRealtimeHandle) {
+        matchRealtimeHandle.unsubscribe();
+        matchRealtimeHandle = null;
+      }
+    });
 
     // Share scoreboard as image to clipboard
     const shareScoreboard = async () => {

--- a/frontend/src/components/MatchesView.vue
+++ b/frontend/src/components/MatchesView.vue
@@ -2026,6 +2026,7 @@ import MatchEditModal from '@/components/MatchEditModal.vue';
 import MatchDetailView from '@/components/MatchDetailView.vue';
 import ClubLogo from '@/components/shared/ClubLogo.vue';
 import FollowButton from '@/components/notifications/FollowButton.vue';
+import { subscribeToMatch } from '@/composables/useMatchRealtime';
 
 export default {
   name: 'MatchesView',
@@ -3177,12 +3178,55 @@ export default {
       await fetchMatches();
     });
 
-    // Clean up interval on component unmount
+    // ── SB-66: Realtime updates for in-progress match rows ──
+    // The existing 10s polling fallback (above) is kept for safety, but
+    // realtime gives instant updates when another device posts a goal /
+    // card / clock event, so a second device showing the schedule no
+    // longer needs a manual refresh during a live game.
+    const realtimeMatchSubs = new Map(); // matchId → handle
+
+    function applyMatchUpdate(newRow) {
+      const idx = matches.value.findIndex(m => m.id === newRow.id);
+      if (idx !== -1) {
+        // Preserve joined display fields (home_team_name etc.) — the
+        // payload only carries raw `matches` row columns.
+        matches.value[idx] = { ...matches.value[idx], ...newRow };
+      }
+    }
+
+    function reconcileRealtimeSubs(currentMatches) {
+      const liveIds = new Set(
+        (currentMatches || [])
+          .filter(m => m.match_status === 'in_progress' && m.id)
+          .map(m => m.id)
+      );
+      // Drop subscriptions for matches no longer live or no longer in view.
+      for (const [id, handle] of realtimeMatchSubs) {
+        if (!liveIds.has(id)) {
+          handle.unsubscribe();
+          realtimeMatchSubs.delete(id);
+        }
+      }
+      // Add subscriptions for newly-live matches.
+      for (const id of liveIds) {
+        if (!realtimeMatchSubs.has(id)) {
+          realtimeMatchSubs.set(id, subscribeToMatch(id, applyMatchUpdate));
+        }
+      }
+    }
+
+    watch(matches, reconcileRealtimeSubs, { deep: false });
+
+    // Clean up interval + realtime subs on component unmount
     onUnmounted(() => {
       if (liveMatchRefreshInterval) {
         clearInterval(liveMatchRefreshInterval);
         liveMatchRefreshInterval = null;
       }
+      for (const handle of realtimeMatchSubs.values()) {
+        handle.unsubscribe();
+      }
+      realtimeMatchSubs.clear();
     });
 
     return {

--- a/frontend/src/composables/useMatchRealtime.js
+++ b/frontend/src/composables/useMatchRealtime.js
@@ -1,0 +1,70 @@
+/**
+ * Match-row realtime subscription (SB-66).
+ *
+ * Thin Supabase Realtime subscriber for a single match's UPDATE events.
+ * Used by MatchesView (per-row live updates) and MatchDetailView so a
+ * score change posted from another device propagates without a manual
+ * refresh.
+ *
+ * Mirrors the pattern in `useLiveMatch.js:151-220` but exposes just the
+ * minimum surface needed for read-only consumers: one channel per
+ * matchId, one callback that fires on UPDATE with the new row.
+ *
+ * Lifecycle:
+ *   const handle = subscribeToMatch(matchId, (newRow) => {...});
+ *   handle.unsubscribe();
+ *
+ * Consumers manage their own collection of handles — typically one per
+ * in_progress match row, unsubscribed when the row transitions to
+ * `completed` or when the view unmounts.
+ */
+
+import { supabase } from '../config/supabase';
+
+/**
+ * Subscribe to UPDATE broadcasts for a single match row.
+ *
+ * @param {number|string} matchId
+ * @param {(newRow: object) => void} onUpdate - called with payload.new
+ * @returns {{ unsubscribe: () => void, isConnected: () => boolean }}
+ */
+export function subscribeToMatch(matchId, onUpdate) {
+  if (matchId == null) {
+    throw new Error('subscribeToMatch requires a matchId');
+  }
+  if (typeof onUpdate !== 'function') {
+    throw new Error('subscribeToMatch requires an onUpdate callback');
+  }
+
+  let connected = false;
+
+  const channel = supabase
+    .channel(`match-row:${matchId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'matches',
+        filter: `id=eq.${matchId}`,
+      },
+      payload => {
+        if (payload?.new) {
+          onUpdate(payload.new);
+        }
+      }
+    )
+    .subscribe(status => {
+      connected = status === 'SUBSCRIBED';
+    });
+
+  return {
+    unsubscribe() {
+      if (channel) {
+        supabase.removeChannel(channel);
+        connected = false;
+      }
+    },
+    isConnected: () => connected,
+  };
+}


### PR DESCRIPTION
Closes [SB-66](https://linear.app/silverbeer/issue/SB-66).

⚠️ **Do NOT merge while you're still live-scoring the IFA match.** GitOps will redeploy MatchesView ~3-4 min after merge and could disrupt your in-progress session. Merge after fulltime.

## The bug this fixes
Tom hit this mid-game during today's MLS NEXT Cup U15 SF (2-1 IFA score not propagating to his MacBook Air while he was scoring on his Pixel 10). Root cause: `useLiveMatch` subscribes to a Supabase Realtime channel for the live admin view, but MatchesView (the schedule list) and MatchDetailView (single match scoreboard) only fetched on mount. Goals posted from another device went unseen until manual refresh.

## What changes
- **New `useMatchRealtime.js` composable** — thin wrapper that subscribes to a single match row's UPDATE events. Returns subscribe/unsubscribe handles. Same channel pattern as `useLiveMatch.js:151-220`.
- **`MatchesView.vue`** reconciles its set of realtime subscriptions whenever `matches` changes: for every row with `match_status === 'in_progress'`, subscribe; for rows that leave the list or transition to completed, unsubscribe. Mutates the row in-place on payload (preserves joined display fields like `home_team_name`). Existing 10s polling fallback is kept untouched as a safety net.
- **`MatchDetailView.vue`** subscribes whenever a match is loaded (any status). On payload, re-fetches via `GET /api/matches/{id}` so joined data (teams, club, events) stays consistent. Cheap — single keyed lookup.

## Tests
- 10 new composable specs (channel setup, callback dispatch, unsubscribe lifecycle, isConnected status, input validation).
- Existing MatchesView + MatchDetailView specs stub the new composable so they continue to mount without a live channel.
- Frontend: **412/412 ✅** (10 new on top of SB-65's 402).
- Lint: ✅

## Test plan (post-merge, post-game)
- [ ] Two devices, both signed in. Device A on a live match's admin view, Device B on the schedule list (MatchesView) with that live match visible.
- [ ] Post a goal from Device A → score on Device B's matching row updates within ~1s, no refresh.
- [ ] Post a card → same.
- [ ] Mark the match completed on Device A → Device B's row reflects the new status; subscription cleans up.
- [ ] Open MatchDetailView for the same match on Device B → same behavior.
- [ ] No console errors on either device.
- [ ] Mobile per `feedback-mobile-first-ui`: same flow on iPhone Safari PWA + Pixel 10.

## Two related bugs filed today, not in scope for this PR
- [SB-67](https://linear.app/silverbeer/issue/SB-67) — Live clock doesn't handle stoppage time (clock froze at 45:00 with +4 minutes called). Surfaced same game.
- [SB-68](https://linear.app/silverbeer/issue/SB-68) — Lineup view showed U14 roster on a U15 match because `team_id=19` is age-agnostic. Same data-model seam as the IFA-follow bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)