### PR TITLE
feat(infra): schema-drift guard — prod migrations vs repo files (SB-79)

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -1,0 +1,39 @@
+name: Migration Drift Guard
+
+# Schema-drift guard (SB-79): assert prod's applied migrations match the repo
+# migration files. This is the ONLY layer that catches out-of-band Studio edits
+# (no commit/PR exists to trigger on), so it runs on a daily schedule. On drift
+# the job fails AND files/updates a Linear issue so it's tracked, not just red.
+
+on:
+  schedule:
+    - cron: '0 13 * * *' # 09:00 ET daily
+  workflow_dispatch: {} # allow manual runs
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install psycopg2
+        run: pip install "psycopg2-binary>=2.9.10"
+
+      - name: Check prod migration drift
+        id: drift
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          set -o pipefail
+          python scripts/check_migration_drift.py --env prod | tee drift_report.txt
+
+      - name: File/update Linear issue on drift
+        if: failure() && steps.drift.outcome == 'failure'
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_KEY: SB
+        run: bash scripts/notify_linear_drift.sh drift_report.txt

--- a/backend/tests/unit/test_migration_drift.py
+++ b/backend/tests/unit/test_migration_drift.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for the schema-drift guard's pure logic (SB-79).
+
+Only the DB-free halves are tested here — reading versions from filenames and
+diffing two version sets. The psycopg fetch and the live prod run are exercised
+by the scheduled CI job, not the unit suite (which must stay env-independent).
+
+The guard lives at repo-root scripts/check_migration_drift.py, so it's loaded
+by file path. It must be registered in sys.modules before exec_module, or the
+dataclass in it fails to resolve its own module annotations.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "scripts" / "check_migration_drift.py"
+)
+_spec = importlib.util.spec_from_file_location("check_migration_drift", _SCRIPT)
+guard = importlib.util.module_from_spec(_spec)
+sys.modules["check_migration_drift"] = guard
+_spec.loader.exec_module(guard)
+
+
+@pytest.mark.unit
+class TestReadMigrationVersions:
+    def test_extracts_version_prefix_and_includes_baseline(self, tmp_path):
+        (tmp_path / "00000000000000_schema.sql").write_text("-- baseline")
+        (tmp_path / "20260529000000_add_players_age_group_id.sql").write_text("-- x")
+        (tmp_path / "20260201000000_foo.sql").write_text("-- y")
+        versions = guard.read_migration_versions(tmp_path)
+        assert versions == {"00000000000000", "20260201000000", "20260529000000"}
+
+    def test_ignores_non_sql_and_non_numeric(self, tmp_path):
+        (tmp_path / "20260201000000_foo.sql").write_text("-- y")
+        (tmp_path / "README.md").write_text("# notes")
+        (tmp_path / "notes_scratch.sql").write_text("-- not a version")
+        versions = guard.read_migration_versions(tmp_path)
+        assert versions == {"20260201000000"}
+
+
+@pytest.mark.unit
+class TestComputeDrift:
+    def test_in_sync_when_equal(self):
+        s = {"00000000000000", "20260201000000"}
+        report = guard.compute_drift(s, set(s))
+        assert report.in_sync
+        assert report.missing_in_env == []
+        assert report.orphan_in_env == []
+
+    def test_missing_in_env_when_file_not_applied(self):
+        files = {"00000000000000", "20260520000000", "20260527010000"}
+        applied = {"00000000000000"}
+        report = guard.compute_drift(files, applied)
+        assert not report.in_sync
+        # Sorted, and only the un-applied ones.
+        assert report.missing_in_env == ["20260520000000", "20260527010000"]
+        assert report.orphan_in_env == []
+
+    def test_orphan_in_env_when_applied_has_no_file(self):
+        files = {"00000000000000"}
+        applied = {"00000000000000", "29990101000000"}
+        report = guard.compute_drift(files, applied)
+        assert not report.in_sync
+        assert report.orphan_in_env == ["29990101000000"]
+        assert report.missing_in_env == []
+
+    def test_reports_both_directions(self):
+        report = guard.compute_drift({"a", "b"}, {"b", "c"})
+        assert report.missing_in_env == ["a"]
+        assert report.orphan_in_env == ["c"]
+
+
+@pytest.mark.unit
+class TestRenderReport:
+    def test_in_sync_message(self):
+        out = guard.render_report("local", guard.compute_drift({"a"}, {"a"}))
+        assert "in sync" in out
+
+    def test_drift_message_lists_versions(self):
+        out = guard.render_report(
+            "prod", guard.compute_drift({"a", "20260520000000"}, {"a"})
+        )
+        assert "DRIFT DETECTED" in out
+        assert "20260520000000" in out
+        assert "Missing in env" in out

