### PR TITLE
feat(auth): silent token refresh for 30-day idle sessions (SB-78)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -410,21 +410,21 @@
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 282
+        "line_number": 309
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "58a37cf13faaed3b81b3a1fce4872824eb4e57c4",
         "is_verified": false,
-        "line_number": 680
+        "line_number": 707
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 739
+        "line_number": 766
       }
     ],
     "docs/04-testing/api-contract-testing.md": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-26T20:17:10Z"
+  "generated_at": "2026-05-30T21:39:30Z"
 }

--- a/backend/app.py
+++ b/backend/app.py
@@ -578,6 +578,10 @@ async def login(request: Request, user_data: UserLogin):
             return {
                 "access_token": response.session.access_token,
                 "refresh_token": response.session.refresh_token,
+                # Surface token lifetime so the frontend can schedule a proactive
+                # silent refresh instead of waiting to hit a 401 (see SB-78).
+                "expires_at": response.session.expires_at,
+                "expires_in": response.session.expires_in,
                 "user": {
                     "id": response.user.id,
                     "username": profile.get("username"),

--- a/docs/03-architecture/authentication.md
+++ b/docs/03-architecture/authentication.md
@@ -100,6 +100,33 @@ PUT  /api/auth/profile
 - Frontend receives simplified session tokens
 - Automatic token refresh handled by backend
 
+##### Silent refresh & session lifetime (SB-78)
+
+Goal: users on the phone PWA / laptop / desktop stay logged in for **30 days of
+inactivity** without re-entering their password. The access token stays
+short-lived (1h) for security; longevity comes from the **refresh token**.
+
+How it works (frontend `stores/auth.js`):
+
+- **`expires_at` is persisted.** `/api/auth/login` and `/api/auth/refresh` both
+  return `expires_at`; `setSession` stores it in `localStorage` (`token_expires_at`)
+  and decodes the JWT `exp` as a fallback. Without this, `isTokenExpiringSoon()`
+  can never fire.
+- **Proactive refresh timer.** A 60s interval refreshes the token once it is
+  within 5 minutes of expiry, so an active session never lapses to a 401.
+- **Refresh-on-resume.** `visibilitychange` + `focus` listeners refresh on tab
+  resume — mobile PWAs/Safari freeze timers while backgrounded, so the interval
+  alone can't cover a long suspend.
+- **Single-flight guard.** Concurrent refreshes share one in-flight promise.
+  With refresh-token rotation enabled, two parallel refreshes would send the
+  same token twice and the second (already-rotated) send would be rejected,
+  forcing a spurious logout.
+
+**Supabase config.** Access-token TTL is `jwt_expiry = 3600` (local
+`supabase-local/config.toml`). The 30-day idle window is the refresh-token
+**inactivity timeout**, set in the **Supabase Cloud dashboard** for production
+(Auth → Sessions), not in the repo. Refresh-token rotation stays enabled.
+
 #### 3. **Frontend Changes**
 ```javascript
 // NEW APPROACH - Backend API calls

--- a/frontend/src/__tests__/stores/auth.silent-refresh.spec.js
+++ b/frontend/src/__tests__/stores/auth.silent-refresh.spec.js
@@ -1,0 +1,179 @@
+/**
+ * Silent-refresh behavior of the auth store (SB-78).
+ *
+ * Covers the three mechanisms that keep a user logged in without re-entering
+ * their password:
+ *   1. expires_at is persisted so the proactive refresh can schedule itself
+ *   2. a single-flight guard prevents the refresh-token rotation race
+ *   3. the proactive timer refreshes a token before it expires
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useAuthStore } from '@/stores/auth';
+
+// Build an unsigned JWT carrying the given `exp` (epoch seconds). When `exp`
+// is null the payload omits it, exercising the "unknown expiry" path.
+const makeJwt = exp => {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify(exp === null ? {} : { exp }));
+  return `${header}.${payload}.sig`;
+};
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+describe('auth store — silent refresh (SB-78)', () => {
+  let store;
+
+  beforeEach(() => {
+    store = useAuthStore();
+    // Reset shared module-level state (session + any armed timer) between tests.
+    store.forceLogout();
+    global.fetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    store.forceLogout();
+  });
+
+  describe('setSession persists expires_at', () => {
+    it('stores the explicit expires_at from the login/refresh response', () => {
+      const exp = nowSec() + 3600;
+      store.setSession({
+        access_token: makeJwt(exp),
+        refresh_token: 'r1',
+        expires_at: exp,
+      });
+      expect(localStorage.getItem('token_expires_at')).toBe(String(exp));
+      expect(store.state.session.expires_at).toBe(exp);
+    });
+
+    it('falls back to decoding exp from the JWT when expires_at is absent', () => {
+      const exp = nowSec() + 3600;
+      // Mimics initialize(): only the access_token survives a reload.
+      store.setSession({ access_token: makeJwt(exp) });
+      expect(store.state.session.expires_at).toBe(exp);
+      expect(localStorage.getItem('token_expires_at')).toBe(String(exp));
+    });
+
+    it('clears token_expires_at when the session is cleared', () => {
+      store.setSession({ access_token: makeJwt(nowSec() + 3600) });
+      store.setSession(null);
+      expect(localStorage.getItem('token_expires_at')).toBeNull();
+    });
+  });
+
+  describe('isTokenExpiringSoon', () => {
+    it('is false when expiry is far away', () => {
+      store.setSession({
+        access_token: makeJwt(nowSec() + 3600),
+        expires_at: nowSec() + 3600,
+      });
+      expect(store.isTokenExpiringSoon()).toBe(false);
+    });
+
+    it('is true within the 5-minute window', () => {
+      store.setSession({
+        access_token: makeJwt(nowSec() + 120),
+        expires_at: nowSec() + 120,
+      });
+      expect(store.isTokenExpiringSoon()).toBe(true);
+    });
+
+    it('is true once the token has already expired', () => {
+      store.setSession({
+        access_token: makeJwt(nowSec() - 10),
+        expires_at: nowSec() - 10,
+      });
+      expect(store.isTokenExpiringSoon()).toBe(true);
+    });
+
+    it('is false when expiry is unknown (no exp claim, no expires_at)', () => {
+      store.setSession({ access_token: makeJwt(null) });
+      expect(store.isTokenExpiringSoon()).toBe(false);
+    });
+  });
+
+  describe('refreshSession single-flight guard', () => {
+    it('coalesces concurrent refreshes into one network call', async () => {
+      let resolveFetch;
+      global.fetch.mockImplementation(
+        () =>
+          new Promise(res => {
+            resolveFetch = res;
+          })
+      );
+      localStorage.setItem('refresh_token', 'r1');
+
+      const p1 = store.refreshSession();
+      const p2 = store.refreshSession();
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const exp = nowSec() + 3600;
+      resolveFetch({
+        ok: true,
+        json: async () => ({
+          session: {
+            access_token: makeJwt(exp),
+            refresh_token: 'r2',
+            expires_at: exp,
+          },
+        }),
+      });
+
+      const [a, b] = await Promise.all([p1, p2]);
+      expect(a.success).toBe(true);
+      expect(b.success).toBe(true);
+
+      // The in-flight guard is released once settled: a fresh refresh makes a
+      // new call rather than returning the old (now-resolved) promise.
+      const exp2 = nowSec() + 3600;
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          session: {
+            access_token: makeJwt(exp2),
+            refresh_token: 'r3',
+            expires_at: exp2,
+          },
+        }),
+      });
+      localStorage.setItem('refresh_token', 'r2');
+      await store.refreshSession();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('proactive refresh timer', () => {
+    it('refreshes the token when it is about to expire', async () => {
+      vi.useFakeTimers();
+      const future = nowSec() + 3600;
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          session: {
+            access_token: makeJwt(future),
+            refresh_token: 'r2',
+            expires_at: future,
+          },
+        }),
+      });
+
+      // Arm the timer with a token already inside the 5-minute window.
+      const soon = nowSec() + 120;
+      store.setSession({
+        access_token: makeJwt(soon),
+        refresh_token: 'r1',
+        expires_at: soon,
+      });
+      global.fetch.mockClear();
+
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8000/api/auth/refresh',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+});

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -25,6 +25,24 @@ const state = reactive({
   error: null,
 });
 
+// Silent-refresh machinery — module-level so it is shared across every
+// useAuthStore() caller (components each invoke the factory). See SB-78.
+let refreshTimer = null; // proactive 60s interval id
+let refreshInFlight = null; // single-flight guard: shared in-flight refresh promise
+let resumeListenersBound = false; // focus/visibilitychange bound once
+
+// Decode a JWT's `exp` claim (epoch seconds) without verifying the signature.
+// Used as a fallback when an explicit expires_at isn't available (e.g. on init
+// where only the access_token survives in localStorage).
+const decodeJwtExp = token => {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+};
+
 export const useAuthStore = () => {
   // Computed properties
   const isAuthenticated = computed(() => !!state.session);
@@ -72,9 +90,64 @@ export const useAuthStore = () => {
       if (session.refresh_token) {
         localStorage.setItem('refresh_token', session.refresh_token);
       }
+      // Resolve token expiry (epoch seconds): prefer the explicit value from the
+      // login/refresh response, else decode it from the JWT. Persist it so a
+      // proactive refresh can be scheduled even after a page reload.
+      const expiresAt =
+        session.expires_at || decodeJwtExp(session.access_token);
+      if (expiresAt) {
+        state.session.expires_at = expiresAt;
+        localStorage.setItem('token_expires_at', String(expiresAt));
+      }
+      startTokenRefreshTimer();
     } else {
       localStorage.removeItem('auth_token');
       localStorage.removeItem('refresh_token');
+      localStorage.removeItem('token_expires_at');
+      stopTokenRefreshTimer();
+    }
+  };
+
+  // Proactive silent refresh: poll once a minute and refresh the token a few
+  // minutes before it expires, so an active session never lapses to a 401.
+  const startTokenRefreshTimer = () => {
+    if (refreshTimer) return;
+    bindResumeListeners();
+    refreshTimer = setInterval(() => {
+      if (state.session && isTokenExpiringSoon()) {
+        refreshSession();
+      }
+    }, 60 * 1000);
+  };
+
+  const stopTokenRefreshTimer = () => {
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+  };
+
+  // Mobile fix: PWAs/Safari freeze timers while backgrounded, so the interval
+  // above won't fire across a long suspend. Refresh on resume (tab focus /
+  // becoming visible) when the token is expiring or already expired.
+  const bindResumeListeners = () => {
+    if (resumeListenersBound || typeof window === 'undefined') return;
+    resumeListenersBound = true;
+    const maybeRefresh = () => {
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState !== 'visible'
+      ) {
+        return;
+      }
+      if (!localStorage.getItem('refresh_token')) return;
+      if (state.session && isTokenExpiringSoon()) {
+        refreshSession();
+      }
+    };
+    window.addEventListener('focus', maybeRefresh);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', maybeRefresh);
     }
   };
 
@@ -214,6 +287,7 @@ export const useAuthStore = () => {
       setSession({
         access_token: data.access_token,
         refresh_token: data.refresh_token,
+        expires_at: data.expires_at,
       });
       // Login endpoint returns basic user info
       setProfile(data.user);
@@ -428,11 +502,13 @@ export const useAuthStore = () => {
       }
 
       // Clear local state regardless of API response
+      stopTokenRefreshTimer();
       setUser(null);
       setSession(null);
       setProfile(null);
       localStorage.removeItem('auth_token');
       localStorage.removeItem('refresh_token');
+      localStorage.removeItem('token_expires_at');
       localStorage.removeItem('sb-localhost-auth-token');
       clearCSRFToken();
 
@@ -456,6 +532,7 @@ export const useAuthStore = () => {
 
   const forceLogout = () => {
     // Force clear all auth state without async calls
+    stopTokenRefreshTimer();
     state.user = null;
     state.session = null;
     state.profile = null;
@@ -720,41 +797,53 @@ export const useAuthStore = () => {
   };
 
   const refreshSession = async () => {
-    try {
-      const refreshToken = localStorage.getItem('refresh_token');
-      if (!refreshToken) {
+    // Single-flight: with refresh-token rotation enabled, two concurrent
+    // refreshes would send the same token twice — the second send uses an
+    // already-rotated token and gets rejected, forcing a spurious logout.
+    // Share one in-flight promise so parallel callers await the same result.
+    if (refreshInFlight) return refreshInFlight;
+
+    refreshInFlight = (async () => {
+      try {
+        const refreshToken = localStorage.getItem('refresh_token');
+        if (!refreshToken) {
+          recordSessionRefresh(false);
+          throw new Error('No refresh token');
+        }
+
+        const response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...getTraceHeaders(),
+          },
+          body: JSON.stringify({ refresh_token: refreshToken }),
+        });
+
+        if (!response.ok) {
+          recordSessionRefresh(false);
+          throw new Error('Token refresh failed');
+        }
+
+        const data = await response.json();
+        setSession(data.session);
+
+        recordSessionRefresh(true);
+        return { success: true };
+      } catch (error) {
+        // Refresh failed, force logout
+        setUser(null);
+        setSession(null);
+        setProfile(null);
+        localStorage.clear();
         recordSessionRefresh(false);
-        throw new Error('No refresh token');
+        return { success: false, error: error.message };
+      } finally {
+        refreshInFlight = null;
       }
+    })();
 
-      const response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...getTraceHeaders(),
-        },
-        body: JSON.stringify({ refresh_token: refreshToken }),
-      });
-
-      if (!response.ok) {
-        recordSessionRefresh(false);
-        throw new Error('Token refresh failed');
-      }
-
-      const data = await response.json();
-      setSession(data.session);
-
-      recordSessionRefresh(true);
-      return { success: true };
-    } catch (error) {
-      // Refresh failed, force logout
-      setUser(null);
-      setSession(null);
-      setProfile(null);
-      localStorage.clear();
-      recordSessionRefresh(false);
-      return { success: false, error: error.message };
-    }
+    return refreshInFlight;
   };
 
   const apiRequest = async (url, options = {}) => {
@@ -916,6 +1005,7 @@ export const useAuthStore = () => {
     getAuthHeaders,
     apiRequest,
     apiCall,
+    setSession,
     refreshSession,
     isTokenExpiringSoon,
     checkUsernameAvailability,


### PR DESCRIPTION
## Summary

Users on the phone PWA / laptop / desktop were getting logged out and forced to re-enter their password too often. This keeps the access token short-lived (1h) but makes **silent refresh** reliable so an active session never lapses. The 30-day idle longevity comes from the **refresh token**, not the access-token TTL.

Fixes SB-78.

## Root causes fixed

1. **`expires_at` never stored at login** — `/api/auth/login` omitted it and `initialize()` set only `access_token`, so `isTokenExpiringSoon()` always returned `false`; any proactive refresh was dead on arrival.
2. **No refresh-on-resume** — mobile PWAs/Safari freeze timers while backgrounded, so nothing refreshed until a request 401'd.
3. **Refresh-token rotation race** — two concurrent refreshes sent the same token twice; the second (already-rotated) send was rejected, forcing a spurious logout.

## Changes

- **backend** (`app.py`): `/api/auth/login` now returns `expires_at` + `expires_in` (refresh endpoint already did).
- **frontend** (`stores/auth.js`):
  - `setSession` persists `expires_at` (JWT `exp` fallback) to localStorage.
  - `login` passes `expires_at` through.
  - Proactive 60s refresh timer (refreshes within 5 min of expiry).
  - Refresh-on-resume via `visibilitychange` + `focus` listeners (mobile fix).
  - Single-flight guard so concurrent refreshes share one in-flight promise.
  - `logout`/`forceLogout` stop the timer and clear `token_expires_at`.
- **tests**: 9 vitest units — `expires_at` persistence, expiring-soon math, single-flight, proactive timer. Full suite: 451 passing.
- **docs**: `authentication.md` session-management section.

## ⚠️ Manual prod step (not in this PR)

Supabase Cloud isn't configurable from the repo. After merge, set in the dashboard:
**Auth → Sessions → Inactivity timeout = 30 days**, keep JWT expiry 1h, keep refresh-token rotation on.

## Test plan

- [x] `npx vitest run` — 451 passed (incl. 9 new)
- [x] `eslint` clean (frontend), `ruff` clean (backend)
- [ ] Manual: log in on phone, background app overnight, reopen → still logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)