### PR TITLE
feat(live): stoppage time indicator + 45+M:SS clock display (SB-67)

### DIFF
--- a/frontend/src/__tests__/components/live/LiveScoreboard.spec.js
+++ b/frontend/src/__tests__/components/live/LiveScoreboard.spec.js
@@ -1,0 +1,68 @@
+/**
+ * LiveScoreboard.vue — stoppage badge (SB-67).
+ *
+ * Just covers the new isInStoppage display surface. The rest of the
+ * scoreboard (score, goals list, team names, period text) is exercised
+ * via manual + e2e checks and isn't under test here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LiveScoreboard from '@/components/live/LiveScoreboard.vue';
+
+const baseMatchState = {
+  home_team_id: 1,
+  away_team_id: 2,
+  home_team_name: 'Home FC',
+  away_team_name: 'Away FC',
+  home_score: 0,
+  away_score: 0,
+  age_group_name: 'U15',
+  division_name: 'Northeast',
+};
+
+const mountBoard = (overrides = {}) =>
+  mount(LiveScoreboard, {
+    props: {
+      matchState: baseMatchState,
+      elapsedTime: '45:00',
+      matchPeriod: '1st Half',
+      events: [],
+      ...overrides,
+    },
+  });
+
+describe('LiveScoreboard stoppage badge (SB-67)', () => {
+  it('does not render the badge during regulation', () => {
+    const wrapper = mountBoard({ isInStoppage: false });
+    expect(wrapper.find('[data-testid="stoppage-badge"]').exists()).toBe(false);
+  });
+
+  it('renders the badge when isInStoppage is true', () => {
+    const wrapper = mountBoard({
+      isInStoppage: true,
+      elapsedTime: '45+2:45',
+    });
+    const badge = wrapper.find('[data-testid="stoppage-badge"]');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe('STOPPAGE TIME');
+  });
+
+  it('applies the clock-stoppage class to the clock when in stoppage', () => {
+    const wrapper = mountBoard({
+      isInStoppage: true,
+      elapsedTime: '45+1:00',
+    });
+    expect(wrapper.find('.clock').classes()).toContain('clock-stoppage');
+  });
+
+  it('renders whatever elapsedTime string the parent provides', () => {
+    // The composable formats `45+M:SS` for us; the scoreboard just
+    // displays whatever string lands in the prop.
+    const wrapper = mountBoard({
+      isInStoppage: true,
+      elapsedTime: '90+3:20',
+    });
+    expect(wrapper.find('.clock').text()).toBe('90+3:20');
+  });
+});

--- a/frontend/src/__tests__/composables/useLiveMatch.spec.js
+++ b/frontend/src/__tests__/composables/useLiveMatch.spec.js
@@ -1,0 +1,169 @@
+/**
+ * useLiveMatch — stoppage time computeds (SB-67).
+ *
+ * The composable initializes its internal `currentTime` ref from Date.now()
+ * at construction. We mock Date.now() to a fixed "fake now" before each
+ * test so the elapsed clock has a deterministic value, then set
+ * `matchState` directly and read the new SB-67 computeds.
+ *
+ * Subscription/network functions (subscribeToRealtime, fetchMatchState,
+ * etc.) only run if the consumer calls initialize() — these tests skip
+ * that and just inspect the reactive state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const FAKE_NOW = 1748966400000; // 2026-06-03T17:20:00Z, fixed.
+
+vi.mock('@/config/supabase', () => ({
+  supabase: {
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn(),
+    })),
+    removeChannel: vi.fn(),
+  },
+}));
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: { value: true },
+    isAdmin: { value: true },
+    isClubManager: { value: false },
+    isTeamManager: { value: false },
+    userTeamId: { value: null },
+    apiRequest: vi.fn(),
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+vi.mock('@/composables/useMatchLineup', () => ({
+  useMatchLineup: () => ({
+    homeLineup: { value: null },
+    awayLineup: { value: null },
+    homeRoster: { value: [] },
+    awayRoster: { value: [] },
+    lineupLoading: { value: false },
+    fetchLineup: vi.fn(),
+    fetchLineups: vi.fn(),
+    saveLineup: vi.fn(),
+    fetchTeamRosters: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW);
+});
+
+import { useLiveMatch } from '@/composables/useLiveMatch';
+
+// Helper: produce an ISO timestamp `seconds` before FAKE_NOW.
+const isoSecondsAgo = seconds =>
+  new Date(FAKE_NOW - seconds * 1000).toISOString();
+
+describe('useLiveMatch — pre-stoppage clock', () => {
+  it('isInStoppage is false before kickoff', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = { half_duration: 45 };
+    expect(live.isInStoppage.value).toBe(false);
+    expect(live.stoppageElapsedSeconds.value).toBe(0);
+  });
+
+  it('isInStoppage is false during regulation 1st half', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(20 * 60), // 20 minutes elapsed
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(false);
+    expect(live.clockDisplayFormatted.value).toBe('20:00');
+  });
+
+  it('isInStoppage is false at halftime (clock paused between halves)', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(50 * 60),
+      halftime_start: isoSecondsAgo(60), // halftime was called 1 min ago
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(false);
+  });
+
+  it('isInStoppage is false after fulltime', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(100 * 60),
+      match_end_time: isoSecondsAgo(5),
+      match_status: 'completed',
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(false);
+  });
+});
+
+describe('useLiveMatch — 1st-half stoppage', () => {
+  it('flips isInStoppage on at the half_duration boundary', () => {
+    const live = useLiveMatch(1);
+    // 45 minutes elapsed = exactly at boundary; need to go just past it.
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(45 * 60 + 5), // 45:05
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(true);
+    expect(Math.round(live.stoppageElapsedSeconds.value)).toBe(5);
+    expect(live.clockDisplayFormatted.value).toBe('45+0:05');
+  });
+
+  it('formats deeper stoppage as 45+M:SS', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(45 * 60 + 165), // 45 + 2:45
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(true);
+    expect(live.clockDisplayFormatted.value).toBe('45+2:45');
+  });
+
+  it('honours non-default half_duration (e.g. 30 min for younger ages)', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(30 * 60 + 90), // 30 + 1:30
+      half_duration: 30,
+    };
+    expect(live.isInStoppage.value).toBe(true);
+    expect(live.clockDisplayFormatted.value).toBe('30+1:30');
+  });
+});
+
+describe('useLiveMatch — 2nd-half stoppage', () => {
+  it('flips isInStoppage on at the 2 × half_duration boundary', () => {
+    const live = useLiveMatch(1);
+    // Kickoff 90+15 min ago, halftime came + went, 2nd half kicked off
+    // such that elapsed (boundary measurement) = 90:15. The composable's
+    // elapsedSeconds for second half is halfDurationSeconds + secondHalfElapsed,
+    // so set second_half_start such that second-half elapsed is 45:15.
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(120 * 60), // arbitrary, past
+      halftime_start: isoSecondsAgo(80 * 60),
+      second_half_start: isoSecondsAgo(45 * 60 + 15), // 45:15 of 2nd half
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(true);
+    expect(live.clockDisplayFormatted.value).toBe('90+0:15');
+  });
+
+  it('formats deeper 2nd-half stoppage as 90+M:SS', () => {
+    const live = useLiveMatch(1);
+    live.matchState.value = {
+      kickoff_time: isoSecondsAgo(150 * 60),
+      halftime_start: isoSecondsAgo(80 * 60),
+      second_half_start: isoSecondsAgo(45 * 60 + 200), // 45 + 3:20
+      half_duration: 45,
+    };
+    expect(live.isInStoppage.value).toBe(true);
+    expect(live.clockDisplayFormatted.value).toBe('90+3:20');
+  });
+});

--- a/frontend/src/components/live/LiveMatchView.vue
+++ b/frontend/src/components/live/LiveMatchView.vue
@@ -31,8 +31,9 @@
       <!-- Scoreboard -->
       <LiveScoreboard
         :match-state="matchState"
-        :elapsed-time="elapsedTimeFormatted"
+        :elapsed-time="clockDisplayFormatted"
         :match-period="matchPeriod"
+        :is-in-stoppage="isInStoppage"
         :events="events"
       />
 
@@ -91,7 +92,8 @@ const {
   isLoading,
   error,
   isConnected,
-  elapsedTimeFormatted,
+  clockDisplayFormatted,
+  isInStoppage,
   matchPeriod,
   canManage,
   updateClock,

--- a/frontend/src/components/live/LiveScoreboard.vue
+++ b/frontend/src/components/live/LiveScoreboard.vue
@@ -92,8 +92,19 @@
 
     <!-- Clock -->
     <div class="clock-container">
-      <div class="clock">{{ elapsedTime }}</div>
+      <div class="clock" :class="{ 'clock-stoppage': isInStoppage }">
+        {{ elapsedTime }}
+      </div>
       <div class="period" :class="periodClass">{{ matchPeriod }}</div>
+      <!-- SB-67: stoppage-time indicator, only shown once the clock crosses
+           the half_duration boundary. The clock itself reads "45+M:SS" -->
+      <div
+        v-if="isInStoppage"
+        class="stoppage-badge"
+        data-testid="stoppage-badge"
+      >
+        STOPPAGE TIME
+      </div>
     </div>
 
     <!-- Match Info -->
@@ -124,6 +135,12 @@ const props = defineProps({
   matchPeriod: {
     type: String,
     required: true,
+  },
+  // SB-67: when true, the clock is past the regulation half boundary and
+  // `elapsedTime` will already be rendered as `45+M:SS`.
+  isInStoppage: {
+    type: Boolean,
+    default: false,
   },
   events: {
     type: Array,
@@ -321,10 +338,29 @@ function formatMinute(goal) {
   font-family: monospace;
 }
 
+/* SB-67: distinct color when clock has crossed regulation. */
+.clock-stoppage {
+  color: #f59e0b; /* amber-500 */
+}
+
 .period {
   font-size: 14px;
   color: #888;
   margin-top: 4px;
+}
+
+/* SB-67: stoppage badge sits under the period label. */
+.stoppage-badge {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 2px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  background: #f59e0b;
+  color: #1f2937;
+  border-radius: 999px;
+  text-transform: uppercase;
 }
 
 .period.active {

--- a/frontend/src/composables/useLiveMatch.js
+++ b/frontend/src/composables/useLiveMatch.js
@@ -67,17 +67,79 @@ export function useLiveMatch(matchId) {
       return halfDurationSeconds;
     }
 
-    // In first half
+    // In first half. SB-67: we no longer cap at halfDurationSeconds —
+    // the clock keeps counting past 45:00 so the consumer can detect
+    // and display stoppage time.
     const firstHalfElapsed = (now - new Date(kickoff_time).getTime()) / 1000;
-    return Math.min(firstHalfElapsed, halfDurationSeconds);
+    return firstHalfElapsed;
   });
 
