### PR TITLE
feat(roster): bulk-assign age_group_id to existing players (SB-69)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -36,6 +36,7 @@ from models import (
     AgeGroupCreate,
     AgeGroupUpdate,
     BatchPlayerStatsUpdate,
+    BulkAgeGroupUpdate,
     BulkRenumberRequest,
     BulkRosterCreate,
     Club,
@@ -5248,6 +5249,53 @@ async def bulk_create_roster(
     except Exception as e:
         logger.error(f"Error bulk creating roster: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to bulk create roster") from e
+
+
+@app.patch("/api/teams/{team_id}/players/age-group")
+async def bulk_assign_player_age_group(
+    team_id: int,
+    data: BulkAgeGroupUpdate,
+    current_user: dict[str, Any] = Depends(require_team_manager_or_admin),
+):
+    """
+    Bulk-assign age_group_id to existing roster entries (SB-69).
+
+    Existing players predate the players.age_group_id column (SB-68) and have it
+    NULL, which makes the live-match lineup empty for every team. This lets a
+    manager tag a team's roster with the right age group in one action.
+
+    Requires admin or team_manager role. The write is scoped to the team and
+    season, so foreign player_ids are silently skipped rather than updated.
+    """
+    try:
+        # Verify team exists
+        team = team_dao.get_team_by_id(team_id)
+        if not team:
+            raise HTTPException(status_code=404, detail="Team not found")
+
+        # Validate the age group exists (FK would reject anyway; this is a clean 400)
+        valid_age_group_ids = {ag["id"] for ag in season_dao.get_all_age_groups()}
+        if data.age_group_id not in valid_age_group_ids:
+            raise HTTPException(status_code=400, detail="Invalid age_group_id")
+
+        updated = roster_dao.bulk_update_age_group(
+            team_id=team_id,
+            season_id=data.season_id,
+            player_ids=data.player_ids,
+            age_group_id=data.age_group_id,
+        )
+
+        return {
+            "success": True,
+            "updated": updated,
+            "updated_count": len(updated),
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error bulk-assigning age group: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to assign age group") from e
 
 
 @app.put("/api/teams/{team_id}/roster/{player_id}")

--- a/backend/dao/roster_dao.py
+++ b/backend/dao/roster_dao.py
@@ -437,6 +437,59 @@ class RosterDAO(BaseDAO):
             return False
 
     @invalidates_cache(ROSTER_CACHE_PATTERN)
+    def bulk_update_age_group(
+        self,
+        team_id: int,
+        season_id: int,
+        player_ids: list[int],
+        age_group_id: int,
+    ) -> list[dict]:
+        """
+        Bulk-assign age_group_id to existing roster entries (SB-69).
+
+        The update is scoped to team_id + season_id + the given player_ids, so a
+        caller cannot touch rows on another team even by passing foreign ids.
+
+        Args:
+            team_id: Team ID (scope guard)
+            season_id: Season ID (scope guard)
+            player_ids: Player IDs to update (must belong to team/season)
+            age_group_id: Age group to assign
+
+        Returns:
+            List of updated player dicts with computed display_name
+        """
+        try:
+            response = (
+                self.client.table("players")
+                .update({"age_group_id": age_group_id})
+                .eq("team_id", team_id)
+                .eq("season_id", season_id)
+                .in_("id", player_ids)
+                .execute()
+            )
+
+            updated = response.data or []
+            logger.info(
+                "roster_bulk_age_group_updated",
+                team_id=team_id,
+                season_id=season_id,
+                age_group_id=age_group_id,
+                count=len(updated),
+            )
+            return [self._add_display_name(p) for p in updated]
+
+        except Exception as e:
+            logger.error(
+                "roster_bulk_age_group_error",
+                team_id=team_id,
+                season_id=season_id,
+                age_group_id=age_group_id,
+                error=str(e),
+            )
+            return []
+
+    @invalidates_cache(ROSTER_CACHE_PATTERN)
     def link_user_to_player(
         self,
         player_id: int,

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -77,6 +77,7 @@ from .post_match import (
 
 # Roster models
 from .roster import (
+    BulkAgeGroupUpdate,
     BulkRenumberRequest,
     BulkRosterCreate,
     BulkRosterPlayer,
@@ -104,6 +105,7 @@ __all__ = [
     "AgeGroupCreate",
     "AgeGroupUpdate",
     "BatchPlayerStatsUpdate",
+    "BulkAgeGroupUpdate",
     "BulkRenumberRequest",
     "BulkRosterCreate",
     "BulkRosterPlayer",

--- a/backend/models/roster.py
+++ b/backend/models/roster.py
@@ -58,6 +58,14 @@ class BulkRenumberRequest(BaseModel):
     changes: list[RenumberEntry] = Field(..., min_length=1)
 
 
+class BulkAgeGroupUpdate(BaseModel):
+    """Model for bulk-assigning age_group_id to existing roster entries (SB-69)."""
+
+    season_id: int
+    player_ids: list[int] = Field(..., min_length=1)
+    age_group_id: int
+
+
 class RosterPlayerResponse(BaseModel):
     """Response model for a roster player."""
 

--- a/backend/tests/integration/api/test_roster_age_group.py
+++ b/backend/tests/integration/api/test_roster_age_group.py
@@ -1,0 +1,55 @@
+"""
+Integration tests for the bulk age-group assignment endpoint (SB-69).
+
+PATCH /api/teams/{team_id}/players/age-group bulk-assigns players.age_group_id
+on existing roster rows so the live-match lineup (which filters strictly on
+age_group_id since SB-68) is no longer empty for pre-existing rosters.
+
+These cover the endpoint contract — authz, validation, and not-found — without
+depending on specific seeded player rows. The happy-path mutation is exercised
+by the frontend component spec and manual verification.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+ENDPOINT = "/api/teams/{team_id}/players/age-group"
+VALID_BODY = {"season_id": 1, "player_ids": [1], "age_group_id": 1}
+
+
+class TestBulkAssignAgeGroup:
+    """Contract tests for PATCH /api/teams/{team_id}/players/age-group."""
+
+    @pytest.mark.e2e
+    def test_requires_manager_or_admin_role(self, authenticated_client: TestClient):
+        """A plain 'user' role is rejected with 403 before any DB work."""
+        response = authenticated_client.patch(
+            ENDPOINT.format(team_id=1), json=VALID_BODY
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.e2e
+    def test_empty_player_ids_is_422(self, admin_client: TestClient):
+        """player_ids must be non-empty (Pydantic min_length=1)."""
+        body = {"season_id": 1, "player_ids": [], "age_group_id": 1}
+        response = admin_client.patch(ENDPOINT.format(team_id=1), json=body)
+        assert response.status_code == 422
+
+    @pytest.mark.e2e
+    def test_unknown_team_is_404(self, admin_client: TestClient):
+        """A non-existent team returns 404."""
+        response = admin_client.patch(
+            ENDPOINT.format(team_id=99_999_999), json=VALID_BODY
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.e2e
+    def test_invalid_age_group_is_400(self, admin_client: TestClient):
+        """A real team with a bogus age_group_id returns a clean 400."""
+        teams = admin_client.get("/api/teams").json()
+        if not teams:
+            pytest.skip("No teams seeded in test database")
+        team_id = teams[0]["id"]
+        body = {"season_id": 1, "player_ids": [1], "age_group_id": 999_999}
+        response = admin_client.patch(ENDPOINT.format(team_id=team_id), json=body)
+        assert response.status_code == 400

--- a/frontend/src/__tests__/components/RosterManager.spec.js
+++ b/frontend/src/__tests__/components/RosterManager.spec.js
@@ -1,0 +1,133 @@
+/**
+ * RosterManager.vue — bulk age-group assignment (SB-69).
+ *
+ * Covers:
+ * - Each player row renders an age-group select reflecting its current value
+ *   (NULL shows the "—" placeholder).
+ * - Select-all + bulk "Assign Age Group" PATCHes every selected player with the
+ *   chosen age group and season.
+ * - The per-row inline select PATCHes just that one player (quick assign).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const apiRequestMock = vi.fn();
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ apiRequest: apiRequestMock }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+import RosterManager from '@/components/roster/RosterManager.vue';
+
+const AGE_GROUPS = [
+  { id: 2, name: 'U14' },
+  { id: 3, name: 'U15' },
+];
+
+// Player 1 is untagged (age_group_id null), player 2 already tagged U15.
+const ROSTER = [
+  { id: 1, jersey_number: 7, display_name: 'Kid Seven', age_group_id: null },
+  { id: 2, jersey_number: 10, display_name: 'Kid Ten', age_group_id: 3 },
+];
+
+const wireMock = () => {
+  apiRequestMock.mockImplementation(url => {
+    if (url.includes('/players/age-group')) {
+      return Promise.resolve({ success: true, updated_count: 2 });
+    }
+    if (url.endsWith('/api/age-groups')) {
+      return Promise.resolve([...AGE_GROUPS]);
+    }
+    if (url.includes('/roster')) {
+      return Promise.resolve({ roster: ROSTER.map(p => ({ ...p })) });
+    }
+    return Promise.resolve({});
+  });
+};
+
+const mountManager = async () => {
+  const wrapper = mount(RosterManager, {
+    props: { teamId: 42, teamName: 'IFA U14', seasonId: 3, ageGroupId: 2 },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+const patchCall = () =>
+  apiRequestMock.mock.calls.find(c => c[0].includes('/players/age-group'));
+
+beforeEach(() => {
+  apiRequestMock.mockReset();
+  wireMock();
+});
+
+describe('RosterManager age-group column (SB-69)', () => {
+  it('renders an age-group select per row reflecting the current value', async () => {
+    const wrapper = await mountManager();
+
+    const untagged = wrapper.find('[data-testid="row-age-group-1"]');
+    const tagged = wrapper.find('[data-testid="row-age-group-2"]');
+    expect(untagged.exists()).toBe(true);
+    expect(untagged.element.value).toBe(''); // NULL → "—" placeholder
+    expect(tagged.element.value).toBe('3'); // already U15
+  });
+
+  it('fetches age groups on mount', async () => {
+    await mountManager();
+    expect(
+      apiRequestMock.mock.calls.some(c => c[0].endsWith('/api/age-groups'))
+    ).toBe(true);
+  });
+});
+
+describe('RosterManager bulk assign (SB-69)', () => {
+  it('assigns the chosen age group to all selected players', async () => {
+    const wrapper = await mountManager();
+
+    // Select all, then choose U14 (id 2) and click Assign.
+    await wrapper.find('[data-testid="select-all-checkbox"]').trigger('change');
+    await wrapper.find('[data-testid="bulk-age-group-select"]').setValue('2');
+    await wrapper
+      .find('[data-testid="assign-age-group-button"]')
+      .trigger('click');
+    await flushPromises();
+
+    const call = patchCall();
+    expect(call).toBeTruthy();
+    expect(call[1].method).toBe('PATCH');
+    const body = JSON.parse(call[1].body);
+    expect(body.player_ids.sort()).toEqual([1, 2]);
+    expect(body.age_group_id).toBe(2);
+    expect(body.season_id).toBe(3);
+  });
+
+  it('does not show the bulk bar until a row is selected', async () => {
+    const wrapper = await mountManager();
+    expect(wrapper.find('[data-testid="bulk-age-group-bar"]').exists()).toBe(
+      false
+    );
+    await wrapper.find('[data-testid="select-player-1"]').setValue(true);
+    expect(wrapper.find('[data-testid="bulk-age-group-bar"]').exists()).toBe(
+      true
+    );
+  });
+});
+
+describe('RosterManager per-row quick assign (SB-69)', () => {
+  it('PATCHes a single player when its inline select changes', async () => {
+    const wrapper = await mountManager();
+
+    await wrapper.find('[data-testid="row-age-group-1"]').setValue('2');
+    await flushPromises();
+
+    const call = patchCall();
+    expect(call).toBeTruthy();
+    const body = JSON.parse(call[1].body);
+    expect(body.player_ids).toEqual([1]);
+    expect(body.age_group_id).toBe(2);
+  });
+});

--- a/frontend/src/components/roster/RosterManager.vue
+++ b/frontend/src/components/roster/RosterManager.vue
@@ -41,8 +41,38 @@
       <div
         class="p-4 border-b border-gray-200 flex justify-between items-center"
       >
-        <div class="text-sm text-gray-600">
-          {{ roster.length }} player{{ roster.length !== 1 ? 's' : '' }}
+        <div class="flex items-center space-x-3">
+          <div class="text-sm text-gray-600">
+            {{ roster.length }} player{{ roster.length !== 1 ? 's' : '' }}
+          </div>
+          <!-- Bulk age-group assignment (SB-69): shows when rows are selected -->
+          <div
+            v-if="selectedIds.length"
+            class="flex items-center space-x-2"
+            data-testid="bulk-age-group-bar"
+          >
+            <span class="text-sm text-gray-600"
+              >{{ selectedIds.length }} selected</span
+            >
+            <select
+              v-model.number="bulkAgeGroupId"
+              class="px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+              data-testid="bulk-age-group-select"
+            >
+              <option :value="null" disabled>Age group…</option>
+              <option v-for="ag in ageGroups" :key="ag.id" :value="ag.id">
+                {{ ag.name }}
+              </option>
+            </select>
+            <button
+              @click="assignSelected"
+              :disabled="!bulkAgeGroupId || formLoading"
+              class="px-3 py-1.5 text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 rounded-md disabled:opacity-50"
+              data-testid="assign-age-group-button"
+            >
+              {{ formLoading ? 'Assigning…' : 'Assign Age Group' }}
+            </button>
+          </div>
         </div>
         <div class="flex space-x-2">
           <button
@@ -98,6 +128,16 @@
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
+              <th class="px-4 py-3 text-left w-10">
+                <input
+                  type="checkbox"
+                  :checked="allSelected"
+                  @change="toggleSelectAll"
+                  class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                  title="Select all"
+                  data-testid="select-all-checkbox"
+                />
+              </th>
               <th
                 class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-16"
               >
@@ -107,6 +147,11 @@
                 class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
               >
                 Name
+              </th>
+              <th
+                class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-28"
+              >
+                Age Group
               </th>
               <th
                 class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
@@ -131,6 +176,15 @@
               :key="player.id"
               :data-testid="`roster-row-${player.id}`"
             >
+              <td class="px-4 py-3 whitespace-nowrap">
+                <input
+                  type="checkbox"
+                  :value="player.id"
+                  v-model="selectedIds"
+                  class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                  :data-testid="`select-player-${player.id}`"
+                />
+              </td>
               <td
                 class="px-4 py-3 whitespace-nowrap text-sm font-bold text-gray-900"
               >
@@ -138,6 +192,26 @@
               </td>
               <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
                 {{ player.display_name }}
+              </td>
+              <!-- Age-group badge + inline single-row quick-assign (SB-69) -->
+              <td class="px-4 py-3 whitespace-nowrap text-sm">
+                <select
+                  :value="player.age_group_id ?? ''"
+                  @change="event => quickAssign(player, event.target.value)"
+                  :disabled="formLoading"
+                  class="px-2 py-1 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  :class="
+                    player.age_group_id
+                      ? 'border-gray-300 text-gray-900'
+                      : 'border-amber-300 text-amber-700 bg-amber-50'
+                  "
+                  :data-testid="`row-age-group-${player.id}`"
+                >
+                  <option value="">—</option>
+                  <option v-for="ag in ageGroups" :key="ag.id" :value="ag.id">
+                    {{ ag.name }}
+                  </option>
+                </select>
               </td>
               <td class="px-4 py-3 whitespace-nowrap text-center">
                 <span
@@ -541,7 +615,7 @@
 </template>
 
 <script>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '@/config/api';
 import { POSITION_ABBREVIATIONS } from '@/constants/positions';
@@ -603,6 +677,16 @@ export default {
     const inviteCode = ref('');
     const invitePlayer = ref(null);
 
+    // Age-group assignment (SB-69)
+    const ageGroups = ref([]);
+    const selectedIds = ref([]);
+    const bulkAgeGroupId = ref(null);
+    const allSelected = computed(
+      () =>
+        roster.value.length > 0 &&
+        selectedIds.value.length === roster.value.length
+    );
+
     // Available positions
     const availablePositions = POSITION_ABBREVIATIONS;
 
@@ -621,6 +705,66 @@ export default {
         console.error('Error fetching roster:', err);
       } finally {
         loading.value = false;
+      }
+    };
+
+    // Fetch age groups for the assignment dropdowns (SB-69)
+    const fetchAgeGroups = async () => {
+      try {
+        ageGroups.value = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/age-groups`,
+          { method: 'GET' }
+        );
+      } catch (err) {
+        console.error('Error fetching age groups:', err);
+      }
+    };
+
+    // Select-all toggle for the bulk assignment (SB-69)
+    const toggleSelectAll = () => {
+      selectedIds.value = allSelected.value ? [] : roster.value.map(p => p.id);
+    };
+
+    // Assign an age group to a set of players via the bulk endpoint (SB-69)
+    const assignAgeGroup = async (ids, ageGroupId) => {
+      try {
+        formLoading.value = true;
+        error.value = null;
+
+        await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/teams/${props.teamId}/players/age-group`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({
+              season_id: props.seasonId,
+              player_ids: ids,
+              age_group_id: ageGroupId,
+            }),
+          }
+        );
+
+        await fetchRoster();
+        selectedIds.value = [];
+        bulkAgeGroupId.value = null;
+      } catch (err) {
+        error.value = err.message || 'Failed to assign age group';
+      } finally {
+        formLoading.value = false;
+      }
+    };
+
+    // Apply the chosen age group to all checked players
+    const assignSelected = () => {
+      if (bulkAgeGroupId.value && selectedIds.value.length) {
+        assignAgeGroup([...selectedIds.value], bulkAgeGroupId.value);
+      }
+    };
+
+    // Single-row quick assign from the inline dropdown
+    const quickAssign = (player, value) => {
+      const ageGroupId = Number(value);
+      if (ageGroupId) {
+        assignAgeGroup([player.id], ageGroupId);
       }
     };
 
@@ -865,6 +1009,7 @@ export default {
     // Initialize
     onMounted(() => {
       fetchRoster();
+      fetchAgeGroups();
     });
 
     return {
@@ -885,6 +1030,13 @@ export default {
       inviteCode,
       invitePlayer,
       availablePositions,
+      ageGroups,
+      selectedIds,
+      bulkAgeGroupId,
+      allSelected,
+      toggleSelectAll,
+      assignSelected,
+      quickAssign,
       fetchRoster,
       addPlayer,
       updatePlayer,


### PR DESCRIPTION
## Summary

Follow-up to **SB-68**. After SB-68 shipped (commit b91e691 — live-match lineup filters strictly by `match.age_group_id`), every existing `players` row has `age_group_id = NULL`, so the lineup renders **empty for every team** even when a roster exists (e.g. the IFA U14 squad). This adds an affordance to tag existing rosters with the right age group.

Fixes SB-69.

## Backend

- New model `BulkAgeGroupUpdate` (`season_id`, `player_ids` [min 1], `age_group_id`).
- `RosterDAO.bulk_update_age_group` — scoped to `team_id + season_id + player_ids`, so foreign ids are silently skipped rather than updated. Carries `@invalidates_cache(ROSTER_CACHE_PATTERN)`.
- New endpoint `PATCH /api/teams/{team_id}/players/age-group`, auth `require_team_manager_or_admin` (same as existing roster ops). Verifies the team exists; validates `age_group_id` against `age_groups` for a clean 400.

## Frontend (`RosterManager.vue`)

- Checkbox column + select-all.
- New **Age Group** column with an inline `<select>` per row (amber when unset) that quick-assigns just that player on change.
- Bulk bar (appears when rows are selected): age-group `<select>` + **Assign Age Group** button that PATCHes all selected players.

## Tests

- **Backend integration** (`test_roster_age_group.py`): 403 for non-manager role, 422 empty `player_ids`, 404 unknown team, 400 invalid age group.
- **Frontend vitest** (`RosterManager.spec.js`): row select reflects current value, bulk-assign request body, bulk-bar visibility, per-row quick assign.

## Test plan

- [x] `npx vitest run` — 456 passed (incl. 5 new)
- [x] `eslint` clean (frontend), `ruff` clean (backend), model/DAO import-checked
- [ ] Backend e2e (`test_roster_age_group.py`) — runs in CI (needs TEST_MODE + local Supabase; not executed locally)
- [ ] Manual: Profile → My Club → Manage Roster for IFA → every player shows "—" → select all, pick U14, Apply → rows show U14 → refresh persists → U14 SF live-view shows roster

## Note

Honest status: the backend integration tests are written to CI conventions but were **not executed locally** (no worktree venv + no running local DB this session). Frontend suite + lint + import-check all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)