### PR TITLE
feat(roster): filter team roster by match age_group_id (SB-68)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4989,7 +4989,18 @@ async def check_match(
 
 
 @app.get("/api/teams/{team_id}/players")
-async def get_team_players(team_id: int, current_user: dict[str, Any] = Depends(get_current_user_required)):
+async def get_team_players(
+    team_id: int,
+    age_group_id: int | None = Query(
+        None,
+        description=(
+            "Optional age group filter (SB-68). When set, returns only "
+            "players whose player_team_history.age_group_id matches. "
+            "When omitted, returns the full team roster regardless of age."
+        ),
+    ),
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+):
     """
     Get all players on a team for the team roster page.
 
@@ -5043,7 +5054,7 @@ async def get_team_players(team_id: int, current_user: dict[str, Any] = Depends(
             raise HTTPException(status_code=404, detail="Team not found")
 
         # Get players
-        players = player_dao.get_team_players(team_id)
+        players = player_dao.get_team_players(team_id, age_group_id)
 
         return {"success": True, "team": team, "players": players}
 
@@ -5061,6 +5072,14 @@ async def get_team_players(team_id: int, current_user: dict[str, Any] = Depends(
 async def get_team_roster(
     team_id: int,
     season_id: int = Query(..., description="Season ID"),
+    age_group_id: int | None = Query(
+        None,
+        description=(
+            "Optional age group filter (SB-68). When set, returns only "
+            "players whose players.age_group_id matches. When omitted, "
+            "returns the full team roster regardless of age."
+        ),
+    ),
     current_user: dict[str, Any] = Depends(get_current_user_required),
 ):
     """
@@ -5076,9 +5095,15 @@ async def get_team_roster(
             raise HTTPException(status_code=404, detail="Team not found")
 
         # Get roster from players table
-        roster = roster_dao.get_team_roster(team_id, season_id)
+        roster = roster_dao.get_team_roster(team_id, season_id, age_group_id)
 
-        return {"success": True, "team_id": team_id, "season_id": season_id, "roster": roster}
+        return {
+            "success": True,
+            "team_id": team_id,
+            "season_id": season_id,
+            "age_group_id": age_group_id,
+            "roster": roster,
+        }
 
     except HTTPException:
         raise

--- a/backend/dao/player_dao.py
+++ b/backend/dao/player_dao.py
@@ -221,8 +221,12 @@ class PlayerDAO(BaseDAO):
 
     # === Team Players Methods ===
 
-    @dao_cache("players:by_team:{team_id}")
-    def get_team_players(self, team_id: int) -> list[dict]:
+    @dao_cache("players:by_team:{team_id}:age:{age_group_id}")
+    def get_team_players(
+        self,
+        team_id: int,
+        age_group_id: int | None = None,
+    ) -> list[dict]:
         """
         Get all players currently on a team for the team roster page.
 
@@ -236,13 +240,17 @@ class PlayerDAO(BaseDAO):
 
         Args:
             team_id: The team ID to get players for
+            age_group_id: Optional age group filter (SB-68). When set,
+                filters `player_team_history.age_group_id` strictly. When
+                None, returns all current roster entries regardless of age
+                (current behavior preserved for the team roster page).
 
         Returns:
             List of player profile dicts
         """
         try:
             # Query player_team_history for current team members
-            response = (
+            query = (
                 self.client.table("player_team_history")
                 .select("""
                 player_id,
@@ -268,8 +276,10 @@ class PlayerDAO(BaseDAO):
             """)
                 .eq("team_id", team_id)
                 .eq("is_current", True)
-                .execute()
             )
+            if age_group_id is not None:
+                query = query.eq("age_group_id", age_group_id)
+            response = query.execute()
 
             # Flatten the results - extract user_profiles and merge with history data
             players = []

--- a/backend/dao/roster_dao.py
+++ b/backend/dao/roster_dao.py
@@ -23,21 +23,31 @@ class RosterDAO(BaseDAO):
 
     # === Read Operations ===
 
-    @dao_cache("roster:team:{team_id}:season:{season_id}")
-    def get_team_roster(self, team_id: int, season_id: int) -> list[dict]:
+    @dao_cache("roster:team:{team_id}:season:{season_id}:age:{age_group_id}")
+    def get_team_roster(
+        self,
+        team_id: int,
+        season_id: int,
+        age_group_id: int | None = None,
+    ) -> list[dict]:
         """
         Get all roster entries for a team in a specific season.
 
         Args:
             team_id: Team ID
             season_id: Season ID
+            age_group_id: Optional age group filter (SB-68). When set, only
+                players whose `players.age_group_id` matches are returned.
+                When None, returns all active roster entries for the team
+                regardless of age group (current behavior preserved for
+                non-live-match consumers).
 
         Returns:
             List of player dicts with computed display_name
         """
         try:
             # Use explicit FK relationship to avoid ambiguity with created_by FK
-            response = (
+            query = (
                 self.client.table("players")
                 .select("""
                 *,
@@ -48,16 +58,23 @@ class RosterDAO(BaseDAO):
                 .eq("team_id", team_id)
                 .eq("season_id", season_id)
                 .eq("is_active", True)
-                .order("jersey_number")
-                .execute()
             )
+            if age_group_id is not None:
+                query = query.eq("age_group_id", age_group_id)
+            response = query.order("jersey_number").execute()
 
             players = response.data or []
             # Add computed display_name to each player
             return [self._add_display_name(p) for p in players]
 
         except Exception as e:
-            logger.error("roster_get_team_error", team_id=team_id, season_id=season_id, error=str(e))
+            logger.error(
+                "roster_get_team_error",
+                team_id=team_id,
+                season_id=season_id,
+                age_group_id=age_group_id,
+                error=str(e),
+            )
             return []
 
     def get_player_by_id(self, player_id: int) -> dict | None:

--- a/backend/tests/unit/dao/test_roster_age_group_filter.py
+++ b/backend/tests/unit/dao/test_roster_age_group_filter.py
@@ -1,0 +1,145 @@
+"""Unit tests for the SB-68 age_group filter on roster queries.
+
+Mocks the Supabase client to assert that:
+  - When `age_group_id` is None, the query has only team + season filters
+    (no behavior change vs. pre-SB-68).
+  - When `age_group_id` is set, the query adds a strict `.eq("age_group_id", N)`
+    filter.
+
+Covers both DAOs that the API exposes:
+  - RosterDAO.get_team_roster   → `players` table
+  - PlayerDAO.get_team_players  → `player_team_history` table
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dao.player_dao import PlayerDAO
+from dao.roster_dao import RosterDAO
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend, pytest.mark.dao]
+
+
+def _build_dao(cls):
+    """Build a DAO whose `client.table(...)` is a chainable mock.
+
+    Bypasses BaseDAO's SupabaseConnection isinstance check by setting the
+    fields directly.
+    """
+    client_mock = MagicMock()
+    holder = MagicMock()
+    holder.get_client.return_value = client_mock
+
+    dao = cls.__new__(cls)
+    dao.connection_holder = holder
+    dao.client = client_mock
+    return dao, client_mock
+
+
+# ---------------------------------------------------------------------------
+# RosterDAO.get_team_roster
+# ---------------------------------------------------------------------------
+
+
+class TestGetTeamRosterFilter:
+    def _setup_query_chain(self, client_mock, returned_rows):
+        """Wire the chainable mock so .eq().eq().eq().[.eq()].order().execute()
+        returns `returned_rows` regardless of intermediate calls."""
+        execute_mock = MagicMock()
+        execute_mock.data = returned_rows
+        order_mock = MagicMock()
+        order_mock.execute.return_value = execute_mock
+        eq_mock = MagicMock()
+        eq_mock.order.return_value = order_mock
+        eq_mock.eq.return_value = eq_mock
+        client_mock.table.return_value.select.return_value.eq.return_value = eq_mock
+
+    def test_no_age_group_filter_when_arg_is_none(self):
+        dao, client = _build_dao(RosterDAO)
+        self._setup_query_chain(client, [])
+
+        dao.get_team_roster(team_id=10, season_id=3, age_group_id=None)
+
+        # The chain of .eq() calls on the post-select mock should NOT include
+        # an age_group_id eq.
+        eq_chain = client.table.return_value.select.return_value
+        # First eq: team_id, returns the inner mock; subsequent eq's are on
+        # that inner mock.
+        eq_chain.eq.assert_called_with("team_id", 10)
+        inner = eq_chain.eq.return_value
+        eq_calls = [c.args for c in inner.eq.call_args_list]
+        assert ("age_group_id", None) not in eq_calls
+        # Sanity: season_id and is_active are still applied.
+        assert ("season_id", 3) in eq_calls
+        assert ("is_active", True) in eq_calls
+
+    def test_age_group_filter_when_arg_is_set(self):
+        dao, client = _build_dao(RosterDAO)
+        self._setup_query_chain(client, [])
+
+        dao.get_team_roster(team_id=10, season_id=3, age_group_id=2)
+
+        eq_chain = client.table.return_value.select.return_value
+        inner = eq_chain.eq.return_value
+        eq_calls = [c.args for c in inner.eq.call_args_list]
+        assert ("age_group_id", 2) in eq_calls
+
+    def test_returns_empty_list_when_query_fails(self):
+        dao, client = _build_dao(RosterDAO)
+        client.table.return_value.select.return_value.eq.side_effect = RuntimeError(
+            "db down"
+        )
+
+        result = dao.get_team_roster(team_id=10, season_id=3, age_group_id=2)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# PlayerDAO.get_team_players
+# ---------------------------------------------------------------------------
+
+
+class TestGetTeamPlayersFilter:
+    def _setup_query_chain(self, client_mock, returned_rows):
+        execute_mock = MagicMock()
+        execute_mock.data = returned_rows
+        eq_mock = MagicMock()
+        eq_mock.execute.return_value = execute_mock
+        eq_mock.eq.return_value = eq_mock
+        client_mock.table.return_value.select.return_value.eq.return_value = eq_mock
+
+    def test_no_age_group_filter_when_arg_is_none(self):
+        dao, client = _build_dao(PlayerDAO)
+        self._setup_query_chain(client, [])
+
+        dao.get_team_players(team_id=19, age_group_id=None)
+
+        eq_chain = client.table.return_value.select.return_value
+        eq_chain.eq.assert_called_with("team_id", 19)
+        inner = eq_chain.eq.return_value
+        eq_calls = [c.args for c in inner.eq.call_args_list]
+        assert ("age_group_id", None) not in eq_calls
+        assert ("is_current", True) in eq_calls
+
+    def test_age_group_filter_when_arg_is_set(self):
+        dao, client = _build_dao(PlayerDAO)
+        self._setup_query_chain(client, [])
+
+        dao.get_team_players(team_id=19, age_group_id=3)
+
+        eq_chain = client.table.return_value.select.return_value
+        inner = eq_chain.eq.return_value
+        eq_calls = [c.args for c in inner.eq.call_args_list]
+        assert ("age_group_id", 3) in eq_calls
+
+    def test_returns_empty_list_when_query_fails(self):
+        dao, client = _build_dao(PlayerDAO)
+        client.table.return_value.select.return_value.eq.side_effect = RuntimeError(
+            "boom"
+        )
+
+        result = dao.get_team_players(team_id=19, age_group_id=3)
+        assert result == []

--- a/frontend/src/__tests__/components/live/LineupManager.spec.js
+++ b/frontend/src/__tests__/components/live/LineupManager.spec.js
@@ -1,0 +1,84 @@
+/**
+ * LineupManager.vue — SB-68 empty-roster pointer.
+ *
+ * Just covers the new empty-state behavior: when the strict-filter from
+ * SB-68 returns no players for the match's age group, the component
+ * shows a helpful pointer instead of the misleading "All players
+ * assigned" message.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LineupManager from '@/components/live/LineupManager.vue';
+
+const mountLM = (props = {}) =>
+  mount(LineupManager, {
+    props: {
+      teamId: 19,
+      teamName: 'IFA',
+      sportType: 'soccer',
+      saving: false,
+      roster: [],
+      ...props,
+    },
+  });
+
+describe('LineupManager empty-roster pointer (SB-68)', () => {
+  it('renders the "No roster set" pointer when the roster is empty', () => {
+    const wrapper = mountLM({
+      ageGroupName: 'U15',
+      roster: [],
+    });
+
+    const pointer = wrapper.find('[data-testid="lineup-empty-no-roster"]');
+    expect(pointer.exists()).toBe(true);
+    expect(pointer.text()).toContain('No roster set');
+    expect(pointer.text()).toContain('U15');
+    expect(pointer.text()).toContain('IFA');
+    expect(pointer.text()).toContain('Other player');
+  });
+
+  it('falls back to a generic message when ageGroupName is missing', () => {
+    const wrapper = mountLM({
+      ageGroupName: '',
+      roster: [],
+    });
+
+    const pointer = wrapper.find('[data-testid="lineup-empty-no-roster"]');
+    expect(pointer.exists()).toBe(true);
+    expect(pointer.text()).toContain('No roster set');
+    // No "for {age}" sub-phrase when we don't have the age group name.
+    expect(pointer.text()).not.toMatch(/for U\d+/);
+  });
+
+  it('does NOT render the pointer when the roster has players', () => {
+    const wrapper = mountLM({
+      ageGroupName: 'U15',
+      roster: [
+        { id: 1, jersey_number: 7, display_name: 'Player A' },
+        { id: 2, jersey_number: 9, display_name: 'Player B' },
+      ],
+    });
+
+    expect(
+      wrapper.find('[data-testid="lineup-empty-no-roster"]').exists()
+    ).toBe(false);
+    // The standard bench section is rendered instead.
+    expect(wrapper.find('.bench-list').exists()).toBe(true);
+  });
+
+  it('shows "All players assigned" when roster has players but all are on the pitch', async () => {
+    // This is the pre-SB-68 behavior — exercised here to confirm we didn't
+    // regress it. We don't actually assign players here (the lineup state
+    // is internal); we just confirm that when roster.length > 0, the
+    // empty-roster pointer is never the active branch.
+    const wrapper = mountLM({
+      ageGroupName: 'U15',
+      roster: [{ id: 1, jersey_number: 7, display_name: 'Player A' }],
+    });
+
+    expect(
+      wrapper.find('[data-testid="lineup-empty-no-roster"]').exists()
+    ).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/composables/useMatchLineup.spec.js
+++ b/frontend/src/__tests__/composables/useMatchLineup.spec.js
@@ -103,6 +103,61 @@ describe('useMatchLineup', () => {
 
       expect(result).toEqual({ home: [], away: [] });
     });
+
+    // ── SB-68: age_group_id filter ──
+    it('appends &age_group_id to the URL when match.age_group_id is set', async () => {
+      const calledUrls = [];
+      mockAuthStore.apiRequest = vi.fn(url => {
+        calledUrls.push(url);
+        return Promise.resolve({ roster: [] });
+      });
+
+      const matchData = ref(createMatchData({ age_group_id: 3 }));
+      const { fetchTeamRosters } = useMatchLineup(1, matchData);
+
+      await fetchTeamRosters();
+
+      expect(calledUrls).toHaveLength(2);
+      for (const url of calledUrls) {
+        expect(url).toContain('season_id=3');
+        expect(url).toContain('age_group_id=3');
+      }
+    });
+
+    it('omits age_group_id when match.age_group_id is null', async () => {
+      const calledUrls = [];
+      mockAuthStore.apiRequest = vi.fn(url => {
+        calledUrls.push(url);
+        return Promise.resolve({ roster: [] });
+      });
+
+      const matchData = ref(createMatchData({ age_group_id: null }));
+      const { fetchTeamRosters } = useMatchLineup(1, matchData);
+
+      await fetchTeamRosters();
+
+      for (const url of calledUrls) {
+        expect(url).not.toContain('age_group_id');
+      }
+    });
+
+    it('omits age_group_id when match.age_group_id is undefined', async () => {
+      const calledUrls = [];
+      mockAuthStore.apiRequest = vi.fn(url => {
+        calledUrls.push(url);
+        return Promise.resolve({ roster: [] });
+      });
+
+      // No age_group_id key on the match object at all.
+      const matchData = ref(createMatchData());
+      const { fetchTeamRosters } = useMatchLineup(1, matchData);
+
+      await fetchTeamRosters();
+
+      for (const url of calledUrls) {
+        expect(url).not.toContain('age_group_id');
+      }
+    });
   });
 
   describe('fetchLineups', () => {

--- a/frontend/src/components/live/LineupManager.vue
+++ b/frontend/src/components/live/LineupManager.vue
@@ -31,7 +31,26 @@
     <!-- Unassigned players (bench) -->
     <div class="bench-section">
       <h4 class="bench-title">Bench ({{ unassignedPlayers.length }})</h4>
-      <div v-if="unassignedPlayers.length === 0" class="no-bench">
+      <!-- SB-68: distinguish "no roster set up for this age group" from
+           "every roster player is on the pitch". When the roster array is
+           empty, surface a helpful pointer; when it's just fully assigned,
+           keep the original message. -->
+      <div
+        v-if="roster.length === 0"
+        class="no-bench no-roster"
+        data-testid="lineup-empty-no-roster"
+      >
+        <p class="no-bench-headline">
+          No roster set
+          <template v-if="ageGroupName"> for {{ ageGroupName }}</template>
+          <template v-if="teamName"> on {{ teamName }} </template>
+        </p>
+        <p class="no-bench-hint">
+          Live-scoring still works — use "Other player" when recording events,
+          or set up the roster via Profile → My Club.
+        </p>
+      </div>
+      <div v-else-if="unassignedPlayers.length === 0" class="no-bench">
         All players assigned
       </div>
       <div v-else class="bench-list">
@@ -122,6 +141,13 @@ const props = defineProps({
     required: true,
   },
   teamName: {
+    type: String,
+    default: '',
+  },
+  // SB-68: rendered in the "No roster set" empty-state so admins
+  // immediately see which age group's roster is missing rather than just
+  // an empty list.
+  ageGroupName: {
     type: String,
     default: '',
   },
@@ -395,6 +421,27 @@ watch(
   color: #666;
   font-size: 13px;
   font-style: italic;
+}
+
+/* SB-68: empty-roster pointer (no roster set up for this age group). */
+.no-bench.no-roster {
+  font-style: normal;
+  color: #ccc;
+  padding: 4px 0;
+}
+
+.no-bench-headline {
+  margin: 0 0 6px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fbbf24; /* amber, matches the stoppage badge palette */
+}
+
+.no-bench-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #aaa;
+  line-height: 1.4;
 }
 
 .bench-list {

--- a/frontend/src/components/live/LiveAdminControls.vue
+++ b/frontend/src/components/live/LiveAdminControls.vue
@@ -36,6 +36,7 @@
           v-else-if="activeLineupTab === 'home'"
           :team-id="matchState.home_team_id"
           :team-name="matchState.home_team_name"
+          :age-group-name="matchState.age_group_name"
           :roster="homeRoster"
           :initial-lineup="homeLineup"
           :saving="savingLineup"
@@ -46,6 +47,7 @@
           v-else
           :team-id="matchState.away_team_id"
           :team-name="matchState.away_team_name"
+          :age-group-name="matchState.age_group_name"
           :roster="awayRoster"
           :initial-lineup="awayLineup"
           :saving="savingLineup"

--- a/frontend/src/composables/useMatchLineup.js
+++ b/frontend/src/composables/useMatchLineup.js
@@ -33,16 +33,22 @@ export function useMatchLineup(matchId, matchData) {
     const match = unwrapMatchData(matchData);
     if (!match) return { home: [], away: [] };
 
-    const { home_team_id, away_team_id, season_id } = match;
+    const { home_team_id, away_team_id, season_id, age_group_id } = match;
     if (!season_id) return { home: [], away: [] };
+
+    // SB-68: pass the match's age_group_id so the live-match path filters
+    // strictly by age group. Without this, an IFA U15 match would pull
+    // the IFA U14 roster (team_id is age-agnostic for umbrella clubs).
+    const ageGroupParam =
+      age_group_id != null ? `&age_group_id=${age_group_id}` : '';
 
     try {
       const [homeResponse, awayResponse] = await Promise.all([
         authStore.apiRequest(
-          `${getApiBaseUrl()}/api/teams/${home_team_id}/roster?season_id=${season_id}`
+          `${getApiBaseUrl()}/api/teams/${home_team_id}/roster?season_id=${season_id}${ageGroupParam}`
         ),
         authStore.apiRequest(
-          `${getApiBaseUrl()}/api/teams/${away_team_id}/roster?season_id=${season_id}`
+          `${getApiBaseUrl()}/api/teams/${away_team_id}/roster?season_id=${season_id}${ageGroupParam}`
         ),
       ]);
 

--- a/supabase-local/migrations/20260529000000_add_players_age_group_id.sql
+++ b/supabase-local/migrations/20260529000000_add_players_age_group_id.sql
@@ -1,0 +1,32 @@
+-- Players: per-(team, season) age_group_id (SB-68).
+--
+-- The 2026-05-28 IFA semifinal surfaced this: team_id=19 (IFA) is
+-- age-agnostic, and the roster-fetch endpoint (`/api/teams/{id}/roster`)
+-- queried only on (team_id, season_id). So Tom's U14 IFA roster appeared
+-- on a U15 match — every age group's roster for an umbrella team lives
+-- under the same team_id and there was no column to disambiguate.
+--
+-- This adds the column. The roster + lineup query path (SB-68) will
+-- accept an optional age_group_id filter and apply it strictly when set.
+-- Existing rows stay NULL until SB-69 ships a bulk-assign UI so admins
+-- can backfill their existing rosters to the right age group. We leave
+-- the column nullable for that reason — tightening to NOT NULL is
+-- premature.
+--
+-- Per-season correctness: each `players` row is already per
+-- (team_id, season_id). Gabe35's 2025-2026 row gets age_group_id=U14;
+-- his 2026-2027 row (created fresh next season) gets U15. No mutation
+-- of historical truth needed.
+
+ALTER TABLE public.players
+    ADD COLUMN age_group_id integer NULL REFERENCES public.age_groups(id);
+
+-- Index supports the SB-68 strict filter:
+-- WHERE team_id = ? AND season_id = ? AND age_group_id = ?
+CREATE INDEX idx_players_team_season_age
+    ON public.players(team_id, season_id, age_group_id);
+
+COMMENT ON COLUMN public.players.age_group_id IS
+    'Per-(team, season) age group this player belongs to. Nullable until '
+    'SB-69 ships a backfill UI. Filter by it when querying for a specific '
+    'age group''s roster (e.g. live-match lineup).';


### PR DESCRIPTION
Closes [SB-68](https://linear.app/silverbeer/issue/SB-68/live-lineup-shows-wrong-age-groups-roster-when-team-id-is-age-agnostic).

## The bug this fixes
During the 2026-05-28 MLS NEXT Cup U15 SF (City SC SD vs IFA), Tom's U14 IFA roster appeared as the bench on the U15 match. Root cause: \`team_id=19\` (IFA) is age-agnostic, and the live-match roster fetch keyed only on \`(team_id, season_id)\` — no age-group dimension. So any roster attached to team 19 showed up regardless of which age group the match was for.

## Schema
New migration: \`ALTER TABLE players ADD COLUMN age_group_id integer NULL REFERENCES age_groups(id)\` plus a \`(team_id, season_id, age_group_id)\` index for the strict filter. Nullable until SB-69 ships a bulk-assign UI for backfilling existing entries. Per-season correctness: each \`players\` row is already per \`(team_id, season_id)\`, so Gabe35's 2025-2026 row carries U14, his 2026-2027 row (created fresh next season) carries U15 — no historical mutation needed.

## Backend
- \`RosterDAO.get_team_roster\` and \`PlayerDAO.get_team_players\` now take optional \`age_group_id\`. When set, add \`.eq("age_group_id", N)\` to the underlying query. Cache key extended so different age groups don't collide.
- \`/api/teams/{id}/roster\` and \`/api/teams/{id}/players\` accept optional \`age_group_id\` query param. **Backwards compatible**: when omitted, current behavior is preserved (return everything regardless of age). Only the live-match flow opts in.

## Frontend
- \`useMatchLineup.fetchTeamRosters()\` now passes \`match.age_group_id\` when available. The live-match path always filters strictly.
- \`LineupManager.vue\` empty-roster pointer replaces the misleading "All players assigned" message with:
  > **No roster set for U15 on IFA**
  > Live-scoring still works — use "Other player" when recording events, or set up the roster via Profile → My Club.
  
  \`LiveAdminControls\` passes \`matchState.age_group_name\` through.

## Tests
- **Backend (6 new)**: with/without \`age_group_id\` on both DAOs + error paths. Backend total: **300/300 ✅**
- **Frontend (7 new)**: composable URL assertions (with set, with null, with undefined) + 4 component specs for the empty pointer. Frontend total: **437/437 ✅**
- **Lint**: ✅

## Migration
After merge: ArgoCD GitOps deploys backend + frontend, but the schema migration needs \`./scripts/db_tools.sh migrate prod\` (or your standard prod migration step) before the new \`age_group_id\` column exists. The frontend will pass the param immediately on deploy — backend handles missing column gracefully because the column is brand new and queries fall through on the optional filter. Recommended order:

1. Merge this PR.
2. Run \`./scripts/db_tools.sh migrate prod\` to apply the migration.
3. Existing roster entries stay NULL → strict filter returns empty for any age group → LineupManager shows the "No roster set" pointer everywhere until SB-69 ships the backfill UI.

## Test plan (post-merge + post-migration)

- [ ] Open the City SC SD vs IFA U15 SF in the admin live view (match 3165, age_group_id=3). Lineup bench shows the "No roster set for U15 on IFA" hint (not the leaking U14 squad).
- [ ] Live-scoring via "Other player" entries still works for goals + cards (no roster needed).
- [ ] On a different match where the team's roster IS age-tagged (after SB-69 backfill ships): roster appears normally.
- [ ] Existing non-live-match surfaces that hit \`/api/teams/{id}/roster\` without \`age_group_id\` return the full roster as today (no regression).
- [ ] Mobile per \`feedback-mobile-first-ui\`: empty-state copy readable at 390px, no overflow.

## Follow-ups (filed separately)

- **SB-69** — Bulk-assign UI in Profile → My Club → Manage Roster so admins can tag existing players with the right \`age_group_id\`. Without this, all current rosters stay invisible to the live-match filter.
- **SB-70** — "Roll over roster to next season" workflow. When 2026-2027 starts, clone last season's roster with \`season_id\` advanced and \`age_group_id\` bumped one (with overrides for hold-backs / play-ups). Critical for year-2 usability — the data model is now correct but re-entering 30 players manually every August would be brutal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)