-  // Computed: formatted elapsed time (MM:SS)
+  // Computed: formatted elapsed time (MM:SS). Retained for any consumer
+  // that wants the raw clock without stoppage notation; the recommended
+  // display surface is `clockDisplayFormatted` below.
   const elapsedTimeFormatted = computed(() => {
     const totalSeconds = Math.floor(elapsedSeconds.value);
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  });
+
+  // ── SB-67: Stoppage time ──
+  // Once the elapsed clock crosses the half_duration boundary (45:00 by
+  // default), we're in stoppage. The badge + the `45+M:SS` formatting in
+  // `clockDisplayFormatted` are driven off these three computeds. The
+  // backend already records `extra_time` on goals/cards via
+  // `calculate_match_minute()` — this is purely a display layer.
+
+  // True only when actively playing past the regulation boundary. False
+  // during halftime, at fulltime, before kickoff.
+  const isInStoppage = computed(() => {
+    if (!matchState.value) return false;
+    const {
+      kickoff_time,
+      halftime_start,
+      second_half_start,
+      match_end_time,
+      match_status,
+      half_duration = 45,
+    } = matchState.value;
+
+    if (!kickoff_time) return false;
+    if (match_end_time || match_status === 'completed') return false;
+    // At halftime (clock paused between halves) — not stoppage.
+    if (halftime_start && !second_half_start) return false;
+
+    const halfDurationSeconds = half_duration * 60;
+    const fullMatchSeconds = halfDurationSeconds * 2;
+
+    if (second_half_start) {
+      return elapsedSeconds.value > fullMatchSeconds;
+    }
+    return elapsedSeconds.value > halfDurationSeconds;
+  });
+
+  // Seconds past the current period's regulation boundary. 0 outside
+  // stoppage.
+  const stoppageElapsedSeconds = computed(() => {
+    if (!isInStoppage.value) return 0;
+    const { second_half_start, half_duration = 45 } = matchState.value;
+    const halfDurationSeconds = half_duration * 60;
+    const boundary = second_half_start
+      ? halfDurationSeconds * 2
+      : halfDurationSeconds;
+    return Math.max(0, elapsedSeconds.value - boundary);
+  });
+
+  // Authoritative display string: regulation `MM:SS`, stoppage `45+M:SS`
+  // (or `90+M:SS` in the 2nd half).
+  const clockDisplayFormatted = computed(() => {
+    if (!isInStoppage.value) return elapsedTimeFormatted.value;
+    const { second_half_start, half_duration = 45 } = matchState.value;
+    const baseMinutes = second_half_start ? half_duration * 2 : half_duration;
+    const stoppageWhole = Math.floor(stoppageElapsedSeconds.value);
+    const minutes = Math.floor(stoppageWhole / 60);
+    const seconds = stoppageWhole % 60;
+    return `${baseMinutes}+${minutes}:${seconds.toString().padStart(2, '0')}`;
   });
 
   // Computed: match period
