### PR TITLE
feat(api): is_test prod test partition — hide TSC test data from real users (SB-85)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -20,11 +20,13 @@ from api.push import router as push_router
 from api.webhooks_email import router as webhooks_email_router
 from auth import (
     AuthManager,
+    get_current_user_optional,
     get_current_user_required,
     require_admin,
     require_admin_or_service_account,
     require_match_management_permission,
     require_team_manager_or_admin,
+    viewer_sees_test_content,
 )
 from constants import PLAYER_POSITIONS
 from csrf_protection import provide_csrf_token
@@ -4250,10 +4252,17 @@ async def delete_season(season_id: int, current_user: dict[str, Any] = Depends(r
 
 # Leagues CRUD
 @app.get("/api/leagues")
-async def get_leagues():
-    """Get all leagues (public access)."""
+async def get_leagues(
+    current_user: dict[str, Any] | None = Depends(get_current_user_optional),
+):
+    """Get all leagues (public access).
+
+    Test leagues (SB-85) are hidden from anonymous + real users; admins and
+    test users see them.
+    """
     try:
-        leagues = league_dao.get_all_leagues()
+        include_test = viewer_sees_test_content(current_user)
+        leagues = league_dao.get_all_leagues(include_test=include_test)
         return leagues
     except Exception as e:
         logger.error(f"Error fetching leagues: {e!s}", exc_info=True)
@@ -6629,10 +6638,17 @@ class TournamentMatchUpdate(BaseModel):
 
 
 @app.get("/api/tournaments")
-async def get_tournaments():
-    """List all active tournaments (public)."""
+async def get_tournaments(
+    current_user: dict[str, Any] | None = Depends(get_current_user_optional),
+):
+    """List all active tournaments (public).
+
+    Test tournaments (SB-85) are hidden from anonymous + real users; admins and
+    test users see them.
+    """
     try:
-        return tournament_dao.get_active_tournaments()
+        include_test = viewer_sees_test_content(current_user)
+        return tournament_dao.get_active_tournaments(include_test=include_test)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -155,6 +155,7 @@ class AuthManager:
                 "team_id": profile.get("team_id"),
                 "club_id": profile.get("club_id"),  # For club managers
                 "display_name": profile.get("display_name"),
+                "is_test": profile.get("is_test", False),  # SB-85 test partition
             }
 
         except jwt.ExpiredSignatureError:
@@ -405,6 +406,16 @@ def get_current_user_required(
     from app import auth_manager
 
     return auth_manager.get_current_user(credentials)
+
+
+def viewer_sees_test_content(user: dict[str, Any] | None) -> bool:
+    """Whether a viewer may see is_test content (SB-85 prod test partition).
+
+    True for admins and flagged test users; False for anonymous and real users.
+    Used by the public list endpoints to hide the TSC test world from real
+    users while keeping it visible to test users + admins.
+    """
+    return bool(user) and (user.get("role") == "admin" or bool(user.get("is_test")))
 
 
 def require_admin(

--- a/backend/dao/league_dao.py
+++ b/backend/dao/league_dao.py
@@ -23,11 +23,19 @@ class LeagueDAO(BaseDAO):
 
     # === League Query Methods ===
 
-    @dao_cache("leagues:all")
-    def get_all_leagues(self) -> list[dict]:
-        """Get all leagues ordered by name."""
+    @dao_cache("leagues:all:{include_test}")
+    def get_all_leagues(self, include_test: bool = False) -> list[dict]:
+        """Get all leagues ordered by name.
+
+        include_test gates the SB-85 test partition: real/anonymous viewers pass
+        False (test leagues hidden); admins + test users pass True. The cache key
+        varies by include_test so the two audiences never share a cached result.
+        """
         try:
-            response = self.client.table("leagues").select("*").order("name").execute()
+            query = self.client.table("leagues").select("*")
+            if not include_test:
+                query = query.eq("is_test", False)
+            response = query.order("name").execute()
             return response.data
         except Exception:
             logger.exception("Error querying leagues")

--- a/backend/dao/tournament_dao.py
+++ b/backend/dao/tournament_dao.py
@@ -104,17 +104,22 @@ class TournamentDAO(BaseDAO):
             rows = [{"tournament_id": tournament_id, "age_group_id": ag_id} for ag_id in age_group_ids]
             self.client.table("tournament_age_groups").insert(rows).execute()
 
-    @dao_cache("tournaments:active")
-    def get_active_tournaments(self) -> list[dict]:
-        """Return all active tournaments ordered by start date descending."""
+    @dao_cache("tournaments:active:{include_test}")
+    def get_active_tournaments(self, include_test: bool = False) -> list[dict]:
+        """Return all active tournaments ordered by start date descending.
+
+        include_test gates the SB-85 test partition: real/anonymous viewers pass
+        False (test tournaments hidden); admins + test users pass True.
+        """
         try:
-            response = (
+            query = (
                 self.client.table("tournaments")
                 .select("id, name, start_date, end_date, location, description, is_active, logo_url")
                 .eq("is_active", True)
-                .order("start_date", desc=True)
-                .execute()
             )
+            if not include_test:
+                query = query.eq("is_test", False)
+            response = query.order("start_date", desc=True).execute()
             data = self._attach_age_groups(response.data or [])
             return self._attach_match_counts(data)
         except Exception:

--- a/backend/tests/integration/test_test_partition_visibility.py
+++ b/backend/tests/integration/test_test_partition_visibility.py
@@ -1,0 +1,149 @@
+"""Prod test-partition visibility (SB-85, Phase 1).
+
+Verifies the is_test partition on the two public list endpoints:
+  GET /api/tournaments
+  GET /api/leagues
+
+A test-flagged league / tournament must be hidden from anonymous and real
+(non-test, non-admin) viewers, and visible to test users + admins.
+
+The viewer is controlled by overriding get_current_user_optional (the same
+dependency the endpoints depend on) — no real tokens needed. The DB rows are
+real (seeded with is_test) so the DAO's WHERE filter is exercised for real.
+
+Requires local Supabase. Skips cleanly if unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+from auth import get_current_user_optional
+from dao.base_dao import clear_cache
+
+pytestmark = [pytest.mark.integration, pytest.mark.backend, pytest.mark.database]
+
+
+def _admin_client():
+    from supabase import create_client
+
+    url = os.getenv("SUPABASE_URL", "http://127.0.0.1:54321")
+    if not ("127.0.0.1" in url or "localhost" in url):
+        pytest.skip(f"Refusing to run destructive test against non-local Supabase: {url}")
+    key = os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not key:
+        pytest.skip("SUPABASE_SERVICE_KEY not set — cannot run test-partition test")
+    return create_client(url, key)
+
+
+def _unique(label: str) -> str:
+    return f"{label}-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def world():
+    """Seed a test-flagged league + tournament and a real (control) pair."""
+    admin = _admin_client()
+    try:
+        admin.table("leagues").select("id").limit(1).execute()
+    except Exception:  # pragma: no cover - infra guard
+        pytest.skip("Local Supabase not reachable")
+
+    test_league = admin.table("leagues").insert(
+        {"name": _unique("ZZ Test League"), "is_active": True, "is_test": True}
+    ).execute().data[0]
+    real_league = admin.table("leagues").insert(
+        {"name": _unique("ZZ Real League"), "is_active": True, "is_test": False}
+    ).execute().data[0]
+
+    today = datetime.now(UTC).date().isoformat()
+    test_tourney = admin.table("tournaments").insert(
+        {"name": _unique("ZZ Test Cup"), "start_date": today, "is_active": True, "is_test": True}
+    ).execute().data[0]
+    real_tourney = admin.table("tournaments").insert(
+        {"name": _unique("ZZ Real Cup"), "start_date": today, "is_active": True, "is_test": False}
+    ).execute().data[0]
+
+    # Raw inserts above bypass the DAO's invalidates_cache, so stale cached
+    # lists could hide the just-seeded rows. Bust both.
+    clear_cache("mt:dao:leagues:*")
+    clear_cache("mt:dao:tournaments:*")
+
+    yield {
+        "test_league": test_league,
+        "real_league": real_league,
+        "test_tourney": test_tourney,
+        "real_tourney": real_tourney,
+    }
+
+    def _safe(fn):
+        try:
+            fn()
+        except Exception:  # pragma: no cover
+            pass
+
+    _safe(lambda: admin.table("tournaments").delete().eq("id", test_tourney["id"]).execute())
+    _safe(lambda: admin.table("tournaments").delete().eq("id", real_tourney["id"]).execute())
+    _safe(lambda: admin.table("leagues").delete().eq("id", test_league["id"]).execute())
+    _safe(lambda: admin.table("leagues").delete().eq("id", real_league["id"]).execute())
+
+
+# Viewer fixtures injected via dependency override.
+_ANON = None
+_REAL_FAN = {"user_id": "real", "role": "team-fan", "is_test": False}
+_TEST_USER = {"user_id": "tester", "role": "team-fan", "is_test": True}
+_ADMIN = {"user_id": "admin", "role": "admin", "is_test": False}
+
+
+def _as(viewer):
+    """Context: run the TestClient with get_current_user_optional → viewer."""
+    app.dependency_overrides[get_current_user_optional] = lambda: viewer
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def _ids(rows):
+    return {r["id"] for r in rows}
+
+
+class TestTournamentPartition:
+    def test_anonymous_and_real_users_dont_see_test_tournament(self, world):
+        for viewer in (_ANON, _REAL_FAN):
+            with _as(viewer) as client:
+                ids = _ids(client.get("/api/tournaments").json())
+            assert world["real_tourney"]["id"] in ids
+            assert world["test_tourney"]["id"] not in ids, f"viewer={viewer}"
+
+    def test_test_user_and_admin_see_test_tournament(self, world):
+        for viewer in (_TEST_USER, _ADMIN):
+            with _as(viewer) as client:
+                ids = _ids(client.get("/api/tournaments").json())
+            assert world["real_tourney"]["id"] in ids
+            assert world["test_tourney"]["id"] in ids, f"viewer={viewer}"
+
+
+class TestLeaguePartition:
+    def test_anonymous_and_real_users_dont_see_test_league(self, world):
+        for viewer in (_ANON, _REAL_FAN):
+            with _as(viewer) as client:
+                ids = _ids(client.get("/api/leagues").json())
+            assert world["real_league"]["id"] in ids
+            assert world["test_league"]["id"] not in ids, f"viewer={viewer}"
+
+    def test_test_user_and_admin_see_test_league(self, world):
+        for viewer in (_TEST_USER, _ADMIN):
+            with _as(viewer) as client:
+                ids = _ids(client.get("/api/leagues").json())
+            assert world["real_league"]["id"] in ids
+            assert world["test_league"]["id"] in ids, f"viewer={viewer}"

--- a/scripts/mark_tsc_test_data.sql
+++ b/scripts/mark_tsc_test_data.sql
@@ -1,0 +1,21 @@
+-- Tag the TSC test world as is_test (SB-85, Phase 1).
+--
+-- Re-runnable / idempotent. Run on local after the is_test migration, and on
+-- prod as a deploy step (like a migration):
+--   local: psql "$LOCAL_DB_URL" -f scripts/mark_tsc_test_data.sql
+--   prod:  psql "$PROD_DB_URL"  -f scripts/mark_tsc_test_data.sql
+--
+-- Identifies the TSC world by name/username rather than hard-coded ids so it
+-- works across environments (local ids differ from prod). Prod ids for
+-- reference: league 90, club 93, tournament 7.
+
+UPDATE public.leagues       SET is_test = true WHERE name = 'TSC League 1';
+UPDATE public.clubs         SET is_test = true WHERE name ILIKE 'TSC%';
+UPDATE public.tournaments   SET is_test = true WHERE name = 'TSC Bracket Test Cup';
+UPDATE public.user_profiles SET is_test = true WHERE username LIKE 'tsc\_%';
+
+-- Report what is now flagged.
+SELECT 'leagues'       AS entity, count(*) FILTER (WHERE is_test) AS test_rows FROM public.leagues
+UNION ALL SELECT 'clubs',         count(*) FILTER (WHERE is_test) FROM public.clubs
+UNION ALL SELECT 'tournaments',   count(*) FILTER (WHERE is_test) FROM public.tournaments
+UNION ALL SELECT 'user_profiles', count(*) FILTER (WHERE is_test) FROM public.user_profiles;

--- a/supabase-local/migrations/20260601100000_add_is_test_partition.sql
+++ b/supabase-local/migrations/20260601100000_add_is_test_partition.sql
@@ -1,0 +1,30 @@
+-- Prod test partition (SB-85, Phase 1).
+--
+-- Adds an is_test flag to the top-level entities so a self-contained test world
+-- (the TSC league/clubs/teams/tournaments + tsc_* users) can be hidden from real
+-- users while staying visible to test users and admins.
+--
+-- Visibility rule (enforced in the API, not the DB): a viewer sees test content
+-- iff viewer.is_test OR viewer.role = 'admin'. Default false → real data and real
+-- users are completely unaffected.
+--
+-- Phase 1 filters the two list endpoints (/api/tournaments, /api/leagues). The
+-- columns on clubs is for Phase 2 (matches/search) but added now so tagging is
+-- done once.
+
+ALTER TABLE public.leagues       ADD COLUMN is_test boolean NOT NULL DEFAULT false;
+ALTER TABLE public.clubs         ADD COLUMN is_test boolean NOT NULL DEFAULT false;
+ALTER TABLE public.tournaments   ADD COLUMN is_test boolean NOT NULL DEFAULT false;
+ALTER TABLE public.user_profiles ADD COLUMN is_test boolean NOT NULL DEFAULT false;
+
+-- Partial indexes: the filtered queries only ever care about the (small) test set
+-- or exclude it; a partial index on the rare true rows keeps it cheap.
+CREATE INDEX idx_tournaments_is_test ON public.tournaments(is_test) WHERE is_test;
+CREATE INDEX idx_leagues_is_test     ON public.leagues(is_test)     WHERE is_test;
+
+COMMENT ON COLUMN public.tournaments.is_test IS
+    'Test-only tournament; hidden from non-test, non-admin viewers (SB-85).';
+COMMENT ON COLUMN public.leagues.is_test IS
+    'Test-only league; hidden from non-test, non-admin viewers (SB-85).';
+COMMENT ON COLUMN public.user_profiles.is_test IS
+    'Test user; may see is_test content (SB-85).';


### PR DESCRIPTION
## Context

Real Homegrown/Academy users currently see **TSC test data** — the TSC league, its tournaments ("TSC Bracket Test Cup"), etc. — because `GET /api/tournaments` and `GET /api/leagues` are global/public with no audience scoping. We want a **prod test partition**: everything TSC is test-only, hidden from real users, but visible to test users + admins so we can validate features on prod.

Implements **SB-85 Phase 1**.

## Approach — one `is_test` boolean + one rule

> A viewer sees test content **iff** `viewer.is_test` OR `viewer.role == 'admin'`. Default `is_test=false` → real data + real users unaffected.

No per-league allowlists.

## Changes

- **Migration** `20260601100000_add_is_test_partition.sql`: `is_test boolean NOT NULL DEFAULT false` on `leagues`, `clubs`, `tournaments`, `user_profiles` + partial indexes on the (rare) test rows.
- **`scripts/mark_tsc_test_data.sql`**: re-runnable tagging of the TSC world (league, clubs, tournament, `tsc_*` users), keyed by name/username so it works across local + prod.
- **`auth.py`**: surface `is_test` on the resolved user dict; add `viewer_sees_test_content(user)` helper.
- **`GET /api/tournaments` + `GET /api/leagues`**: add optional auth + filter via the helper. Filtering `/api/leagues` centrally cleans every standings/matches/leaderboard selector. Admins + test users keep full visibility.
- **DAO**: `get_active_tournaments` / `get_all_leagues` gain `include_test`. **Cache keys now vary by `include_test`** so the two audiences never share a cached result — caught `get_active_tournaments` serving an unfiltered cached list under a static key.

## Out of scope (Phase 2)
- Matches list + search filtering.
- Admin UI toggle for `is_test`.

## Tests
`test_test_partition_visibility.py` — visibility matrix for both endpoints across anonymous / real team-fan / test user / admin (viewer injected via `get_current_user_optional` override; rows seeded real with `is_test`). 4 pass. Existing push/bracket/notification suites: 17 pass, no regression. ruff clean.

## Deploy
1. Apply migration to prod: `./scripts/db_tools.sh migrate prod`
2. Tag prod TSC data: run `scripts/mark_tsc_test_data.sql` against prod.

Fixes SB-85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
