### PR TITLE
feat(notifications): push to team followers on admin/skill score writes (SB-77)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,7 @@ from models import (
     UserProfileUpdate,
     UserSignup,
 )
+from notifications.score_change import is_new_final_score
 from notifications.tasks import notify_event_task
 from services import EmailService, InviteService
 
@@ -2440,6 +2441,27 @@ async def get_match(
         ) from e
 
 
+def _maybe_notify_final_score(
+    background_tasks: BackgroundTasks,
+    before: dict | None,
+    after: dict | None,
+) -> None:
+    """Fire a 'fulltime' follower notification when a write sets a new final score.
+
+    Shared by the admin/skill match-write endpoints (tournament create/update
+    and the regular league update/patch path). The live in-app scoring endpoints
+    have their own goal/clock notifications and don't use this. (SB-77)
+
+    No-op unless `is_new_final_score(before, after)` — so metadata-only edits and
+    idempotent re-submissions of an already-recorded score never re-notify.
+    """
+    match_id = (after or {}).get("id")
+    if match_id is None:
+        return
+    if is_new_final_score(before, after):
+        background_tasks.add_task(notify_event_task, "fulltime", match_id, None)
+
+
 @app.post("/api/matches")
 async def add_match(
     request: Request,
@@ -2492,11 +2514,13 @@ async def add_match(
 async def update_match(
     match_id: int,
     match: EnhancedMatch,
+    background_tasks: BackgroundTasks,
     current_user: dict[str, Any] = Depends(require_match_management_permission),
 ):
     """Update an existing match (requires admin, team manager, or service account with manage_matches)."""
     try:
-        # Get current match to check permissions
+        # Get current match to check permissions (also the before-snapshot for
+        # the score-change notification below).
         current_match = match_dao.get_match_by_id(match_id)
         if not current_match:
             raise HTTPException(status_code=404, detail="Match not found")
@@ -2527,6 +2551,9 @@ async def update_match(
             scheduled_kickoff=match.scheduled_kickoff.isoformat() if match.scheduled_kickoff else None,
         )
         if updated_match:
+            # Notify followers if this write set/changed the final score (SB-77).
+            after = match_dao.get_match_by_id(match_id)
+            _maybe_notify_final_score(background_tasks, current_match, after)
             return {"message": "Match updated successfully"}
         else:
             raise HTTPException(status_code=500, detail="Failed to update match")
@@ -2539,6 +2566,7 @@ async def update_match(
 async def patch_match(
     match_id: int,
     match_patch: MatchPatch,
+    background_tasks: BackgroundTasks,
     current_user: dict[str, Any] = Depends(require_match_management_permission),
 ):
     """Partially update a match (requires manage_matches permission).
@@ -2547,7 +2575,8 @@ async def patch_match(
     Commonly used for score updates from match-scraper.
     """
     try:
-        # Get current match to check permissions and get existing values
+        # Get current match to check permissions and get existing values (also
+        # the before-snapshot for the score-change notification below).
         current_match = match_dao.get_match_by_id(match_id)
         if not current_match:
             raise HTTPException(status_code=404, detail="Match not found")
@@ -2616,6 +2645,10 @@ async def patch_match(
         logger.info(f"PATCH /api/matches/{match_id} - Update success: {bool(updated_match)}")
 
         if updated_match:
+            # Notify followers if this write set/changed the final score (SB-77).
+            # This is the path match-scraper uses to post league results.
+            after = match_dao.get_match_by_id(match_id)
+            _maybe_notify_final_score(background_tasks, current_match, after)
             # Return the updated match data directly from update_match
             # This avoids read-after-write consistency issues
             logger.info(f"PATCH /api/matches/{match_id} - Returning updated match: {updated_match}")
@@ -6732,11 +6765,12 @@ async def admin_upload_tournament_logo(
 async def admin_create_tournament_match(
     tournament_id: int,
     payload: TournamentMatchCreate,
+    background_tasks: BackgroundTasks,
     current_user: dict[str, Any] = Depends(require_admin),
 ):
     """Add a match to a tournament (admin)."""
     try:
-        return tournament_dao.create_tournament_match(
+        created = tournament_dao.create_tournament_match(
             tournament_id=tournament_id,
             our_team_id=payload.our_team_id,
             opponent_name=payload.opponent_name,
@@ -6754,6 +6788,11 @@ async def admin_create_tournament_match(
             tournament_round_order=payload.tournament_round_order,
             scheduled_kickoff=payload.scheduled_kickoff,
         )
+        # Skill often creates already-played matches in one shot (score + status
+        # completed) — notify followers when that happens. A scheduled matchup
+        # with no score is a no-op. (SB-77)
+        _maybe_notify_final_score(background_tasks, None, created)
+        return created
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
     except Exception as e:
@@ -6765,10 +6804,15 @@ async def admin_update_tournament_match(
     tournament_id: int,
     match_id: int,
     payload: TournamentMatchUpdate,
+    background_tasks: BackgroundTasks,
     current_user: dict[str, Any] = Depends(require_admin),
 ):
     """Update score, status, or context on a tournament match (admin)."""
     try:
+        # Snapshot before the write so we only notify on a real score change —
+        # the skill's upsert loop frequently re-PUTs metadata or identical
+        # scores, which must stay silent. (SB-77)
+        before = match_dao.get_match_by_id(match_id)
         updated = tournament_dao.update_tournament_match(
             match_id=match_id,
             home_score=payload.home_score,
@@ -6787,6 +6831,9 @@ async def admin_update_tournament_match(
         )
         if not updated:
             raise HTTPException(status_code=404, detail="Match not found")
+        # Re-read flattened for a like-shaped comparison vs. `before`.
+        after = match_dao.get_match_by_id(match_id)
+        _maybe_notify_final_score(background_tasks, before, after)
         return updated
     except HTTPException:
         raise

--- a/backend/notifications/dispatcher.py
+++ b/backend/notifications/dispatcher.py
@@ -184,18 +184,6 @@ class Notifier:
         home_club_id = home_club.get("id")
         away_club_id = away_club.get("id")
 
-        destinations = resolve_destinations(home_club_id, away_club_id, self.notif_dao)
-        if not destinations:
-            logger.info(
-                "notifications.skipped",
-                reason="no_channels",
-                match_id=match_id,
-                event_type=event_type,
-                home_club_id=home_club_id,
-                away_club_id=away_club_id,
-            )
-            return
-
         tz_name = fetch_club_timezone(home_club_id, self.connection.get_client())
         try:
             tz = ZoneInfo(tz_name)
@@ -212,30 +200,46 @@ class Notifier:
             )
             return
 
-        sent = 0
-        failed = 0
-        for platform, destination in destinations:
-            try:
-                self.send_fn(platform, destination, content)
-                sent += 1
-            except Exception as exc:
-                failed += 1
-                logger.warning(
-                    "notifications.send_failed",
-                    platform=platform,
-                    match_id=match_id,
-                    event_type=event_type,
-                    error_type=type(exc).__name__,
-                    error=str(exc),
-                )
+        # Club notification channels (Telegram/Discord). A match may have none
+        # — e.g. tournament teams whose clubs have no channel config — in which
+        # case we skip the club sends but STILL run the Web Push fan-out below.
+        # Push to team followers must not depend on the clubs having channels
+        # (SB-77); previously a no-channels match returned here and followers
+        # got nothing.
+        destinations = resolve_destinations(home_club_id, away_club_id, self.notif_dao)
+        if destinations:
+            sent = 0
+            failed = 0
+            for platform, destination in destinations:
+                try:
+                    self.send_fn(platform, destination, content)
+                    sent += 1
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "notifications.send_failed",
+                        platform=platform,
+                        match_id=match_id,
+                        event_type=event_type,
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
 
-        logger.info(
-            "notifications.dispatched",
-            match_id=match_id,
-            event_type=event_type,
-            sent=sent,
-            failed=failed,
-        )
+            logger.info(
+                "notifications.dispatched",
+                match_id=match_id,
+                event_type=event_type,
+                sent=sent,
+                failed=failed,
+            )
+        else:
+            logger.info(
+                "notifications.no_club_channels",
+                match_id=match_id,
+                event_type=event_type,
+                home_club_id=home_club_id,
+                away_club_id=away_club_id,
+            )
 
         # --- Web Push fan-out -------------------------------------------------
         # Independent of club-channel sends above; failures don't affect each

--- a/backend/notifications/score_change.py
+++ b/backend/notifications/score_change.py
@@ -1,0 +1,71 @@
+"""Detect when a match write represents a *new final score* worth notifying.
+
+Used by the admin/skill match-write endpoints (tournament create/update, and
+the regular league update/patch path) to decide whether to fan a "fulltime"
+notification out to followers. (SB-77)
+
+This is a pure function with no I/O so it can be unit-tested directly.
+
+A write qualifies as a notify-worthy scoring event when, AFTER the write, the
+match has both a home and away score, AND either:
+
+  - the (home, away) score pair actually changed vs. before the write
+    (covers scheduled→scored, and an admin correcting a wrong score), or
+  - the match newly transitioned into a completed status carrying a score
+    (covers the rare case where the score was already present but the match
+    only just got marked completed).
+
+It deliberately does NOT fire when:
+
+  - the write only touched metadata (round / group / order / kickoff / team
+    identity) and left the score untouched — the common upsert-loop case, and
+  - an identical score is re-submitted (idempotent re-runs of the skill), and
+  - the match has no score yet, or is still in a non-completed state.
+"""
+
+from __future__ import annotations
+
+
+def _status(match: dict) -> str | None:
+    """Read the status under either key the row may expose.
+
+    Raw `matches` rows use `match_status`; some joined read shapes alias it to
+    `status`. Accept both so detection is robust to which path produced the dict.
+    """
+    return match.get("match_status") or match.get("status")
+
+
+def _scores(match: dict) -> tuple[int | None, int | None]:
+    return match.get("home_score"), match.get("away_score")
+
+
+def is_new_final_score(old: dict | None, new: dict | None) -> bool:
+    """Return True if `new` represents a fresh final score relative to `old`.
+
+    `old` is the match row before the write (None for a create); `new` is the
+    row after the write. Both are plain dicts straight off the matches table.
+    """
+    if not new:
+        return False
+
+    new_home, new_away = _scores(new)
+    if new_home is None or new_away is None:
+        return False  # no complete score yet — nothing to announce
+
+    new_status = _status(new)
+    # If a status is present it must be 'completed'; a partial/in-progress
+    # write is not a final score. (None status is tolerated — tournament rows
+    # may omit it; the score-pair check below still gates the notification.)
+    if new_status is not None and new_status != "completed":
+        return False
+
+    old = old or {}
+    old_home, old_away = _scores(old)
+    old_status = _status(old)
+
+    if (old_home, old_away) != (new_home, new_away):
+        return True  # score newly set or corrected
+
+    # Same score, but only just marked completed → fire once. Otherwise it's an
+    # unchanged score on an already-completed match — no-op.
+    return old_status != "completed" and new_status == "completed"

--- a/backend/tests/unit/test_dispatcher_push_without_channels.py
+++ b/backend/tests/unit/test_dispatcher_push_without_channels.py
@@ -1,0 +1,107 @@
+"""Dispatcher push-fan-out-without-club-channels tests (SB-77).
+
+Regression guard for the bug where `Notifier.notify()` returned early when a
+match's clubs had no notification channels — silently skipping the Web Push
+fan-out to team followers. Tournament teams typically have no club channels,
+so this was the whole gap behind "notify followers when a match is scored".
+
+The fix: club-channel sends and the push fan-out are independent; a match with
+no channels must still push to followers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from notifications.dispatcher import Notifier
+from notifications.preferences import DEFAULT_PREFERENCES
+from notifications.web_push_sender import SendResult
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend]
+
+
+def _send_ok(_sub, _payload):
+    return SendResult(status="sent", http_status=201)
+
+
+# A fulltime match for two teams whose clubs have NO notification channels.
+_MATCH = {
+    "id": 555,
+    "home_team_id": 10,
+    "away_team_id": 20,
+    "home_team_name": "Houston Rangers",
+    "away_team_name": "Cedar Stars Academy Bergen",
+    "home_score": 0,
+    "away_score": 1,
+    "home_team_club": None,
+    "away_team_club": None,
+}
+
+
+@pytest.fixture(autouse=True)
+def _push_configured(monkeypatch):
+    monkeypatch.setattr("notifications.dispatcher.push_is_configured", lambda: True)
+
+
+def _notifier_with_follower():
+    """Notifier whose match lookup returns _MATCH, no club channels, and one
+    follower with one device. DB-touching DAOs are mocked."""
+    push_send_fn = MagicMock(side_effect=_send_ok)
+    notifier = Notifier(send_fn=MagicMock(), push_send_fn=push_send_fn)
+
+    notifier._match_dao = MagicMock()
+    notifier._match_dao.get_match_by_id.return_value = _MATCH
+
+    # No club channels for either club.
+    notifier._notif_dao = MagicMock()
+    notifier._notif_dao.list_by_club.return_value = []
+
+    # Timezone lookup hits connection.get_client(); stub the whole connection.
+    notifier._connection = MagicMock()
+
+    # One follower, one device.
+    notifier._team_follow_dao = MagicMock()
+    notifier._team_follow_dao.list_subscriptions_for_team_ids.return_value = [
+        {"id": "sub-1", "user_id": "u-follower", "endpoint": "https://push/x",
+         "p256dh_key": "k", "auth_key": "a"},
+    ]
+    notifier._prefs_dao = MagicMock()
+    notifier._prefs_dao.get_preferences_batch.return_value = {
+        "u-follower": dict(DEFAULT_PREFERENCES)
+    }
+    notifier._push_log_dao = MagicMock()
+    notifier._push_sub_dao = MagicMock()
+
+    return notifier, push_send_fn
+
+
+def test_fulltime_pushes_to_follower_with_no_club_channels():
+    notifier, push_send_fn = _notifier_with_follower()
+
+    notifier.notify("fulltime", _MATCH["id"], None)
+
+    # The whole point: a no-channel match still pushes to the follower.
+    push_send_fn.assert_called_once()
+    sent_sub = push_send_fn.call_args.args[0]
+    assert sent_sub["id"] == "sub-1"
+    # And the send was logged.
+    notifier._push_log_dao.log.assert_called_once()
+
+
+def test_club_send_not_attempted_when_no_channels():
+    notifier, _ = _notifier_with_follower()
+    notifier.notify("fulltime", _MATCH["id"], None)
+    # No club channels resolved → outbound club sender never called.
+    notifier.send_fn.assert_not_called()
+
+
+def test_no_followers_means_no_push_but_no_error():
+    notifier, push_send_fn = _notifier_with_follower()
+    notifier._team_follow_dao.list_subscriptions_for_team_ids.return_value = []
+
+    notifier.notify("fulltime", _MATCH["id"], None)
+
+    push_send_fn.assert_not_called()
+    notifier._push_log_dao.log.assert_not_called()

--- a/backend/tests/unit/test_score_change.py
+++ b/backend/tests/unit/test_score_change.py
@@ -1,0 +1,107 @@
+"""Unit tests for the score-change detector (SB-77).
+
+`is_new_final_score(before, after)` decides whether an admin/skill match write
+should fan a 'fulltime' notification out to followers. The contract:
+
+  - fire when a complete score newly appears or actually changes, on a match
+    that is completed (or whose status is unspecified, e.g. a raw tournament
+    row), and
+  - stay silent on metadata-only edits, idempotent re-submissions, partial
+    scores, and non-completed statuses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notifications.score_change import is_new_final_score
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend]
+
+
+def _row(home=None, away=None, status=None, **extra):
+    """Build a match-like row. `status` is written under match_status (raw row
+    shape); pass status_key='status' to use the flattened-read alias instead."""
+    row: dict = {"id": 999, **extra}
+    if home is not None:
+        row["home_score"] = home
+    if away is not None:
+        row["away_score"] = away
+    if status is not None:
+        row["match_status"] = status
+    return row
+
+
+class TestFires:
+    def test_scheduled_to_completed_score_fires(self):
+        before = _row(status="scheduled")  # no score yet
+        after = _row(home=0, away=1, status="completed")
+        assert is_new_final_score(before, after) is True
+
+    def test_create_with_completed_score_fires(self):
+        # before is None for a create
+        after = _row(home=2, away=2, status="completed")
+        assert is_new_final_score(None, after) is True
+
+    def test_score_correction_fires(self):
+        before = _row(home=1, away=0, status="completed")
+        after = _row(home=2, away=0, status="completed")
+        assert is_new_final_score(before, after) is True
+
+    def test_same_score_newly_completed_fires(self):
+        # Score was already present but match only just got marked completed.
+        before = _row(home=1, away=1, status="in_progress")
+        after = _row(home=1, away=1, status="completed")
+        assert is_new_final_score(before, after) is True
+
+    def test_status_absent_but_score_appears_fires(self):
+        # Raw tournament rows may omit status entirely — the score-pair change
+        # still gates the notification.
+        before = _row()  # nothing
+        after = _row(home=3, away=1)
+        assert is_new_final_score(before, after) is True
+
+    def test_flattened_status_alias_fires(self):
+        # get_match_by_id exposes status under "status", not "match_status".
+        before = {"id": 1, "home_score": None, "away_score": None, "status": "scheduled"}
+        after = {"id": 1, "home_score": 4, "away_score": 0, "status": "completed"}
+        assert is_new_final_score(before, after) is True
+
+
+class TestSilent:
+    def test_identical_score_is_noop(self):
+        before = _row(home=0, away=1, status="completed")
+        after = _row(home=0, away=1, status="completed")
+        assert is_new_final_score(before, after) is False
+
+    def test_metadata_only_edit_is_noop(self):
+        # Same score, only round/group changed.
+        before = _row(home=0, away=1, status="completed", tournament_round="semifinal")
+        after = _row(home=0, away=1, status="completed", tournament_round="final")
+        assert is_new_final_score(before, after) is False
+
+    def test_no_score_yet_is_noop(self):
+        before = _row(status="scheduled")
+        after = _row(status="scheduled")
+        assert is_new_final_score(before, after) is False
+
+    def test_partial_score_is_noop(self):
+        # Only one side set — not a complete result.
+        before = _row(status="scheduled")
+        after = _row(home=2, status="scheduled")
+        assert is_new_final_score(before, after) is False
+
+    def test_non_completed_status_with_score_is_noop(self):
+        # Score present but match explicitly not completed (e.g. live in_progress);
+        # the live endpoints own that notification, not this path.
+        before = _row(status="scheduled")
+        after = _row(home=1, away=0, status="in_progress")
+        assert is_new_final_score(before, after) is False
+
+    def test_after_none_is_noop(self):
+        assert is_new_final_score(_row(home=1, away=0), None) is False
+
+    def test_metadata_edit_on_unscored_match_is_noop(self):
+        before = _row(status="scheduled", tournament_round_order=0)
+        after = _row(status="scheduled", tournament_round_order=1)
+        assert is_new_final_score(before, after) is False


### PR DESCRIPTION
Fixes SB-77

## What

Followers of a team get a push notification (with the score) when a match is scored via an **admin/skill write path**, not only via live in-app tracking.

## Why it was silent before

The follower-push machinery (follows, Web Push/VAPID, prefs, dispatcher fan-out, send logging) already existed but only fired from `/api/matches/{id}/live/goal` and `/live/clock`. The `load-tournament-matches` skill scores via `PUT/POST /api/admin/tournaments/.../matches`, and match-scraper via `PUT/PATCH /api/matches/{id}` — none of which notified. Scores landed in the DB silently.

There was also a latent bug: `Notifier.notify()` returned early on `no_channels` **before** the push fan-out, so a match whose clubs had no Telegram/Discord channels (typical for tournament teams like Cedar Stars) never pushed to followers even from the live path.

## Changes

**1. Dispatcher — decouple push fan-out from club channels** (`notifications/dispatcher.py`)
Club-channel sends and the Web Push fan-out are now independent. A match with no club channels still pushes to followers. The existing has-channels behavior is unchanged.

**2. Score-change detector** (`notifications/score_change.py`, new)
Pure function `is_new_final_score(before, after)` — fires only when a complete score newly appears or actually changes on a completed match. Stays silent on metadata-only edits, partial scores, non-completed statuses, and identical re-submissions (the skill's upsert loop re-PUTs constantly). Handles both raw rows (`match_status`) and flattened reads (`status`).

**3. Wire 4 admin/skill write handlers** (`app.py`) to fire `notify_event_task("fulltime", …)` via the detector:
- `admin_create_tournament_match` (skill one-shot already-played create)
- `admin_update_tournament_match` (skill fills scores in as results arrive)
- `update_match` (league PUT)
- `patch_match` (league PATCH — match-scraper's score path)

Reuses the existing `fulltime` event type → **no migration**.

### Intentionally not wired
League `POST /api/matches` (create): returns no match id, and the scraper flow is create-scheduled → patch-score, so PATCH covers league results.

## Tests
- `test_score_change.py` — 13 cases (fires / silent matrix)
- `test_dispatcher_push_without_channels.py` — 3 cases, regression guard for the no-channel push bug
- Existing dispatcher/formatter/resolver suites still pass (`27 passed` in the dispatcher set; `21 passed` formatters+resolver). `import app` clean.

## Verification status
- Unit: ✅ green locally
- Integration (real-DB fan-out): not run — local Supabase was down this session. The existing `test_no_channels_configured_sends_nothing` integration test stays valid (it disables push, asserts club sends only).
- Manual prod: VAPID is confirmed configured in prod (per SB-77). Recommended check after deploy: follow a team, score one of its matches via the skill, confirm the device push shows the score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)