@@ -465,6 +527,10 @@ export function useLiveMatch(matchId) {
     // Computed
     elapsedSeconds,
     elapsedTimeFormatted,
+    // SB-67: stoppage-time display surface.
+    isInStoppage,
+    stoppageElapsedSeconds,
+    clockDisplayFormatted,
     matchPeriod,
     canManage,
 


### PR DESCRIPTION
Closes [SB-67](https://linear.app/silverbeer/issue/SB-67/live-clock-handle-stoppage-time-added-time-per-half).

## The bug this fixes
During the 2026-05-28 MLS NEXT Cup U15 SF, the first half had **+4 minutes** of stoppage announced by the ref. MT's live clock froze at \`45:00\` with no signal the half was still running and no count of how much extra time had elapsed. Tom asked for an indicator when we cross the half boundary and a clear display of stoppage so far.

## Scope (intentionally narrow)
**Passive detection + display only.** No admin "Add 3 min" buttons, no announced-stoppage state, no schema changes — just honest rendering of what's already happening. The backend already records \`extra_time\` on goal/card events via \`calculate_match_minute()\` (\`backend/app.py:2859\`) and the notification formatter already renders \`45+N'\` (\`backend/notifications/formatters.py:36\`). This PR just surfaces the same truth on the live clock.

The admin-side "set announced stoppage budget" idea is captured in SB-67's body as a clean follow-up if it ever matters.

## What changes

**\`useLiveMatch.js\`**
- Removed the \`Math.min(firstHalfElapsed, halfDurationSeconds)\` cap that pinned the clock at 45:00. It now counts past the boundary so consumers can detect stoppage.
- Three new computeds:
  - \`isInStoppage\` — true once elapsed crosses \`half_duration\` (or \`2 × half_duration\` in the 2nd half) AND we're actively playing (not halftime, not completed, not pre-kickoff).
  - \`stoppageElapsedSeconds\` — seconds past the current period boundary; 0 outside stoppage.
  - \`clockDisplayFormatted\` — string. \`MM:SS\` in regulation, \`45+M:SS\` (or \`90+M:SS\`) in stoppage. Authoritative display string for consumers.

**\`LiveScoreboard.vue\`**
- New \`isInStoppage\` prop.
- Amber "STOPPAGE TIME" pill renders under the period label when set.
- \`.clock-stoppage\` class on the numerals shifts them amber so it's unmistakable.

**\`LiveMatchView.vue\`**
- Passes \`clockDisplayFormatted\` and \`isInStoppage\` through to the scoreboard.

## Tests
- **9 composable specs** — pre-stoppage / 1st-half stoppage / 2nd-half stoppage / non-default half_duration (e.g. 30 min for U13).
- **4 component specs** — badge absent in regulation, present in stoppage, \`.clock-stoppage\` applied, parent-provided elapsedTime renders.
- Full frontend suite: **415/415 ✅**
- Lint: ✅

## Test plan (post-merge)
- [ ] Start a test match with \`half_duration\` overridden to a small value (e.g. 1 min via the API) so the boundary crossing is fast.
- [ ] Watch the clock cross → "STOPPAGE TIME" pill appears, clock numerals turn amber, display reads \`1+0:01\`, \`1+0:30\`, etc.
- [ ] Click Halftime → badge disappears, period switches to "Halftime", clock state pauses.
- [ ] Start 2nd half → same boundary behavior at \`2 × half_duration\`.
- [ ] Click Full Time → badge disappears, period switches to "Full Time".
- [ ] Reopen Match → behaves like 2nd half if reopen pre-stoppage.
- [ ] Mobile (iPhone Safari PWA + Pixel 10) per \`feedback-mobile-first-ui\`: badge readable on narrow viewport.

## Related
- [SB-66](https://github.com/silverbeer/missing-table/pull/416) — realtime updates on MatchesView / MatchDetailView. Same game, same testing session. Merge that first if you want stoppage updates to propagate to non-live views automatically.
- [SB-68](https://linear.app/silverbeer/issue/SB-68) — lineup shows wrong age group's roster (separate data-model bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)