### PR TITLE
feat(tournament): list-view polish — sort, team logos, hide redundant age chip (SB-73)

### DIFF
--- a/backend/dao/tournament_dao.py
+++ b/backend/dao/tournament_dao.py
@@ -167,15 +167,26 @@ class TournamentDAO(BaseDAO):
                     tournament_round,
                     tournament_round_order,
                     age_group:age_groups!matches_age_group_id_fkey(id, name),
-                    home_team:teams!matches_home_team_id_fkey(id, name),
-                    away_team:teams!matches_away_team_id_fkey(id, name)
+                    home_team:teams!matches_home_team_id_fkey(id, name, club:clubs(id, name, logo_url)),
+                    away_team:teams!matches_away_team_id_fkey(id, name, club:clubs(id, name, logo_url))
                 """)
                 .eq("tournament_id", tournament_id)
                 .order("match_date", desc=False)
                 .execute()
             )
 
-            tournament["matches"] = m_response.data or []
+            # Flatten the nested club under each team into a top-level
+            # `home_team_club` / `away_team_club` on the match, matching the
+            # shape used by `/api/matches` and consumed by MatchDetailView /
+            # MatchesView. Keeps the frontend club-logo code paths consistent
+            # across endpoints.
+            matches = m_response.data or []
+            for m in matches:
+                home = m.get("home_team") or {}
+                away = m.get("away_team") or {}
+                m["home_team_club"] = home.pop("club", None)
+                m["away_team_club"] = away.pop("club", None)
+            tournament["matches"] = matches
             return tournament
 
         except Exception:

--- a/frontend/src/__tests__/components/TournamentMatchCenter.spec.js
+++ b/frontend/src/__tests__/components/TournamentMatchCenter.spec.js
@@ -1,0 +1,189 @@
+/**
+ * TournamentMatchCenter.vue Tests (list-view polish — SB-73)
+ *
+ * Covers the three list-view UX rules:
+ *  - chronological sort of group/knockout/untagged sections by
+ *    `match_date` then `scheduled_kickoff`
+ *  - team-club logos render in each row when `home_team_club.logo_url`
+ *    / `away_team_club.logo_url` are present, and silently absent when not
+ *  - age-group chip is hidden when the tournament has a single age group
+ *    (it duplicates the tournament header), but visible when multiple
+ *
+ * The component fetches tournaments on mount via `authStore.apiRequest`;
+ * we stub the auth store so the mount stays deterministic and offline.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+// Stub the auth store BEFORE importing the component so the import sees the mock.
+const apiRequest = vi.fn();
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ apiRequest }),
+}));
+
+import TournamentMatchCenter from '@/components/TournamentMatchCenter.vue';
+
+const team = (id, name, logoUrl = null) => ({
+  id,
+  name,
+  // The match payload carries the team's club as a flat sibling field, mirroring
+  // the shape returned by the tournament endpoint after the SB-73 backend
+  // change (and matching /api/matches).
+  __club: logoUrl
+    ? { id: id * 100, name: `${name} Club`, logo_url: logoUrl }
+    : null,
+});
+
+// Build one match row with optional kickoff + clubs. The two club refs are
+// flattened to home_team_club / away_team_club to match the backend shape.
+const mkMatch = (id, home, away, opts = {}) => ({
+  id,
+  match_date: opts.date || '2026-06-05',
+  scheduled_kickoff: opts.kickoff || null,
+  match_status: opts.status || 'scheduled',
+  home_score: opts.home_score ?? null,
+  away_score: opts.away_score ?? null,
+  home_penalty_score: null,
+  away_penalty_score: null,
+  tournament_group: opts.group || 'A',
+  tournament_round: opts.round || 'group_stage',
+  tournament_round_order: opts.order ?? null,
+  age_group: opts.age_group || { id: 2, name: 'U14' },
+  home_team: { id: home.id, name: home.name },
+  away_team: { id: away.id, name: away.name },
+  home_team_club: home.__club,
+  away_team_club: away.__club,
+});
+
+// Mount with a pre-staged tournament + matches. We resolve the two
+// apiRequest calls (`/api/tournaments` list, then `/api/tournaments/{id}`
+// detail) so the component renders against real data, not loading state.
+async function mountWith(tournament) {
+  apiRequest.mockReset();
+  apiRequest.mockResolvedValueOnce([tournament]);
+  apiRequest.mockResolvedValueOnce(tournament);
+  const wrapper = mount(TournamentMatchCenter, {
+    global: { stubs: { MatchDetailView: true } },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+const IFA = team(19, 'IFA');
+const BWG = team(13, 'Blau Weiss Gottschee');
+const OAK = team(24, 'Oakwood SC', 'https://cdn.example/oakwood.png');
+const BOLTS = team(17, 'Boston Bolts', 'https://cdn.example/bolts.png');
+
+describe('TournamentMatchCenter — list polish (SB-73)', () => {
+  it('sorts group-stage matches by date then kickoff', async () => {
+    // Deliberately out of order in the input.
+    const matches = [
+      mkMatch(102, IFA, BWG, {
+        date: '2026-06-06',
+        kickoff: '2026-06-06T12:00:00Z',
+      }),
+      mkMatch(100, OAK, BOLTS, {
+        date: '2026-06-05',
+        kickoff: '2026-06-05T19:00:00Z',
+      }),
+      mkMatch(101, IFA, OAK, {
+        date: '2026-06-05',
+        kickoff: '2026-06-05T14:30:00Z',
+      }),
+    ];
+    const tournament = {
+      id: 6,
+      name: 'NAC',
+      start_date: '2026-06-05',
+      end_date: '2026-06-07',
+      matches,
+      age_groups: [{ id: 2, name: 'U14' }],
+    };
+    const wrapper = await mountWith(tournament);
+
+    // Pull the rendered text of each group-stage row in order; the earliest
+    // kickoff should come first (IFA vs Oakwood at 14:30 on 06-05).
+    const rows = wrapper.findAll(
+      '[data-testid="group-stage-match"], .cursor-pointer'
+    );
+    const text = rows.map(r => r.text()).join('\n');
+    const ifaOakIdx = text.indexOf('Oakwood');
+    const ifaBwgIdx = text.indexOf('Blau Weiss Gottschee');
+    const oakBoltsIdx = text.indexOf('Boston Bolts');
+    // 06-05 14:30 (IFA vs Oakwood) renders before 06-05 19:00 (Oakwood vs Bolts)
+    // which renders before 06-06 12:00 (IFA vs BWG).
+    expect(ifaOakIdx).toBeGreaterThan(-1);
+    expect(oakBoltsIdx).toBeGreaterThan(ifaOakIdx);
+    expect(ifaBwgIdx).toBeGreaterThan(oakBoltsIdx);
+  });
+
+  it('renders team-club logos when logo_url is present', async () => {
+    const tournament = {
+      id: 6,
+      name: 'NAC',
+      start_date: '2026-06-05',
+      matches: [mkMatch(1, OAK, BOLTS, { kickoff: '2026-06-05T14:30:00Z' })],
+      age_groups: [{ id: 2, name: 'U14' }],
+    };
+    const wrapper = await mountWith(tournament);
+
+    const imgs = wrapper.findAll('img');
+    const srcs = imgs.map(i => i.attributes('src'));
+    expect(srcs).toContain('https://cdn.example/oakwood.png');
+    expect(srcs).toContain('https://cdn.example/bolts.png');
+  });
+
+  it('omits the logo img when a team has no club logo_url', async () => {
+    const tournament = {
+      id: 6,
+      name: 'NAC',
+      start_date: '2026-06-05',
+      // Both teams have null clubs — no team logos in this row.
+      matches: [mkMatch(1, IFA, BWG)],
+      age_groups: [{ id: 2, name: 'U14' }],
+    };
+    const wrapper = await mountWith(tournament);
+
+    const srcs = wrapper.findAll('img').map(i => i.attributes('src'));
+    // No team-club URLs (only tournament-header logo, if any, would appear).
+    expect(srcs.every(s => !s?.includes('cdn.example'))).toBe(true);
+  });
+
+  it('hides the age-group chip when the tournament has only one age group', async () => {
+    const tournament = {
+      id: 6,
+      name: 'NAC',
+      start_date: '2026-06-05',
+      matches: [mkMatch(1, IFA, BWG, { age_group: { id: 2, name: 'U14' } })],
+      age_groups: [{ id: 2, name: 'U14' }],
+    };
+    const wrapper = await mountWith(tournament);
+
+    // The U14 chip would appear twice per row (mobile + desktop) if rendered.
+    // The tournament header still renders the U14 badge, so we look for the
+    // chip styled with bg-indigo-100 (the per-row variant).
+    const chips = wrapper.findAll('.bg-indigo-100');
+    expect(chips.length).toBe(0);
+  });
+
+  it('shows the age-group chip when matches span multiple age groups', async () => {
+    const tournament = {
+      id: 4,
+      name: 'MLS NEXT Cup',
+      start_date: '2026-05-23',
+      matches: [
+        mkMatch(1, IFA, BWG, { age_group: { id: 1, name: 'U13' } }),
+        mkMatch(2, OAK, BOLTS, { age_group: { id: 2, name: 'U14' } }),
+      ],
+      age_groups: [
+        { id: 1, name: 'U13' },
+        { id: 2, name: 'U14' },
+      ],
+    };
+    const wrapper = await mountWith(tournament);
+
+    // At least one bg-indigo-100 chip should render now that there are 2 ages.
+    expect(wrapper.findAll('.bg-indigo-100').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -295,7 +295,7 @@
                       >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
                     >
                     <span
-                      v-if="match.age_group"
+                      v-if="match.age_group && showAgeChip"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
                     >
@@ -340,7 +340,7 @@
                   </div>
                   <div class="hidden sm:flex gap-1 shrink-0">
                     <span
-                      v-if="match.age_group"
+                      v-if="match.age_group && showAgeChip"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
                     >
@@ -351,10 +351,18 @@
                     >
                   </div>
                   <div class="flex-1 flex items-center gap-2 min-w-0">
-                    <span
-                      class="text-sm font-medium text-gray-900 text-right truncate flex-1"
-                      >{{ match.home_team?.name }}</span
-                    >
+                    <div class="flex-1 flex items-center gap-1.5 min-w-0">
+                      <img
+                        v-if="match.home_team_club?.logo_url"
+                        :src="match.home_team_club.logo_url"
+                        alt=""
+                        class="w-5 h-5 object-contain shrink-0"
+                      />
+                      <span
+                        class="text-sm font-medium text-gray-900 text-right truncate flex-1 min-w-0"
+                        >{{ match.home_team?.name }}</span
+                      >
+                    </div>
                     <span
                       :class="[
                         'text-xs sm:text-sm font-mono px-1.5 sm:px-2 py-0.5 rounded shrink-0',
@@ -371,10 +379,18 @@
                           : 'vs'
                       }}
                     </span>
-                    <span
-                      class="text-sm font-medium text-gray-900 text-left truncate flex-1"
-                      >{{ match.away_team?.name }}</span
-                    >
+                    <div class="flex-1 flex items-center gap-1.5 min-w-0">
+                      <span
+                        class="text-sm font-medium text-gray-900 text-left truncate flex-1 min-w-0"
+                        >{{ match.away_team?.name }}</span
+                      >
+                      <img
+                        v-if="match.away_team_club?.logo_url"
+                        :src="match.away_team_club.logo_url"
+                        alt=""
+                        class="w-5 h-5 object-contain shrink-0"
+                      />
+                    </div>
                   </div>
                   <div class="hidden sm:block w-20 shrink-0 text-right">
                     <span
@@ -429,7 +445,7 @@
                       >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
                     >
                     <span
-                      v-if="match.age_group"
+                      v-if="match.age_group && showAgeChip"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
                     >
@@ -474,7 +490,7 @@
                   </div>
                   <div class="hidden sm:flex gap-1 shrink-0">
                     <span
-                      v-if="match.age_group"
+                      v-if="match.age_group && showAgeChip"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
                     >
@@ -490,10 +506,18 @@
                     >
                   </div>
                   <div class="flex-1 flex items-center gap-2 min-w-0">
-                    <span
-                      class="text-sm font-medium text-gray-900 text-right truncate flex-1"
-                      >{{ match.home_team?.name }}</span
-                    >
+                    <div class="flex-1 flex items-center gap-1.5 min-w-0">
+                      <img
+                        v-if="match.home_team_club?.logo_url"
+                        :src="match.home_team_club.logo_url"
+                        alt=""
+                        class="w-5 h-5 object-contain shrink-0"
+                      />
+                      <span
+                        class="text-sm font-medium text-gray-900 text-right truncate flex-1 min-w-0"
+                        >{{ match.home_team?.name }}</span
+                      >
+                    </div>
                     <span
                       :class="[
                         'text-xs sm:text-sm font-mono px-1.5 sm:px-2 py-0.5 rounded shrink-0',
@@ -510,10 +534,18 @@
                           : 'vs'
                       }}
                     </span>
-                    <span
-                      class="text-sm font-medium text-gray-900 text-left truncate flex-1"
-                      >{{ match.away_team?.name }}</span
-                    >
+                    <div class="flex-1 flex items-center gap-1.5 min-w-0">
+                      <span
+                        class="text-sm font-medium text-gray-900 text-left truncate flex-1 min-w-0"
+                        >{{ match.away_team?.name }}</span
+                      >
+                      <img
+                        v-if="match.away_team_club?.logo_url"
+                        :src="match.away_team_club.logo_url"
+                        alt=""
+                        class="w-5 h-5 object-contain shrink-0"
+                      />
+                    </div>
                   </div>
                   <div class="hidden sm:block w-20 shrink-0 text-right">
                     <span
@@ -568,7 +600,7 @@
                       >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
                     >
                     <span
-                      v-if="match.age_group"
+                      v-if="match.age_group && showAgeChip"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
                     >
@@ -608,16 +640,24 @@
                   </div>
                   <div class="hidden sm:flex gap-1 shrink-0">
                     <span
-                      v-if="match.age_group"
+                      v-if="match.age_group && showAgeChip"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700"
                       >{{ match.age_group.name }}</span
                     >
                   </div>
                   <div class="flex-1 flex items-center gap-2 min-w-0">
-                    <span
-                      class="text-sm font-medium text-gray-900 text-right truncate flex-1"
-                      >{{ match.home_team?.name }}</span
-                    >
+                    <div class="flex-1 flex items-center gap-1.5 min-w-0">
+                      <img
+                        v-if="match.home_team_club?.logo_url"
+                        :src="match.home_team_club.logo_url"
+                        alt=""
+                        class="w-5 h-5 object-contain shrink-0"
+                      />
+                      <span
+                        class="text-sm font-medium text-gray-900 text-right truncate flex-1 min-w-0"
+                        >{{ match.home_team?.name }}</span
+                      >
+                    </div>
                     <span
                       :class="[
                         'text-xs sm:text-sm font-mono px-1.5 sm:px-2 py-0.5 rounded shrink-0',
@@ -634,10 +674,18 @@
                           : 'vs'
                       }}
                     </span>
-                    <span
-                      class="text-sm font-medium text-gray-900 text-left truncate flex-1"
-                      >{{ match.away_team?.name }}</span
-                    >
+                    <div class="flex-1 flex items-center gap-1.5 min-w-0">
+                      <span
+                        class="text-sm font-medium text-gray-900 text-left truncate flex-1 min-w-0"
+                        >{{ match.away_team?.name }}</span
+                      >
+                      <img
+                        v-if="match.away_team_club?.logo_url"
+                        :src="match.away_team_club.logo_url"
+                        alt=""
+                        class="w-5 h-5 object-contain shrink-0"
+                      />
+                    </div>
                   </div>
                   <div class="hidden sm:block w-20 shrink-0 text-right">
                     <span
@@ -951,37 +999,68 @@ export default {
       );
     });
 
+    // Sort key used across all three sections: ascending by match_date first,
+    // then by scheduled_kickoff within the day, then by id as a stable
+    // tiebreaker. Matches without a scheduled_kickoff still group correctly
+    // because the date sort still applies; they fall to the bottom of the
+    // day in id-order.
+    const byKickoffAsc = (a, b) => {
+      const da = a.match_date || '';
+      const db = b.match_date || '';
+      if (da !== db) return da < db ? -1 : 1;
+      const ka = a.scheduled_kickoff || '';
+      const kb = b.scheduled_kickoff || '';
+      if (ka !== kb) return ka < kb ? -1 : 1;
+      return (a.id || 0) - (b.id || 0);
+    };
+
     const groupStageMatches = computed(() =>
-      filteredMatches.value.filter(m => m.tournament_round === 'group_stage')
+      filteredMatches.value
+        .filter(m => m.tournament_round === 'group_stage')
+        .slice()
+        .sort(byKickoffAsc)
     );
 
-    const knockoutMatches = computed(() =>
-      filteredMatches.value
+    // Knockout: round first (R32 → R16 → QF → SF → 3rd → Final), then
+    // chronological within the round. This keeps the visual flow of the
+    // tournament progression intact while still ordering within each round.
+    const knockoutMatches = computed(() => {
+      const order = [
+        'round_of_32',
+        'round_of_16',
+        'quarterfinal',
+        'semifinal',
+        'third_place',
+        'final',
+      ];
+      return filteredMatches.value
         .filter(m => KNOCKOUT_ROUNDS.has(m.tournament_round))
+        .slice()
         .sort((a, b) => {
-          const order = [
-            'round_of_32',
-            'round_of_16',
-            'quarterfinal',
-            'semifinal',
-            'third_place',
-            'final',
-          ];
-          return (
+          const r =
             order.indexOf(a.tournament_round) -
-            order.indexOf(b.tournament_round)
-          );
-        })
-    );
+            order.indexOf(b.tournament_round);
+          return r !== 0 ? r : byKickoffAsc(a, b);
+        });
+    });
 
     const untaggedMatches = computed(() =>
-      filteredMatches.value.filter(
-        m =>
-          !m.tournament_round ||
-          (!KNOCKOUT_ROUNDS.has(m.tournament_round) &&
-            m.tournament_round !== 'group_stage')
-      )
+      filteredMatches.value
+        .filter(
+          m =>
+            !m.tournament_round ||
+            (!KNOCKOUT_ROUNDS.has(m.tournament_round) &&
+              m.tournament_round !== 'group_stage')
+        )
+        .slice()
+        .sort(byKickoffAsc)
     );
+
+    // True when the tournament has more than one age group represented in
+    // its matches — drives whether each row should show the age-group chip.
+    // For single-age tournaments (e.g. NAC = U14-only) the chip is pure
+    // noise, since the tournament header already states the age group.
+    const showAgeChip = computed(() => availableAgeGroups.value.length > 1);
 
     // ── bracket-mode computed state ──
 
@@ -1185,6 +1264,7 @@ export default {
       selectedMatchId,
       viewMatch,
       handleBackFromMatchDetail,
+      showAgeChip,
     };
   },
 };


### PR DESCRIPTION
Closes [SB-73](https://linear.app/silverbeer/issue/SB-73/tournament-list-view-chronological-sort-team-logos-hide-redundant-age).

Three UX improvements to the tournament list view, surfaced while loading the 2026 NAC bracket.

### 1. Chronological sort
Group-stage / knockout / untagged sections now sort by **match_date → scheduled_kickoff → id** (ascending). Previously matches rendered in API/insert order, so a single day looked like `3:00 PM, 3:00 PM, 10:30 AM, 10:30 AM, 3:00 PM…` instead of clean chronological. Knockout sort still groups by round first (R32 → R16 → QF → SF → 3rd → Final), then chronological within round.

### 2. Team-club logos
Each row shows the home/away team-club logo (20px, `object-contain`) next to the team name — falls back gracefully when `logo_url` is null. Logos sit on the outer edges of each row, names toward the score, matching the convention in MatchDetailView / MatchesView / LeagueTable.

**Required backend change** (`backend/dao/tournament_dao.py:155`): the matches select now pulls the nested `club:clubs(id, name, logo_url)` under each team and flattens to `home_team_club` / `away_team_club` on the match — the same shape `/api/matches` returns and the rest of the frontend already consumes.

### 3. Hide redundant age chip
The per-row `U14` chip is hidden when the tournament has a single age group (it duplicated info already in the tournament header). Still rendered for multi-age tournaments like MLS NEXT Cup so U13/U14/U15 stay distinguishable in the same list.

## Test plan
- `cd frontend && npm run test:run` → **442 pass, 0 fail** (5 new tests in `TournamentMatchCenter.spec.js` cover sort, logo render, missing-logo fallback, single-age chip hide, multi-age chip show)
- `cd frontend && npm run lint` → clean
- `cd backend && uv run ruff check dao/tournament_dao.py` → clean
- Manual (after backend restart): NAC tournament list should render in chronological order with team logos and no per-row U14 chip; MLS NEXT Cup list should still show the U14 / U15 / etc. chips.

## Notes
- Builds on the mobile-rendering work merged from PR #411 — breakpoint norms and truncation patterns there are preserved (logo flex layouts use `min-w-0` so truncation still kicks in on narrow viewports).
- Cache invalidation gap from [SB-72](https://linear.app/silverbeer/issue/SB-72) still applies: after deploy, a `redis-cli FLUSHDB` may be needed for already-cached tournament responses to pick up the new club fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)