### PR TITLE
chore: gitignore parallel coverage data files (.coverage.*) (SB-74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ crew_testing/*.md
 
 # Test artifacts
 .coverage
+.coverage.*
 coverage.json
 **/coverage.json
 coverage_audit.json


### PR DESCRIPTION
## Summary

`.gitignore` ignored `.coverage` but not the parallel pytest-cov worker data files (`.coverage.<host>.<pid>.<rand>.wgwN`). These accumulated in the working tree and cluttered `git status`.

This adds `.coverage.*` so parallel coverage runs no longer pollute status.

Found while auditing git worktree cleanup — worktrees were clean; this stray-file noise was the actual issue.

Closes SB-74

🤖 Generated with [Claude Code](https://claude.com/claude-code)