### PR TITLE
fix(cache): match creates must bust the tournament cache (SB-72)

### DIFF
--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -12,6 +12,7 @@ import httpx
 import structlog
 from dotenv import load_dotenv
 from postgrest.exceptions import APIError
+from supabase import create_client
 
 from dao.base_dao import BaseDAO, clear_cache, dao_cache, invalidates_cache
 from dao.exceptions import DuplicateRecordError
@@ -21,7 +22,6 @@ from dao.standings import (
     filter_completed_matches,
     filter_same_division_matches,
 )
-from supabase import create_client
 
 logger = structlog.get_logger()
 
@@ -234,7 +234,7 @@ class MatchDAO(BaseDAO):
             logger.exception("Error getting match by teams and date")
             return None
 
-    @invalidates_cache(MATCHES_CACHE_PATTERN)
+    @invalidates_cache(MATCHES_CACHE_PATTERN, PLAYOFF_CACHE_PATTERN, TOURNAMENTS_CACHE_PATTERN)
     def update_match_external_id(self, match_id: int, external_match_id: str) -> bool:
         """Update only the external match_id field on an existing match.
 
@@ -274,7 +274,7 @@ class MatchDAO(BaseDAO):
             logger.exception("Error updating match external_id")
             return False
 
-    @invalidates_cache(MATCHES_CACHE_PATTERN)
+    @invalidates_cache(MATCHES_CACHE_PATTERN, PLAYOFF_CACHE_PATTERN, TOURNAMENTS_CACHE_PATTERN)
     def create_match(
         self,
         home_team_id: int,
@@ -790,7 +790,7 @@ class MatchDAO(BaseDAO):
                 "head_to_head": [],
             }
 
-    @invalidates_cache(MATCHES_CACHE_PATTERN)
+    @invalidates_cache(MATCHES_CACHE_PATTERN, PLAYOFF_CACHE_PATTERN, TOURNAMENTS_CACHE_PATTERN)
     def add_match(
         self,
         home_team_id: int,
@@ -859,7 +859,7 @@ class MatchDAO(BaseDAO):
             logger.exception("Error adding match")
             return False
 
-    @invalidates_cache(MATCHES_CACHE_PATTERN)
+    @invalidates_cache(MATCHES_CACHE_PATTERN, PLAYOFF_CACHE_PATTERN, TOURNAMENTS_CACHE_PATTERN)
     def add_match_with_external_id(
         self,
         home_team_id: int,

--- a/backend/tests/unit/dao/test_tournament_cache_invalidation.py
+++ b/backend/tests/unit/dao/test_tournament_cache_invalidation.py
@@ -1,0 +1,73 @@
+"""Regression tests for SB-72: match writes must bust the tournament cache.
+
+The bracket view reads `GET /api/tournaments/{id}` → `get_tournament_by_id`,
+cached under `mt:dao:tournaments:by_id:{id}`. Several match-write methods
+(`create_match`, `add_match`, `add_match_with_external_id`,
+`update_match_external_id`) previously invalidated only `mt:dao:matches:*`, so
+creating/relinking a tournament match left the bracket cache stale until a
+`redis-cli FLUSHDB`. These assert each now also clears the tournaments pattern.
+
+The `@invalidates_cache` decorator calls `clear_cache(pattern)` per pattern
+after the method returns, so patching `clear_cache` lets us assert invalidation
+with a mocked Supabase client (no DB, no Redis).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao.match_dao import TOURNAMENTS_CACHE_PATTERN, MatchDAO
+
+pytestmark = [pytest.mark.unit, pytest.mark.backend, pytest.mark.dao]
+
+
+def _make_dao() -> MatchDAO:
+    """MatchDAO with a chainable mock client whose writes return a row."""
+    client = MagicMock()
+    holder = MagicMock()
+    holder.get_client.return_value = client
+    dao = MatchDAO.__new__(MatchDAO)
+    dao.connection_holder = holder
+    dao.client = client
+    # Any insert/update .execute() returns a single fake row so the methods
+    # take their success path.
+    client.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[{"id": 1}]
+    )
+    client.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": 1}]
+    )
+    return dao
+
+
+class TestTournamentCacheInvalidation:
+    def test_create_match_busts_tournament_cache(self):
+        dao = _make_dao()
+        with patch("dao.base_dao.clear_cache") as clear_cache:
+            dao.create_match(
+                home_team_id=1, away_team_id=2, match_date="2026-05-30", season_id=3
+            )
+        clear_cache.assert_any_call(TOURNAMENTS_CACHE_PATTERN)
+
+    def test_add_match_busts_tournament_cache(self):
+        dao = _make_dao()
+        with patch("dao.base_dao.clear_cache") as clear_cache:
+            dao.add_match(
+                home_team_id=1,
+                away_team_id=2,
+                match_date="2026-05-30",
+                home_score=0,
+                away_score=0,
+                season_id=3,
+                age_group_id=2,
+                match_type_id=2,
+            )
+        clear_cache.assert_any_call(TOURNAMENTS_CACHE_PATTERN)
+
+    def test_update_match_external_id_busts_tournament_cache(self):
+        dao = _make_dao()
+        with patch("dao.base_dao.clear_cache") as clear_cache:
+            dao.update_match_external_id(1, "ext-123")
+        clear_cache.assert_any_call(TOURNAMENTS_CACHE_PATTERN)


### PR DESCRIPTION
## Summary

The tournament **bracket view** rendered **stale** after batch-loading a round (scores missing, later rounds empty) — fixed only by `redis-cli FLUSHDB`. Root-caused to a cache-invalidation gap.

Fixes SB-72.

## Root cause

The bracket reads `GET /api/tournaments/{id}` → `get_tournament_by_id`, cached under `mt:dao:tournaments:by_id:{id}`. Four match-write methods invalidated **only** `MATCHES_CACHE_PATTERN` (`mt:dao:matches:*`), never the tournaments pattern — so creating/relinking a tournament match left the bracket cache stale:

| Method | Before | Path |
|--------|--------|------|
| `create_match` | MATCHES only ❌ | |
| `add_match` | MATCHES only ❌ | **POST /api/matches** (the load skill's `match create`) |
| `add_match_with_external_id` | MATCHES only ❌ | scraper create |
| `update_match_external_id` | MATCHES only ❌ | scraper relink |
| `update_match` | MATCHES, PLAYOFF, TOURNAMENTS ✓ | |
| `delete_match` | MATCHES, TOURNAMENTS ✓ | |

A **create** (new round) thus never busted `mt:dao:tournaments:by_id:{id}` → "later rounds empty". Exactly the reported symptom.

## Fix

Align the four to the same trio `update_match` already uses:
`@invalidates_cache(MATCHES_CACHE_PATTERN, PLAYOFF_CACHE_PATTERN, TOURNAMENTS_CACHE_PATTERN)`.

## Tests

DAO-level regression (`test_tournament_cache_invalidation.py`) — mocked client + patched `clear_cache`, asserting `create_match`, `add_match`, and `update_match_external_id` each clear the tournaments pattern. **3/3 pass**, ruff clean.

## Acceptance (from ticket)

- [x] After `POST /api/matches` (create/add) the tournament cache key is invalidated — verified by test.
- [x] `PUT`/`DELETE` already invalidated it (unchanged).
- [ ] Manual: rerun a tournament-load session, watch the bracket update **without** a Redis flush (verify on a real load).

Note: once merged, the local `feedback_bracket_cache_redis_flush.md` memo (warn user + recommend FLUSHDB) is obsolete and should be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)