### PR TITLE
feat(notifications): follow tournament bracket for fulltime push

### DIFF
--- a/backend/api/push.py
+++ b/backend/api/push.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, Field
 
 from auth import get_current_user_required
+from dao.bracket_follow_dao import BracketFollowDAO
 from dao.match_dao import SupabaseConnection
 from dao.notification_preferences_dao import NotificationPreferencesDAO
 from dao.push_send_log_dao import PushSendLogDAO
@@ -67,6 +68,10 @@ def _sub_dao() -> PushSubscriptionDAO:
 
 def _follow_dao() -> TeamFollowDAO:
     return TeamFollowDAO(_conn())
+
+
+def _bracket_follow_dao() -> BracketFollowDAO:
+    return BracketFollowDAO(_conn())
 
 
 def _log_dao() -> PushSendLogDAO:
@@ -128,6 +133,19 @@ class TeamFollowIn(BaseModel):
     """Body of POST /api/users/me/team-follows."""
 
     team_id: int = Field(..., ge=1)
+
+
+class BracketFollowIn(BaseModel):
+    """Body of POST /api/users/me/bracket-follows.
+
+    A bracket is (tournament_id, tournament_group, age_group_id) — e.g.
+    "Bracket A · U14". Following it delivers a push at fulltime for every
+    match in that bracket/age-group.
+    """
+
+    tournament_id: int = Field(..., ge=1)
+    tournament_group: str = Field(..., min_length=1, max_length=100)
+    age_group_id: int = Field(..., ge=1)
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +278,68 @@ def unfollow_team(
 ) -> Response:
     user_id = _user_id(current_user)
     _follow_dao().unfollow(user_id, team_id)  # idempotent
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Bracket follows
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/users/me/bracket-follows",
+    status_code=status.HTTP_201_CREATED,
+)
+def follow_bracket(
+    payload: BracketFollowIn,
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+) -> dict[str, Any]:
+    user_id = _user_id(current_user)
+    ok = _bracket_follow_dao().follow(
+        user_id,
+        payload.tournament_id,
+        payload.tournament_group,
+        payload.age_group_id,
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to follow bracket.",
+        )
+    return {
+        "tournament_id": payload.tournament_id,
+        "tournament_group": payload.tournament_group,
+        "age_group_id": payload.age_group_id,
+        "following": True,
+    }
+
+
+@router.get("/users/me/bracket-follows")
+def list_bracket_follows(
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+) -> dict[str, list[dict]]:
+    user_id = _user_id(current_user)
+    return {"follows": _bracket_follow_dao().list_for_user(user_id)}
+
+
+@router.delete(
+    "/users/me/bracket-follows",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def unfollow_bracket(
+    tournament_id: int,
+    tournament_group: str,
+    age_group_id: int,
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+) -> Response:
+    """Unfollow a bracket. Composite key via query params (no single id).
+
+    Idempotent — returns 204 even if the user wasn't following.
+    """
+    user_id = _user_id(current_user)
+    _bracket_follow_dao().unfollow(
+        user_id, tournament_id, tournament_group, age_group_id
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/dao/bracket_follow_dao.py
+++ b/backend/dao/bracket_follow_dao.py
@@ -1,0 +1,177 @@
+"""Bracket Follow DAO.
+
+Tracks which tournament brackets a user follows. A bracket is the tuple
+(tournament_id, tournament_group, age_group_id) — e.g. "Bracket A · U14".
+Following a bracket means: get a Web Push when any match in that bracket
+reaches a final score (fulltime). See dispatcher._send_push_fanout.
+
+list_subscriptions_for_bracket is the fan-out hot path — called once per
+fulltime event to find every push subscription that should receive it.
+Mirrors TeamFollowDAO (dao/team_follow_dao.py).
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from dao.base_dao import BaseDAO
+
+logger = structlog.get_logger()
+
+TABLE = "user_bracket_follows"
+
+
+class BracketFollowDAO(BaseDAO):
+    """Data access for user→bracket follow relationships."""
+
+    def follow(
+        self,
+        user_id: str,
+        tournament_id: int,
+        tournament_group: str,
+        age_group_id: int,
+    ) -> bool:
+        """Follow a bracket. Idempotent — re-following returns True silently."""
+        try:
+            existing = (
+                self.client.table(TABLE)
+                .select("user_id")
+                .eq("user_id", user_id)
+                .eq("tournament_id", tournament_id)
+                .eq("tournament_group", tournament_group)
+                .eq("age_group_id", age_group_id)
+                .limit(1)
+                .execute()
+            )
+            if existing.data:
+                return True
+            self.client.table(TABLE).insert(
+                {
+                    "user_id": user_id,
+                    "tournament_id": tournament_id,
+                    "tournament_group": tournament_group,
+                    "age_group_id": age_group_id,
+                }
+            ).execute()
+            return True
+        except Exception:
+            logger.exception(
+                "bracket_follow_failed",
+                user_id=user_id,
+                tournament_id=tournament_id,
+                tournament_group=tournament_group,
+                age_group_id=age_group_id,
+            )
+            return False
+
+    def unfollow(
+        self,
+        user_id: str,
+        tournament_id: int,
+        tournament_group: str,
+        age_group_id: int,
+    ) -> bool:
+        """Unfollow a bracket. Idempotent — returns True even if not following."""
+        try:
+            (
+                self.client.table(TABLE)
+                .delete()
+                .eq("user_id", user_id)
+                .eq("tournament_id", tournament_id)
+                .eq("tournament_group", tournament_group)
+                .eq("age_group_id", age_group_id)
+                .execute()
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "bracket_unfollow_failed",
+                user_id=user_id,
+                tournament_id=tournament_id,
+                tournament_group=tournament_group,
+                age_group_id=age_group_id,
+            )
+            return False
+
+    def list_for_user(self, user_id: str) -> list[dict]:
+        """Return brackets the user follows, joined with tournament + age group
+        names for display."""
+        try:
+            response = (
+                self.client.table(TABLE)
+                .select(
+                    "tournament_id, tournament_group, age_group_id, created_at, "
+                    "tournament:tournaments(id, name, logo_url), "
+                    "age_group:age_groups(id, name)"
+                )
+                .eq("user_id", user_id)
+                .order("created_at", desc=True)
+                .execute()
+            )
+            return response.data or []
+        except Exception:
+            logger.exception("bracket_follow_list_failed", user_id=user_id)
+            return []
+
+    def list_subscriptions_for_bracket(
+        self,
+        tournament_id: int,
+        tournament_group: str,
+        age_group_id: int,
+    ) -> list[dict]:
+        """Fan-out query: every push subscription whose owner follows this bracket.
+
+        Returns subscription rows (id, endpoint, p256dh_key, auth_key, user_id),
+        deduplicated by subscription id (a user with multiple devices appears
+        once per device — intentional, each device gets its own push).
+
+        Two plain `in_`/`eq` queries rather than a PostgREST embed: as with
+        user_team_follows, there is no FK between user_bracket_follows and
+        push_subscriptions (both only reference user_profiles), so an embed
+        raises PGRST200 and — since the DAO swallows exceptions — the dispatcher
+        would silently deliver zero pushes. See dao/team_follow_dao.py:97.
+        """
+        try:
+            # Step 1: distinct users following this exact bracket.
+            follow_resp = (
+                self.client.table(TABLE)
+                .select("user_id")
+                .eq("tournament_id", tournament_id)
+                .eq("tournament_group", tournament_group)
+                .eq("age_group_id", age_group_id)
+                .execute()
+            )
+            user_ids = list(
+                {
+                    row["user_id"]
+                    for row in (follow_resp.data or [])
+                    if row.get("user_id")
+                }
+            )
+            if not user_ids:
+                return []
+
+            # Step 2: every push subscription owned by those users.
+            sub_resp = (
+                self.client.table("push_subscriptions")
+                .select("id, endpoint, p256dh_key, auth_key, user_id")
+                .in_("user_id", user_ids)
+                .execute()
+            )
+
+            seen_ids: set[str] = set()
+            flat: list[dict] = []
+            for sub in sub_resp.data or []:
+                if sub["id"] in seen_ids:
+                    continue
+                seen_ids.add(sub["id"])
+                flat.append(sub)
+            return flat
+        except Exception:
+            logger.exception(
+                "bracket_follow_list_subscriptions_failed",
+                tournament_id=tournament_id,
+                tournament_group=tournament_group,
+                age_group_id=age_group_id,
+            )
+            return []

--- a/backend/notifications/dispatcher.py
+++ b/backend/notifications/dispatcher.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 
 import structlog
 
+from dao.bracket_follow_dao import BracketFollowDAO
 from dao.club_notifications_dao import ClubNotificationsDAO
 from dao.match_dao import MatchDAO, SupabaseConnection
 from dao.push_send_log_dao import PushSendLogDAO
@@ -87,6 +88,7 @@ class Notifier:
         self._match_dao: MatchDAO | None = None
         self._notif_dao: ClubNotificationsDAO | None = None
         self._team_follow_dao: TeamFollowDAO | None = None
+        self._bracket_follow_dao: BracketFollowDAO | None = None
         self._push_sub_dao: PushSubscriptionDAO | None = None
         self._push_log_dao: PushSendLogDAO | None = None
         # NotificationPreferencesDAO; typed via local import to avoid the cycle.
@@ -119,6 +121,12 @@ class Notifier:
         if self._team_follow_dao is None:
             self._team_follow_dao = TeamFollowDAO(self.connection)
         return self._team_follow_dao
+
+    @property
+    def bracket_follow_dao(self) -> BracketFollowDAO:
+        if self._bracket_follow_dao is None:
+            self._bracket_follow_dao = BracketFollowDAO(self.connection)
+        return self._bracket_follow_dao
 
     @property
     def push_sub_dao(self) -> PushSubscriptionDAO:
@@ -267,6 +275,32 @@ class Notifier:
         subscriptions = resolve_user_push_subscriptions(
             home_team_id, away_team_id, self.team_follow_dao
         )
+
+        # Bracket followers: users who follow this match's tournament bracket
+        # (tournament_id + group + age_group). Fulltime only — bracket follows
+        # are "tell me the final score", not play-by-play. Merged into the same
+        # fan-out and deduped below so a user following both the team and the
+        # bracket gets one push per device, not two.
+        if event_type == "fulltime":
+            tournament_id = match.get("tournament_id")
+            tournament_group = match.get("tournament_group")
+            age_group_id = match.get("age_group_id")
+            if tournament_id and tournament_group and age_group_id:
+                subscriptions = subscriptions + self.bracket_follow_dao.list_subscriptions_for_bracket(
+                    tournament_id, tournament_group, age_group_id
+                )
+
+        # Dedupe by subscription id across the team + bracket sources.
+        seen_sub_ids: set[str] = set()
+        deduped: list[dict] = []
+        for sub in subscriptions:
+            sub_id = sub.get("id")
+            if sub_id in seen_sub_ids:
+                continue
+            seen_sub_ids.add(sub_id)
+            deduped.append(sub)
+        subscriptions = deduped
+
         if not subscriptions:
             return
 

--- a/backend/tests/integration/test_bracket_follow_dao.py
+++ b/backend/tests/integration/test_bracket_follow_dao.py
@@ -1,0 +1,165 @@
+"""BracketFollowDAO integration tests against real local Supabase.
+
+Covers the paths the delivery test doesn't: follow idempotency, unfollow,
+and that list_subscriptions_for_bracket returns ONLY subscriptions of users
+following that exact (tournament, group, age_group) tuple.
+
+Requires local Supabase running. Skips cleanly if it isn't reachable.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from dao.bracket_follow_dao import BracketFollowDAO
+from dao.match_dao import SupabaseConnection
+
+pytestmark = [pytest.mark.integration, pytest.mark.backend, pytest.mark.database]
+
+_TEST_PASSWORD = "test-password-123"  # pragma: allowlist secret
+
+
+def _admin_client():
+    from supabase import create_client
+
+    url = os.getenv("SUPABASE_URL", "http://127.0.0.1:54321")
+    if not ("127.0.0.1" in url or "localhost" in url):
+        pytest.skip(f"Refusing to run destructive test against non-local Supabase: {url}")
+    key = os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not key:
+        pytest.skip("SUPABASE_SERVICE_KEY not set — cannot run bracket-follow DAO test")
+    return create_client(url, key)
+
+
+def _mk_user(admin) -> str:
+    email = f"bracket-dao-{uuid.uuid4().hex[:8]}@missingtable.local"
+    created = admin.auth.admin.create_user(
+        {"email": email, "password": _TEST_PASSWORD, "email_confirm": True}
+    )
+    uid = created.user.id
+    admin.table("user_profiles").upsert(
+        {"id": uid, "email": email, "role": "team-fan"}
+    ).execute()
+    return uid
+
+
+@pytest.fixture
+def ctx():
+    admin = _admin_client()
+    try:
+        admin.table("tournaments").select("id").limit(1).execute()
+    except Exception:  # pragma: no cover - infra guard
+        pytest.skip("Local Supabase not reachable")
+
+    age_group_id = admin.table("age_groups").select("id").limit(1).execute().data[0]["id"]
+    tournament = admin.table("tournaments").insert(
+        {
+            "name": f"BracketDAO-{uuid.uuid4().hex[:8]}",
+            "start_date": datetime.now(UTC).date().isoformat(),
+            "is_active": True,
+        }
+    ).execute().data[0]
+
+    dao = BracketFollowDAO(SupabaseConnection())
+    users: list[str] = []
+
+    def new_user() -> str:
+        uid = _mk_user(admin)
+        users.append(uid)
+        return uid
+
+    yield {
+        "admin": admin,
+        "dao": dao,
+        "tournament_id": tournament["id"],
+        "age_group_id": age_group_id,
+        "new_user": new_user,
+    }
+
+    def _safe(fn):
+        try:
+            fn()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            pass
+
+    for uid in users:
+        _safe(lambda u=uid: admin.table("user_bracket_follows").delete().eq("user_id", u).execute())
+        _safe(lambda u=uid: admin.table("push_subscriptions").delete().eq("user_id", u).execute())
+        _safe(lambda u=uid: admin.table("user_profiles").delete().eq("id", u).execute())
+        _safe(lambda u=uid: admin.auth.admin.delete_user(u))
+    _safe(lambda: admin.table("tournaments").delete().eq("id", tournament["id"]).execute())
+
+
+def test_follow_is_idempotent(ctx):
+    dao, uid = ctx["dao"], ctx["new_user"]()
+    tid, ag = ctx["tournament_id"], ctx["age_group_id"]
+
+    assert dao.follow(uid, tid, "Bracket A", ag) is True
+    assert dao.follow(uid, tid, "Bracket A", ag) is True  # re-follow, no dup
+
+    rows = (
+        ctx["admin"].table("user_bracket_follows")
+        .select("*").eq("user_id", uid).execute().data
+    )
+    assert len(rows) == 1
+
+
+def test_unfollow_removes_and_is_idempotent(ctx):
+    dao, uid = ctx["dao"], ctx["new_user"]()
+    tid, ag = ctx["tournament_id"], ctx["age_group_id"]
+
+    dao.follow(uid, tid, "Bracket A", ag)
+    assert dao.unfollow(uid, tid, "Bracket A", ag) is True
+    assert dao.unfollow(uid, tid, "Bracket A", ag) is True  # already gone
+
+    rows = (
+        ctx["admin"].table("user_bracket_follows")
+        .select("*").eq("user_id", uid).execute().data
+    )
+    assert rows == []
+
+
+def test_list_subscriptions_only_matches_exact_bracket(ctx):
+    """A follower of (T, 'Bracket A', AG) is returned; a follower of a
+    different group or age group is not."""
+    admin, dao = ctx["admin"], ctx["dao"]
+    tid, ag = ctx["tournament_id"], ctx["age_group_id"]
+    other_ag = (
+        admin.table("age_groups").select("id").neq("id", ag).limit(1).execute().data
+    )
+
+    follower = ctx["new_user"]()
+    sub = admin.table("push_subscriptions").insert(
+        {
+            "user_id": follower,
+            "endpoint": f"https://push.example/{uuid.uuid4().hex}",
+            "p256dh_key": "k",  # pragma: allowlist secret
+            "auth_key": "a",  # pragma: allowlist secret
+        }
+    ).execute().data[0]
+    dao.follow(follower, tid, "Bracket A", ag)
+
+    # A user following a DIFFERENT bracket group — must be excluded.
+    other_group_user = ctx["new_user"]()
+    admin.table("push_subscriptions").insert(
+        {
+            "user_id": other_group_user,
+            "endpoint": f"https://push.example/{uuid.uuid4().hex}",
+            "p256dh_key": "k",  # pragma: allowlist secret
+            "auth_key": "a",  # pragma: allowlist secret
+        }
+    ).execute()
+    dao.follow(other_group_user, tid, "Bracket B", ag)
+
+    subs = dao.list_subscriptions_for_bracket(tid, "Bracket A", ag)
+    endpoints = {s["endpoint"] for s in subs}
+    assert sub["endpoint"] in endpoints
+    assert len(subs) == 1
+
+    # Different age group on the same group also misses (if another AG exists).
+    if other_ag:
+        assert dao.list_subscriptions_for_bracket(tid, "Bracket A", other_ag[0]["id"]) == []

--- a/backend/tests/integration/test_bracket_follow_delivery.py
+++ b/backend/tests/integration/test_bracket_follow_delivery.py
@@ -1,0 +1,282 @@
+"""End-to-end push-delivery integration test for bracket follows.
+
+A user follows a tournament *bracket* — the tuple (tournament_id,
+tournament_group, age_group_id) — rather than a team, and gets a push at
+fulltime for every match in that bracket. This proves the new fan-out branch
+in dispatcher._send_push_fanout end-to-end against the real local Supabase.
+
+Mirrors test_push_delivery_on_score.py (the team-follow version). The only
+mock is the push network send (pywebpush), injected as push_send_fn.
+
+Requires local Supabase running. Skips cleanly if it isn't reachable.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app, require_admin, require_match_management_permission
+from dao.match_dao import SupabaseConnection
+from notifications.dispatcher import Notifier, set_notifier
+from notifications.web_push_sender import SendResult
+
+pytestmark = [pytest.mark.integration, pytest.mark.backend, pytest.mark.database]
+
+_TEST_PASSWORD = "test-password-123"  # pragma: allowlist secret
+_BRACKET = "Bracket A"
+
+
+def _admin_client():
+    from supabase import create_client
+
+    url = os.getenv("SUPABASE_URL", "http://127.0.0.1:54321")
+    if not ("127.0.0.1" in url or "localhost" in url):
+        pytest.skip(f"Refusing to run destructive test against non-local Supabase: {url}")
+    key = os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not key:
+        pytest.skip("SUPABASE_SERVICE_KEY not set — cannot run bracket-follow integration test")
+    return create_client(url, key)
+
+
+def _unique(label: str) -> str:
+    return f"{label}-{uuid.uuid4().hex[:8]}"
+
+
+class _RecordingSender:
+    """Records every push call; never hits the network. Returns 'sent'."""
+
+    def __init__(self, result: SendResult | None = None):
+        self.calls: list[tuple[dict, dict]] = []
+        self._result = result or SendResult(status="sent", http_status=201)
+
+    def __call__(self, subscription: dict, payload: dict) -> SendResult:
+        self.calls.append((subscription, payload))
+        return self._result
+
+
+@pytest.fixture
+def world():
+    """Seed a tournament with a bracket match + a bracket-follower with a device.
+
+    The follower follows the BRACKET (tournament + group + age_group), NOT the
+    team — so any push proves the bracket fan-out, not team-follow.
+    """
+    admin = _admin_client()
+    try:
+        admin.table("clubs").select("id").limit(1).execute()
+    except Exception:  # pragma: no cover - infra guard
+        pytest.skip("Local Supabase not reachable")
+
+    email = f"bracket-follow-{uuid.uuid4().hex[:8]}@missingtable.local"
+    created = admin.auth.admin.create_user(
+        {"email": email, "password": _TEST_PASSWORD, "email_confirm": True}
+    )
+    user_id = created.user.id
+    admin.table("user_profiles").upsert(
+        {"id": user_id, "email": email, "role": "team-fan"}
+    ).execute()
+
+    def _ref(table: str) -> int:
+        return admin.table(table).select("id").limit(1).execute().data[0]["id"]
+
+    age_group_id = _ref("age_groups")
+    season_id = _ref("seasons")
+
+    home_club = admin.table("clubs").insert(
+        {"name": _unique("BkHome"), "city": "Houston"}
+    ).execute().data[0]
+    away_club = admin.table("clubs").insert(
+        {"name": _unique("BkAway"), "city": "Bergen"}
+    ).execute().data[0]
+    home_team = admin.table("teams").insert(
+        {"name": _unique("HomeTeam"), "city": "Houston", "club_id": home_club["id"]}
+    ).execute().data[0]
+    away_team = admin.table("teams").insert(
+        {"name": _unique("AwayTeam"), "city": "Bergen", "club_id": away_club["id"]}
+    ).execute().data[0]
+
+    tournament = admin.table("tournaments").insert(
+        {
+            "name": _unique("Bracket Cup"),
+            "start_date": datetime.now(UTC).date().isoformat(),
+            "is_active": True,
+        }
+    ).execute().data[0]
+
+    # Scheduled match tagged with the bracket group + a knockout round.
+    match = admin.table("matches").insert(
+        {
+            "home_team_id": home_team["id"],
+            "away_team_id": away_team["id"],
+            "age_group_id": age_group_id,
+            "season_id": season_id,
+            "match_type_id": 2,  # TOURNAMENT_MATCH_TYPE_ID
+            "tournament_id": tournament["id"],
+            "tournament_group": _BRACKET,
+            "tournament_round": "semifinal",
+            "match_date": datetime.now(UTC).date().isoformat(),
+            "match_status": "scheduled",
+        }
+    ).execute().data[0]
+
+    # The user follows the BRACKET and has one registered device.
+    admin.table("user_bracket_follows").insert(
+        {
+            "user_id": user_id,
+            "tournament_id": tournament["id"],
+            "tournament_group": _BRACKET,
+            "age_group_id": age_group_id,
+        }
+    ).execute()
+    subscription = admin.table("push_subscriptions").insert(
+        {
+            "user_id": user_id,
+            "endpoint": f"https://push.example/{uuid.uuid4().hex}",
+            "p256dh_key": "p256dh-key-example",  # pragma: allowlist secret
+            "auth_key": "auth-key-example",  # pragma: allowlist secret
+            "device_label": "Test Phone",
+        }
+    ).execute().data[0]
+
+    yield {
+        "admin": admin,
+        "user_id": user_id,
+        "age_group_id": age_group_id,
+        "home_team": home_team,
+        "away_team": away_team,
+        "tournament": tournament,
+        "match": match,
+        "subscription": subscription,
+    }
+
+    def _safe(fn):
+        try:
+            fn()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            pass
+
+    _safe(lambda: admin.table("push_send_log").delete().eq("user_id", user_id).execute())
+    _safe(lambda: admin.table("user_bracket_follows").delete().eq("user_id", user_id).execute())
+    _safe(lambda: admin.table("user_notification_preferences").delete().eq("user_id", user_id).execute())
+    _safe(lambda: admin.table("push_subscriptions").delete().eq("user_id", user_id).execute())
+    _safe(lambda: admin.table("matches").delete().eq("id", match["id"]).execute())
+    _safe(lambda: admin.table("tournaments").delete().eq("id", tournament["id"]).execute())
+    _safe(lambda: admin.table("teams").delete().eq("id", home_team["id"]).execute())
+    _safe(lambda: admin.table("teams").delete().eq("id", away_team["id"]).execute())
+    _safe(lambda: admin.table("clubs").delete().eq("id", home_club["id"]).execute())
+    _safe(lambda: admin.table("clubs").delete().eq("id", away_club["id"]).execute())
+    _safe(lambda: admin.table("user_profiles").delete().eq("id", user_id).execute())
+    _safe(lambda: admin.auth.admin.delete_user(user_id))
+
+
+@pytest.fixture
+def instrumented_notifier(monkeypatch):
+    """Real-DAO Notifier with only the push network send faked. Yields
+    (sender, notifier) so tests can also drive notify() directly."""
+    monkeypatch.setattr("notifications.dispatcher.push_is_configured", lambda: True)
+    sender = _RecordingSender()
+    notifier = Notifier(connection=SupabaseConnection(), push_send_fn=sender)
+    set_notifier(notifier)
+    yield sender, notifier
+    set_notifier(None)
+
+
+@pytest.fixture(autouse=True)
+def _override_admin_auth():
+    fake_admin = {
+        "user_id": "00000000-0000-0000-0000-0000000000ad",
+        "id": "00000000-0000-0000-0000-0000000000ad",
+        "email": "admin@missingtable.local",
+        "username": "admin",
+        "role": "admin",
+    }
+    app.dependency_overrides[require_admin] = lambda: fake_admin
+    app.dependency_overrides[require_match_management_permission] = lambda: fake_admin
+    yield
+    app.dependency_overrides.clear()
+
+
+def _push_log_rows(admin, match_id: int, user_id: str) -> list[dict]:
+    return (
+        admin.table("push_send_log")
+        .select("*")
+        .eq("match_id", match_id)
+        .eq("user_id", user_id)
+        .execute()
+        .data
+        or []
+    )
+
+
+def _score_url(world) -> str:
+    return f"/api/admin/tournaments/{world['tournament']['id']}/matches/{world['match']['id']}"
+
+
+class TestBracketScorePushesFollower:
+    def test_fulltime_pushes_to_bracket_follower_and_logs(self, world, instrumented_notifier):
+        sender, _ = instrumented_notifier
+        with TestClient(app) as client:
+            resp = client.put(
+                _score_url(world),
+                json={"home_score": 2, "away_score": 1, "match_status": "completed"},
+            )
+        assert resp.status_code == 200, resp.text
+
+        assert len(sender.calls) == 1
+        sub, payload = sender.calls[0]
+        assert sub["endpoint"] == world["subscription"]["endpoint"]
+        text = f"{payload.get('title', '')}\n{payload.get('body', '')}"
+        assert "2 - 1" in text
+
+        rows = _push_log_rows(world["admin"], world["match"]["id"], world["user_id"])
+        assert len(rows) == 1
+        assert rows[0]["event_type"] == "fulltime"
+        assert rows[0]["status"] == "sent"
+
+    def test_goal_event_does_not_push_bracket_follower(self, world, instrumented_notifier):
+        """Bracket follows are fulltime-only — a goal event must stay silent
+        for a user who follows the bracket but neither team."""
+        sender, notifier = instrumented_notifier
+        notifier.notify("goal", world["match"]["id"], {"team_id": world["home_team"]["id"]})
+        assert sender.calls == []
+
+    def test_fulltime_pref_off_suppresses_push(self, world, instrumented_notifier):
+        """The shared per-user preference gate still applies: fulltime off → no push."""
+        sender, _ = instrumented_notifier
+        world["admin"].table("user_notification_preferences").upsert(
+            {"user_id": world["user_id"], "event_type": "fulltime", "enabled": False},
+            on_conflict="user_id,event_type",
+        ).execute()
+
+        with TestClient(app) as client:
+            resp = client.put(
+                _score_url(world),
+                json={"home_score": 3, "away_score": 0, "match_status": "completed"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert sender.calls == []
+
+    def test_following_team_and_bracket_dedupes_to_one_push(self, world, instrumented_notifier):
+        """A user who follows both the home team and the bracket gets exactly
+        one push per device, not two."""
+        sender, _ = instrumented_notifier
+        world["admin"].table("user_team_follows").insert(
+            {"user_id": world["user_id"], "team_id": world["home_team"]["id"]}
+        ).execute()
+        try:
+            with TestClient(app) as client:
+                resp = client.put(
+                    _score_url(world),
+                    json={"home_score": 1, "away_score": 1, "match_status": "completed"},
+                )
+            assert resp.status_code == 200, resp.text
+            assert len(sender.calls) == 1
+        finally:
+            world["admin"].table("user_team_follows").delete().eq(
+                "user_id", world["user_id"]
+            ).execute()

--- a/frontend/src/__tests__/components/TournamentMatchCenter.spec.js
+++ b/frontend/src/__tests__/components/TournamentMatchCenter.spec.js
@@ -17,9 +17,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
 
 // Stub the auth store BEFORE importing the component so the import sees the mock.
+// isAuthenticated is a ref-like ({ value }) — the bracket-follow composable and
+// the component both read `authStore.isAuthenticated.value`. Unauthenticated
+// keeps the bracket-follow fetch a no-op and hides the follow toggle.
 const apiRequest = vi.fn();
 vi.mock('@/stores/auth', () => ({
-  useAuthStore: () => ({ apiRequest }),
+  useAuthStore: () => ({ apiRequest, isAuthenticated: { value: false } }),
 }));
 
 import TournamentMatchCenter from '@/components/TournamentMatchCenter.vue';

--- a/frontend/src/__tests__/composables/useBracketFollows.spec.js
+++ b/frontend/src/__tests__/composables/useBracketFollows.spec.js
@@ -1,0 +1,172 @@
+/**
+ * useBracketFollows tests.
+ *
+ * Singleton composable mirroring useTeamFollows, keyed by the bracket tuple
+ * (tournament_id, tournament_group, age_group_id). Reset via
+ * _resetBracketFollowsForTest between cases.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const isAuthenticatedRef = { value: true };
+const apiRequestMock = vi.fn();
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: isAuthenticatedRef,
+    apiRequest: apiRequestMock,
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiBaseUrl: () => 'http://test.example',
+}));
+
+import {
+  useBracketFollows,
+  _resetBracketFollowsForTest,
+} from '@/composables/useBracketFollows';
+
+beforeEach(() => {
+  apiRequestMock.mockReset();
+  isAuthenticatedRef.value = true;
+  _resetBracketFollowsForTest();
+});
+
+describe('useBracketFollows.ensureLoaded', () => {
+  it('hits GET /bracket-follows once and populates followed keys', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [
+        { tournament_id: 6, tournament_group: 'Bracket A', age_group_id: 2 },
+        { tournament_id: 6, tournament_group: 'Bracket B', age_group_id: 2 },
+      ],
+    });
+
+    const { ensureLoaded, isFollowing, loaded } = useBracketFollows();
+    await ensureLoaded();
+
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'http://test.example/api/users/me/bracket-follows'
+    );
+    expect(loaded.value).toBe(true);
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(true);
+    expect(isFollowing(6, 'Bracket B', 2)).toBe(true);
+    // Wrong age group / group misses.
+    expect(isFollowing(6, 'Bracket A', 3)).toBe(false);
+    expect(isFollowing(6, 'Bracket C', 2)).toBe(false);
+  });
+
+  it('skips the fetch when user is not authenticated', async () => {
+    isAuthenticatedRef.value = false;
+    const { ensureLoaded, loaded } = useBracketFollows();
+    await ensureLoaded();
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(loaded.value).toBe(true);
+  });
+});
+
+describe('useBracketFollows.follow', () => {
+  it('optimistically marks following + POSTs the tuple', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // initial GET
+    apiRequestMock.mockResolvedValueOnce({ following: true }); // POST
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [
+        { tournament_id: 6, tournament_group: 'Bracket A', age_group_id: 2 },
+      ],
+    }); // background refresh
+
+    const { ensureLoaded, follow, isFollowing } = useBracketFollows();
+    await ensureLoaded();
+
+    const result = await follow(6, 'Bracket A', 2);
+    expect(result).toEqual({ success: true });
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(true);
+
+    expect(apiRequestMock).toHaveBeenNthCalledWith(
+      2,
+      'http://test.example/api/users/me/bracket-follows',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          tournament_id: 6,
+          tournament_group: 'Bracket A',
+          age_group_id: 2,
+        }),
+      }
+    );
+  });
+
+  it('reverts optimistic state when POST fails', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    apiRequestMock.mockRejectedValueOnce(new Error('boom'));
+
+    const { ensureLoaded, follow, isFollowing, error } = useBracketFollows();
+    await ensureLoaded();
+
+    const result = await follow(6, 'Bracket A', 2);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('boom');
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(false);
+    expect(error.value).toBe('boom');
+  });
+});
+
+describe('useBracketFollows.unfollow', () => {
+  it('optimistically clears + DELETEs with composite query params', async () => {
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [
+        { tournament_id: 6, tournament_group: 'Bracket A', age_group_id: 2 },
+      ],
+    });
+    apiRequestMock.mockResolvedValueOnce(null); // DELETE 204 → null
+    apiRequestMock.mockResolvedValueOnce({ follows: [] }); // refresh
+
+    const { ensureLoaded, unfollow, isFollowing } = useBracketFollows();
+    await ensureLoaded();
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(true);
+
+    await unfollow(6, 'Bracket A', 2);
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(false);
+
+    const [url, opts] = apiRequestMock.mock.calls[1];
+    expect(opts).toEqual({ method: 'DELETE' });
+    expect(url).toContain('/api/users/me/bracket-follows?');
+    expect(url).toContain('tournament_id=6');
+    // URLSearchParams encodes the space in "Bracket A".
+    expect(url).toContain('tournament_group=Bracket+A');
+    expect(url).toContain('age_group_id=2');
+  });
+
+  it('is a no-op when not currently following', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+
+    const { ensureLoaded, unfollow } = useBracketFollows();
+    await ensureLoaded();
+    await unfollow(6, 'Bracket A', 2);
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1); // only initial GET
+  });
+});
+
+describe('useBracketFollows.toggle', () => {
+  it('follows then unfollows on successive calls', async () => {
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+    apiRequestMock.mockResolvedValueOnce({ following: true });
+    apiRequestMock.mockResolvedValueOnce({
+      follows: [
+        { tournament_id: 6, tournament_group: 'Bracket A', age_group_id: 2 },
+      ],
+    });
+    apiRequestMock.mockResolvedValueOnce(null);
+    apiRequestMock.mockResolvedValueOnce({ follows: [] });
+
+    const { ensureLoaded, toggle, isFollowing } = useBracketFollows();
+    await ensureLoaded();
+
+    await toggle(6, 'Bracket A', 2);
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(true);
+
+    await toggle(6, 'Bracket A', 2);
+    expect(isFollowing(6, 'Bracket A', 2)).toBe(false);
+  });
+});

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -765,6 +765,24 @@
                 {{ g }}
               </button>
             </div>
+
+            <!-- Follow this bracket: push at fulltime for every match in
+                 (tournament + group + age group). Two-state toggle. -->
+            <button
+              v-if="canFollowBracket"
+              type="button"
+              @click="toggleBracketFollow"
+              data-testid="bracket-follow-toggle"
+              :class="[
+                'sm:ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                isBracketFollowed
+                  ? 'bg-green-600 text-white hover:bg-green-700'
+                  : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+              ]"
+            >
+              <span v-if="isBracketFollowed">✓ Following — Unfollow</span>
+              <span v-else>🔔 Follow this bracket</span>
+            </button>
           </div>
 
           <TournamentBracket
@@ -839,6 +857,8 @@ import { getApiBaseUrl } from '../config/api';
 import TournamentBracket from './TournamentBracket.vue';
 import TournamentStandings from './TournamentStandings.vue';
 import MatchDetailView from './MatchDetailView.vue';
+import { useBracketFollows } from '../composables/useBracketFollows';
+import { usePushNotifications } from '../composables/usePushNotifications';
 
 const KNOCKOUT_ROUNDS = new Set([
   'round_of_32',
@@ -872,6 +892,8 @@ export default {
   components: { TournamentBracket, TournamentStandings, MatchDetailView },
   setup() {
     const authStore = useAuthStore();
+    const bracketFollows = useBracketFollows();
+    const { isEnabled: pushEnabled } = usePushNotifications();
 
     const tournaments = ref([]);
     const loading = ref(true);
@@ -1146,6 +1168,36 @@ export default {
       }
     });
 
+    // ── bracket follow toggle ──
+    // A user can follow the currently-selected bracket (tournament + group +
+    // age group) to get a push at fulltime for every match in it. Gated on
+    // being signed in with push enabled, mirroring team-follow buttons.
+    const canFollowBracket = computed(
+      () =>
+        authStore.isAuthenticated.value &&
+        pushEnabled.value &&
+        selectedId.value != null &&
+        bracketGroup.value != null &&
+        bracketAgeGroupId.value != null
+    );
+
+    const isBracketFollowed = computed(() =>
+      bracketFollows.isFollowing(
+        selectedId.value,
+        bracketGroup.value,
+        bracketAgeGroupId.value
+      )
+    );
+
+    const toggleBracketFollow = () => {
+      if (!canFollowBracket.value) return;
+      return bracketFollows.toggle(
+        selectedId.value,
+        bracketGroup.value,
+        bracketAgeGroupId.value
+      );
+    };
+
     // ── standings-mode computed state ──
     // Same pattern as bracket-mode, but keyed off group_stage matches
     // grouped by `tournament_group` (e.g. 'U14 Boys Diamond Bracket A').
@@ -1227,9 +1279,15 @@ export default {
       }
     });
 
-    onMounted(fetchTournaments);
+    onMounted(() => {
+      fetchTournaments();
+      bracketFollows.ensureLoaded();
+    });
 
     return {
+      canFollowBracket,
+      isBracketFollowed,
+      toggleBracketFollow,
       tournaments,
       loading,
       error,

--- a/frontend/src/composables/useBracketFollows.js
+++ b/frontend/src/composables/useBracketFollows.js
@@ -1,0 +1,172 @@
+/**
+ * Bracket-follows composable.
+ *
+ * Singleton reactive state shared by every bracket FollowButton. Mirrors
+ * useTeamFollows: module-level reactive state, useBracketFollows() returns
+ * the same refs every call. A bracket is keyed by the tuple
+ * (tournament_id, tournament_group, age_group_id), joined into a string key.
+ *
+ * Backend endpoints (idempotent):
+ *   GET    /api/users/me/bracket-follows  → { follows: [{ tournament_id, tournament_group, age_group_id, ... }] }
+ *   POST   /api/users/me/bracket-follows  → 201 { ..., following: true }
+ *   DELETE /api/users/me/bracket-follows?tournament_id=&tournament_group=&age_group_id=  → 204
+ */
+
+import { reactive, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { getApiBaseUrl } from '../config/api';
+
+const state = reactive({
+  followedKeys: new Set(),
+  follows: [],
+  loaded: false,
+  loading: false,
+  error: null,
+});
+
+let inflightLoad = null;
+
+// Stable string key for a bracket tuple.
+function bracketKey(tournamentId, tournamentGroup, ageGroupId) {
+  return `${Number(tournamentId)}:${tournamentGroup}:${Number(ageGroupId)}`;
+}
+
+async function fetchFollows() {
+  const authStore = useAuthStore();
+  if (!authStore.isAuthenticated.value) {
+    state.followedKeys = new Set();
+    state.follows = [];
+    state.loaded = true;
+    return;
+  }
+
+  state.loading = true;
+  state.error = null;
+  try {
+    const data = await authStore.apiRequest(
+      `${getApiBaseUrl()}/api/users/me/bracket-follows`
+    );
+    const rows = data?.follows || [];
+    state.follows = rows;
+    state.followedKeys = new Set(
+      rows.map(r =>
+        bracketKey(r.tournament_id, r.tournament_group, r.age_group_id)
+      )
+    );
+    state.loaded = true;
+  } catch (err) {
+    state.error = err.message || String(err);
+    state.followedKeys = new Set();
+    state.follows = [];
+  } finally {
+    state.loading = false;
+  }
+}
+
+export function useBracketFollows() {
+  const authStore = useAuthStore();
+
+  const ensureLoaded = () => {
+    if (state.loaded || state.loading) return inflightLoad || Promise.resolve();
+    inflightLoad = fetchFollows().finally(() => {
+      inflightLoad = null;
+    });
+    return inflightLoad;
+  };
+
+  const refresh = () => {
+    inflightLoad = fetchFollows().finally(() => {
+      inflightLoad = null;
+    });
+    return inflightLoad;
+  };
+
+  const isFollowing = (tournamentId, tournamentGroup, ageGroupId) =>
+    state.followedKeys.has(
+      bracketKey(tournamentId, tournamentGroup, ageGroupId)
+    );
+
+  const follow = async (tournamentId, tournamentGroup, ageGroupId) => {
+    const key = bracketKey(tournamentId, tournamentGroup, ageGroupId);
+    if (state.followedKeys.has(key)) return { success: true };
+
+    // Optimistic
+    state.followedKeys.add(key);
+    state.error = null;
+    try {
+      await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/bracket-follows`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            tournament_id: Number(tournamentId),
+            tournament_group: tournamentGroup,
+            age_group_id: Number(ageGroupId),
+          }),
+        }
+      );
+      refresh();
+      return { success: true };
+    } catch (err) {
+      state.followedKeys.delete(key);
+      state.error = err.message || String(err);
+      return { success: false, error: state.error };
+    }
+  };
+
+  const unfollow = async (tournamentId, tournamentGroup, ageGroupId) => {
+    const key = bracketKey(tournamentId, tournamentGroup, ageGroupId);
+    if (!state.followedKeys.has(key)) return { success: true };
+
+    // Optimistic
+    state.followedKeys.delete(key);
+    state.error = null;
+    try {
+      const qs = new URLSearchParams({
+        tournament_id: String(Number(tournamentId)),
+        tournament_group: tournamentGroup,
+        age_group_id: String(Number(ageGroupId)),
+      });
+      await authStore.apiRequest(
+        `${getApiBaseUrl()}/api/users/me/bracket-follows?${qs.toString()}`,
+        { method: 'DELETE' }
+      );
+      refresh();
+      return { success: true };
+    } catch (err) {
+      state.followedKeys.add(key);
+      state.error = err.message || String(err);
+      return { success: false, error: state.error };
+    }
+  };
+
+  const toggle = async (tournamentId, tournamentGroup, ageGroupId) => {
+    return isFollowing(tournamentId, tournamentGroup, ageGroupId)
+      ? unfollow(tournamentId, tournamentGroup, ageGroupId)
+      : follow(tournamentId, tournamentGroup, ageGroupId);
+  };
+
+  return {
+    follows: computed(() => state.follows),
+    followedKeys: computed(() => state.followedKeys),
+    loaded: computed(() => state.loaded),
+    loading: computed(() => state.loading),
+    error: computed(() => state.error),
+    ensureLoaded,
+    refresh,
+    isFollowing,
+    follow,
+    unfollow,
+    toggle,
+  };
+}
+
+// Test-only: reset module-level singleton between tests.
+export function _resetBracketFollowsForTest() {
+  state.followedKeys = new Set();
+  state.follows = [];
+  state.loaded = false;
+  state.loading = false;
+  state.error = null;
+  inflightLoad = null;
+}

--- a/supabase-local/migrations/20260601000000_add_bracket_follows.sql
+++ b/supabase-local/migrations/20260601000000_add_bracket_follows.sql
@@ -1,0 +1,58 @@
+-- Bracket follows: tournament-bracket notification subscriptions.
+--
+-- A user follows a specific (tournament, bracket, age_group) and receives a
+-- Web Push when any match in that bracket reaches a final score (fulltime).
+-- A "bracket" is the tournament_group value on a match (e.g. "Bracket A");
+-- one bracket can span multiple age groups, so the age_group is part of the
+-- key — the user follows one age group within a bracket.
+--
+-- Mirrors user_team_follows (20260527000000_add_push_subscriptions.sql):
+--   - FK to user_profiles(id) ON DELETE CASCADE
+--   - RLS: users manage their own follows; admins read/manage all
+-- The fan-out (dispatcher) reads this via the service role, bypassing RLS.
+
+CREATE TABLE public.user_bracket_follows (
+    user_id uuid NOT NULL REFERENCES public.user_profiles(id) ON DELETE CASCADE,
+    tournament_id integer NOT NULL REFERENCES public.tournaments(id) ON DELETE CASCADE,
+    tournament_group text NOT NULL,
+    age_group_id integer NOT NULL REFERENCES public.age_groups(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, tournament_id, tournament_group, age_group_id)
+);
+
+-- Fan-out hot path: "who follows this bracket?" keyed on the match's
+-- (tournament_id, tournament_group, age_group_id).
+CREATE INDEX idx_user_bracket_follows_bracket
+    ON public.user_bracket_follows(tournament_id, tournament_group, age_group_id);
+
+ALTER TABLE public.user_bracket_follows ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_bracket_follows_user_select
+    ON public.user_bracket_follows FOR SELECT
+    USING (user_id = auth.uid());
+
+CREATE POLICY user_bracket_follows_user_insert
+    ON public.user_bracket_follows FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY user_bracket_follows_user_delete
+    ON public.user_bracket_follows FOR DELETE
+    USING (user_id = auth.uid());
+
+CREATE POLICY user_bracket_follows_admin_all
+    ON public.user_bracket_follows FOR ALL
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.user_profiles up
+            WHERE up.id = auth.uid() AND up.role = 'admin'
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.user_profiles up
+            WHERE up.id = auth.uid() AND up.role = 'admin'
+        )
+    );
+
+COMMENT ON TABLE public.user_bracket_follows IS
+    'Which tournament brackets (tournament + group + age_group) a user follows for fulltime push notifications.';


### PR DESCRIPTION
## Context

Big tournament next weekend (2026 National Academy Championships). Users want to **follow a bracket** and get a push when each match in that bracket finishes.

A "bracket" = the tuple `(tournament_id, tournament_group, age_group_id)` — e.g. "Bracket A · U14". One bracket can span multiple age groups, so the user follows a specific age group within it.

## What this does

- **Follow a bracket** → push notification at **fulltime** (match scored + completed) for every match in that bracket/age-group.
- **Fulltime only** — no goal/kickoff/halftime pings.
- **Respects existing per-user notification preferences** (the `fulltime` toggle) — same gating as team-follow.
- **No club-follow** — following a club's team is already covered by the existing team-follow feature.

## Why it's small

The whole notification stack already exists for team-follow. Tournament match scoring already fires the `fulltime` event via the shared `_maybe_notify_final_score` helper. Only a parallel follow type was needed, mirroring `user_team_follows` end-to-end. The dispatcher fan-out now unions team-follow + bracket-follow subscriptions, deduped by subscription id (so team+bracket double-follow = one push per device).

## Changes

- **Migration** `user_bracket_follows` — table + RLS (mirrors `user_team_follows`) + fan-out index
- **`dao/bracket_follow_dao.py`** — follow/unfollow/list + `list_subscriptions_for_bracket` (same two-query fan-out as team-follow)
- **`notifications/dispatcher.py`** — fulltime-only bracket fan-out branch + dedup
- **`api/push.py`** — `POST`/`GET`/`DELETE /api/users/me/bracket-follows`
- **Frontend** — `useBracketFollows` composable + a Follow/Unfollow toggle in the `TournamentMatchCenter` bracket view (gated on signed-in + push enabled)

## Tests

- `test_bracket_follow_delivery.py` — fulltime pushes to bracket follower + logs; goal event stays silent; `fulltime` pref off suppresses; team+bracket dedupes to one push
- `test_bracket_follow_dao.py` — follow idempotency, unfollow, exact-bracket filtering
- `useBracketFollows.spec.js` — composable follow/unfollow/toggle + DELETE query-param shape

All green locally: backend 7 new pass + existing push/dispatch 15 pass (no regression); frontend 12 pass; ruff + eslint clean.

## Deploy note

Production needs the migration applied before the tournament weekend:
`./scripts/db_tools.sh migrate prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes SB-84