### PR TITLE
fix(infra): drift guard only notifies on real drift; assign+label auto-issues (SB-83)

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -28,11 +28,19 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
         run: |
-          set -o pipefail
+          # Capture the exit code so the notify step can distinguish real drift
+          # (1) from a misconfiguration like a missing DB URL (2). The job still
+          # goes red on any non-zero, but only exit 1 should file a Linear issue.
+          set +e
           python scripts/check_migration_drift.py --env prod | tee drift_report.txt
+          code=${PIPESTATUS[0]}
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          exit "$code"
 
       - name: File/update Linear issue on drift
-        if: failure() && steps.drift.outcome == 'failure'
+        # Only on real drift (exit 1) — NOT on config failures (exit 2), which
+        # would otherwise file a spurious issue with an empty report (SB-82/SB-83).
+        if: failure() && steps.drift.outputs.code == '1'
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_KEY: SB

--- a/backend/tests/unit/test_migration_drift.py
+++ b/backend/tests/unit/test_migration_drift.py
@@ -87,3 +87,24 @@ class TestRenderReport:
         assert "DRIFT DETECTED" in out
         assert "20260520000000" in out
         assert "Missing in env" in out
+
+
+@pytest.mark.unit
+class TestMainExitCodes:
+    """Exit-code contract the CI workflow relies on (SB-83): 2 = misconfig.
+
+    The notify step files a Linear issue only on exit 1 (real drift), so exit 2
+    (no DB URL / bad dir) must stay distinct. These paths return before any DB
+    connection, so they're unit-testable with no database.
+    """
+
+    def test_missing_db_url_returns_2(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        rc = guard.main(["--db-url", "", "--migrations-dir", str(tmp_path)])
+        assert rc == 2
+
+    def test_missing_migrations_dir_returns_2(self):
+        rc = guard.main(
+            ["--db-url", "postgresql://unused", "--migrations-dir", "/no/such/dir"]
+        )
+        assert rc == 2

--- a/scripts/notify_linear_drift.sh
+++ b/scripts/notify_linear_drift.sh
@@ -6,14 +6,18 @@
 # — adds a comment instead of duplicating. Idempotent across daily runs.
 #
 # Env:
-#   LINEAR_API_KEY  (required) Linear personal API key
-#   LINEAR_TEAM_KEY (default SB) team key to file under
+#   LINEAR_API_KEY        (required) Linear personal API key
+#   LINEAR_TEAM_KEY       (default SB) team key to file under
+#   LINEAR_ASSIGNEE_EMAIL (default silverbeer.io@gmail.com) issue assignee
+#   LINEAR_LABELS         (default MT,infra) comma-separated label names
 # Args:
 #   $1  path to the drift report text file
 set -euo pipefail
 
 REPORT_FILE="${1:?usage: notify_linear_drift.sh <report-file>}"
 TEAM_KEY="${LINEAR_TEAM_KEY:-SB}"
+ASSIGNEE_EMAIL="${LINEAR_ASSIGNEE_EMAIL:-silverbeer.io@gmail.com}"
+LABELS_CSV="${LINEAR_LABELS:-MT,infra}"
 TITLE="[drift-guard] Prod migration drift detected"
 API="https://api.linear.app/graphql"
 
@@ -52,7 +56,23 @@ if [[ -n "$issue_id" ]]; then
     "$(jq -n --arg i "$issue_id" --arg b "$body" '{i:$i,b:$b}')" >/dev/null
   echo "Drift still open — commented on existing issue: $url"
 else
-  created="$(gql 'mutation($t:String!,$d:String!,$tm:String!){ issueCreate(input:{title:$t, description:$d, teamId:$tm}){ issue{ identifier url } } }' \
-    "$(jq -n --arg t "$TITLE" --arg d "$body" --arg tm "$team_id" '{t:$t,d:$d,tm:$tm}')")"
+  # Resolve assignee + labels so the auto-filed issue follows workspace
+  # conventions (never unassigned; always repo + type labeled). Each is
+  # best-effort — if resolution fails, still file the issue (don't drop the
+  # alert), just without that field.
+  assignee_id="$(gql 'query($e:String!){ users(filter:{email:{eq:$e}}){ nodes{ id } } }' \
+    "$(jq -n --arg e "$ASSIGNEE_EMAIL" '{e:$e}')" | jq -r '.data.users.nodes[0].id // empty')"
+  label_names="$(jq -n --arg c "$LABELS_CSV" '$c | split(",")')"
+  label_ids="$(gql 'query($n:[String!]!){ issueLabels(filter:{name:{in:$n}}){ nodes{ id } } }' \
+    "$(jq -n --argjson n "$label_names" '{n:$n}')" | jq -c '[.data.issueLabels.nodes[].id]')"
+
+  input="$(jq -n --arg t "$TITLE" --arg d "$body" --arg tm "$team_id" \
+    --arg a "$assignee_id" --argjson l "${label_ids:-[]}" '
+    {title:$t, description:$d, teamId:$tm}
+    + (if $a != "" then {assigneeId:$a} else {} end)
+    + (if ($l|length) > 0 then {labelIds:$l} else {} end)')"
+
+  created="$(gql 'mutation($input:IssueCreateInput!){ issueCreate(input:$input){ issue{ identifier url } } }' \
+    "$(jq -n --argjson i "$input" '{input:$i}')")"
   echo "Filed new Linear issue: $(echo "$created" | jq -r '.data.issueCreate.issue.url')"
 fi


### PR DESCRIPTION
## Summary

Hardens the SB-79 drift guard after it cried wolf. Its first cron run **exited 2 (no `DATABASE_URL` secret yet)** — a misconfiguration, not drift — but the notify step (gated only on `failure()`) filed **SB-82 with an empty report**. Prod was actually in sync. The auto-filed issue was also **unassigned + unlabeled**, against workspace conventions.

Fixes SB-83. SB-82 canceled as a false positive.

## Changes

- **`.github/workflows/migration-drift.yml`** — capture the drift step's exit code to a step output; gate the notify step on `steps.drift.outputs.code == '1'` (real drift only). The job still goes **red on exit 2** (misconfig is a build failure) — it just no longer files a spurious Linear issue.
- **`scripts/notify_linear_drift.sh`** — on create, resolve + set `assignee` (silverbeer.io) and labels (`MT`, `infra`) via a typed `IssueCreateInput!`. Best-effort: a resolution miss still files the issue (never drop the alert), just without that field.
- **`backend/tests/unit/test_migration_drift.py`** — cover the exit-code contract the gating depends on (no DB URL → 2; bad dir → 2).

## Exit-code contract (what the gating relies on)

| Code | Meaning | Job | Files Linear issue? |
|------|---------|-----|---------------------|
| 0 | in sync | green | no |
| 1 | real drift | red | **yes** (assigned + labeled) |
| 2 | misconfig (no DB URL / bad dir) | red | **no** |

## Test plan

- [x] `pytest tests/unit/test_migration_drift.py` — 10/10 pass
- [x] `bash -n` notify script · workflow YAML parses · ruff clean
- [ ] Live: exercised on the next real-drift run (GraphQL assignee/label shapes verified by inspection; not callable without filing a real issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)