--- a/docs/02-development/schema-migrations.md
+++ b/docs/02-development/schema-migrations.md
@@ -659,6 +659,42 @@ PGPASSWORD=postgres pg_dump --schema-only --no-owner --no-privileges \
 # Then remove the \restrict/\unrestrict lines and CREATE SCHEMA public
 ```
 
+## Schema-Drift Guard (SB-79)
+
+`scripts/check_migration_drift.py` is the "advanced lint" for migration *state*:
+it asserts the set of applied versions in an environment's
+`supabase_migrations.schema_migrations` equals the set of timestamped migration
+files in `supabase-local/migrations/`.
+
+Code/unit tests can't catch drift — CI's test DB is built from the migration
+files, so it always has the correct schema. Drift is an **environment-state**
+problem (a migration merged but never deployed, or schema hand-applied in the
+Supabase SQL editor without recording a row), so it needs an environment check.
+
+```bash
+# Local (expects in-sync):
+export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"  # pragma: allowlist secret
+python scripts/check_migration_drift.py --env local
+
+# Prod (CI uses the PROD_DATABASE_URL secret):
+DATABASE_URL="$PROD_DATABASE_URL" python scripts/check_migration_drift.py --env prod
+```
+
+It reports two buckets and exits non-zero on either:
+
+- **Missing in env** — file exists, not applied → likely *un-deployed*. Fix by
+  deploying (`./scripts/db_tools.sh migrate prod`).
+- **Orphan in env** — recorded/applied with no matching file → history was
+  rewritten, or schema was Studio-applied and needs its tracking row repaired
+  (`npx supabase migration repair --status applied <version> --linked`).
+
+**When it runs:** a daily GitHub Actions cron
+(`.github/workflows/migration-drift.yml`) against prod. This is the only layer
+that catches *out-of-band Studio edits* — there's no commit/PR to trigger on.
+On drift the job fails **and** files/updates a Linear issue
+(`scripts/notify_linear_drift.sh`, needs `LINEAR_API_KEY` +
+`PROD_DATABASE_URL` secrets).
+
 ## Resources
 
 - **Supabase CLI Documentation**: https://supabase.com/docs/guides/cli

--- a/scripts/check_migration_drift.py
+++ b/scripts/check_migration_drift.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Schema-drift guard (SB-79).
+
+"Advanced linting" for migration state: assert that the set of applied
+versions in an environment's `supabase_migrations.schema_migrations` equals the
+set of timestamped migration files in `supabase-local/migrations/`.
+
+Unit/code tests can't catch this — CI's test DB is built from the migration
+files, so it always has the correct schema. Drift is an *environment-state*
+problem (a migration merged but never deployed, or schema hand-applied in the
+Supabase SQL editor without recording a row), so it needs an environment check.
+
+Two halves, deliberately split so the diff logic stays pure and unit-testable
+with no DB:
+  - read_migration_versions() / compute_drift()  → pure, no IO
+  - fetch_applied_versions()                     → the only DB touch
+
+Usage:
+    DATABASE_URL=postgresql://... python scripts/check_migration_drift.py --env prod
+    python scripts/check_migration_drift.py --env local --db-url postgresql://...
+
+Exits 0 when in sync, 1 on any drift (so CI fails the build).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MIGRATIONS_DIR = REPO_ROOT / "supabase-local" / "migrations"
+
+
+def read_migration_versions(migrations_dir: Path) -> set[str]:
+    """
+    Collect migration *versions* from the *.sql filenames in a directory.
+
+    A version is the leading token before the first underscore, e.g.
+    `20260529000000_add_players_age_group_id.sql` -> `20260529000000`. The
+    consolidated baseline `00000000000000_schema.sql` is included.
+    """
+    versions: set[str] = set()
+    for path in migrations_dir.glob("*.sql"):
+        version = path.name.split("_", 1)[0]
+        if version.isdigit():
+            versions.add(version)
+    return versions
+
+
+@dataclass
+class DriftReport:
+    """Result of comparing repo migration files against an env's applied set."""
+
+    missing_in_env: list[str] = field(default_factory=list)  # file exists, not applied
+    orphan_in_env: list[str] = field(default_factory=list)  # applied, no file
+
+    @property
+    def in_sync(self) -> bool:
+        return not self.missing_in_env and not self.orphan_in_env
+
+
+def compute_drift(file_versions: set[str], applied_versions: set[str]) -> DriftReport:
+    """Pure diff of repo migration files vs. an environment's applied versions."""
+    return DriftReport(
+        missing_in_env=sorted(file_versions - applied_versions),
+        orphan_in_env=sorted(applied_versions - file_versions),
+    )
+
+
+def fetch_applied_versions(db_url: str) -> set[str]:
+    """Read applied migration versions from supabase_migrations.schema_migrations."""
+    import psycopg2  # imported lazily so the pure logic stays import-light
+
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT version FROM supabase_migrations.schema_migrations")
+            return {row[0] for row in cur.fetchall()}
+    finally:
+        conn.close()
+
+
+def render_report(env: str, report: DriftReport) -> str:
+    """Human-readable summary for CI logs."""
+    lines = [f"Migration drift check — env: {env}"]
+    if report.in_sync:
+        lines.append("✓ in sync — applied versions match the repo migration files")
+        return "\n".join(lines)
+
+    lines.append("✗ DRIFT DETECTED")
+    if report.missing_in_env:
+        lines.append("")
+        lines.append("  Missing in env (file exists, NOT applied — likely un-deployed):")
+        lines.extend(f"    - {v}" for v in report.missing_in_env)
+    if report.orphan_in_env:
+        lines.append("")
+        lines.append("  Orphan in env (applied/recorded, NO file — history rewritten):")
+        lines.extend(f"    - {v}" for v in report.orphan_in_env)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Schema-drift guard (SB-79)")
+    parser.add_argument(
+        "--env",
+        default=os.getenv("APP_ENV", "local"),
+        help="Environment label for the report (local/prod). Default: $APP_ENV or local.",
+    )
+    parser.add_argument(
+        "--db-url",
+        default=os.getenv("DATABASE_URL"),
+        help="Postgres connection string. Default: $DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--migrations-dir",
+        type=Path,
+        default=DEFAULT_MIGRATIONS_DIR,
+        help=f"Migrations directory. Default: {DEFAULT_MIGRATIONS_DIR}",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.db_url:
+        print("error: no database URL (set DATABASE_URL or pass --db-url)", file=sys.stderr)
+        return 2
+    if not args.migrations_dir.is_dir():
+        print(f"error: migrations dir not found: {args.migrations_dir}", file=sys.stderr)
+        return 2
+
+    file_versions = read_migration_versions(args.migrations_dir)
+    applied_versions = fetch_applied_versions(args.db_url)
+    report = compute_drift(file_versions, applied_versions)
+
+    print(render_report(args.env, report))
+    return 0 if report.in_sync else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notify_linear_drift.sh
+++ b/scripts/notify_linear_drift.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Schema-drift guard notifier (SB-79).
+#
+# Called by .github/workflows/migration-drift.yml when the drift check fails.
+# Files a Linear issue describing the drift, or — if an open one already exists
+# — adds a comment instead of duplicating. Idempotent across daily runs.
+#
+# Env:
+#   LINEAR_API_KEY  (required) Linear personal API key
+#   LINEAR_TEAM_KEY (default SB) team key to file under
+# Args:
+#   $1  path to the drift report text file
+set -euo pipefail
+
+REPORT_FILE="${1:?usage: notify_linear_drift.sh <report-file>}"
+TEAM_KEY="${LINEAR_TEAM_KEY:-SB}"
+TITLE="[drift-guard] Prod migration drift detected"
+API="https://api.linear.app/graphql"
+
+if [[ -z "${LINEAR_API_KEY:-}" ]]; then
+  echo "LINEAR_API_KEY not set — skipping Linear notification (drift still failed the build)."
+  exit 0
+fi
+
+report_body="$(cat "$REPORT_FILE")"
+# Body: fenced report so it renders in Linear.
+body="$(printf 'Automated drift check failed. See \`scripts/check_migration_drift.py\` (SB-79).\n\n```\n%s\n```\n\nFix via the prod-reconciliation ticket (SB-80).' "$report_body")"
+
+gql() {
+  # $1 = query, $2 = variables JSON
+  curl -fsS -X POST "$API" \
+    -H "Authorization: ${LINEAR_API_KEY}" \
+    -H "Content-Type: application/json" \
+    --data "$(jq -n --arg q "$1" --argjson v "$2" '{query:$q, variables:$v}')"
+}
+
+team_id="$(gql 'query($k:String!){ teams(filter:{key:{eq:$k}}){ nodes{ id } } }' \
+  "$(jq -n --arg k "$TEAM_KEY" '{k:$k}')" | jq -r '.data.teams.nodes[0].id // empty')"
+if [[ -z "$team_id" ]]; then
+  echo "Could not resolve Linear team '$TEAM_KEY'." >&2
+  exit 1
+fi
+
+# Existing open issue with our marker title?
+existing="$(gql 'query($t:String!){ issues(filter:{ title:{ eq:$t }, completedAt:{ null:true }, canceledAt:{ null:true } }){ nodes{ id identifier url } } }' \
+  "$(jq -n --arg t "$TITLE" '{t:$t}')")"
+issue_id="$(echo "$existing" | jq -r '.data.issues.nodes[0].id // empty')"
+
+if [[ -n "$issue_id" ]]; then
+  url="$(echo "$existing" | jq -r '.data.issues.nodes[0].url')"
+  gql 'mutation($i:String!,$b:String!){ commentCreate(input:{issueId:$i, body:$b}){ success } }' \
+    "$(jq -n --arg i "$issue_id" --arg b "$body" '{i:$i,b:$b}')" >/dev/null
+  echo "Drift still open — commented on existing issue: $url"
+else
+  created="$(gql 'mutation($t:String!,$d:String!,$tm:String!){ issueCreate(input:{title:$t, description:$d, teamId:$tm}){ issue{ identifier url } } }' \
+    "$(jq -n --arg t "$TITLE" --arg d "$body" --arg tm "$team_id" '{t:$t,d:$d,tm:$tm}')")"
+  echo "Filed new Linear issue: $(echo "$created" | jq -r '.data.issueCreate.issue.url')"
+fi


### PR DESCRIPTION
## Summary

"Advanced lint" for migration **state**: assert that the applied versions in an environment's `supabase_migrations.schema_migrations` equal the timestamped migration files in `supabase-local/migrations/`.

Code/unit tests can't catch this — CI's test DB is built from the migration files, so it always has the correct schema. Drift is an **environment-state** problem (a migration merged but never deployed, or schema hand-applied in the Supabase SQL editor without recording a row), so it needs an environment check. This is also the guard that would have caught the SB-68 deploy break.

Fixes SB-79.

## What's here

- **`scripts/check_migration_drift.py`** — pure diff logic (`read_migration_versions`, `compute_drift`; no IO, unit-tested) + a single `psycopg2` fetch. Reports **missing in env** (file exists, not applied → un-deployed) and **orphan in env** (recorded, no file → history rewritten); exits non-zero on drift.
- **`.github/workflows/migration-drift.yml`** — daily cron against prod (the only layer that catches *out-of-band Studio edits* — no commit/PR to trigger on). On drift: fail the build **and** file/update a Linear issue.
- **`scripts/notify_linear_drift.sh`** — idempotent find-or-create Linear issue via GraphQL.
- **`backend/tests/unit/test_migration_drift.py`** — 8 unit tests for the pure logic.
- **docs** — drift-guard section in `schema-migrations.md`.

## Verification

- ✅ **GREEN against local** (40 files == 40 applied), exit 0.
- 🔴 **RED against live prod** (set pulled via SQL) — flags exactly the 4 drifted versions:
  `20260520000000`, `20260523000000`, `20260525130000`, `20260527010000`.
  That red is *correct* and is what **SB-80** (prod reconciliation) will turn green.
- ✅ 8/8 unit tests pass; ruff clean.

## Required CI secrets

- `PROD_DATABASE_URL` (already provisioned per `setup-github-secrets.sh`)
- `LINEAR_API_KEY` (for the on-drift issue filing) — **needs to be added**.

## Relationship

- Pairs with **SB-80** (prod reconciliation): this guard is red now, SB-80 makes it green.
- Related: **SB-71** (migrations dir cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)