### PR TITLE
fix(scripts): tag test clubs by test-league membership, not name (SB-85)

### DIFF
--- a/scripts/mark_tsc_test_data.sql
+++ b/scripts/mark_tsc_test_data.sql
@@ -10,9 +10,20 @@
 -- reference: league 90, club 93, tournament 7.
 
 UPDATE public.leagues       SET is_test = true WHERE name = 'TSC League 1';
-UPDATE public.clubs         SET is_test = true WHERE name ILIKE 'TSC%';
 UPDATE public.tournaments   SET is_test = true WHERE name = 'TSC Bracket Test Cup';
 UPDATE public.user_profiles SET is_test = true WHERE username LIKE 'tsc\_%';
+
+-- Clubs: derive from test-league membership rather than matching the club name.
+-- The TSC club is "Toms Soccer Club" (TSC = initials, name spelled out), so a
+-- name match like ILIKE 'TSC%' misses it. Any club fielding a team in a test
+-- league is itself test. Run the leagues UPDATE above first so is_test is set.
+UPDATE public.clubs SET is_test = true
+WHERE id IN (
+    SELECT DISTINCT t.club_id
+    FROM public.teams t
+    JOIN public.leagues l ON l.id = t.league_id
+    WHERE l.is_test AND t.club_id IS NOT NULL
+);
 
 -- Report what is now flagged.
 SELECT 'leagues'       AS entity, count(*) FILTER (WHERE is_test) AS test_rows FROM public.leagues


### PR DESCRIPTION
## Context

When tagging the TSC test world on prod (SB-85 Phase 1 deploy), `scripts/mark_tsc_test_data.sql` reported **clubs = 0** — the TSC club is named **"Toms Soccer Club"** (TSC = initials, spelled out), so the `ILIKE 'TSC%'` name match missed it.

## Fix

Derive test clubs from **test-league membership** instead of a name match: any club fielding a team in an `is_test` league is itself test. Robust across environments and resilient to naming. The leagues `UPDATE` runs before the clubs derivation so `is_test` is set first.

```sql
UPDATE public.clubs SET is_test = true
WHERE id IN (
    SELECT DISTINCT t.club_id FROM public.teams t
    JOIN public.leagues l ON l.id = t.league_id
    WHERE l.is_test AND t.club_id IS NOT NULL
);
```

Validated on local: clubs now tagged 1 (was 0). Idempotent.

Prod already corrected via a one-off `UPDATE` (club 93 "Toms Soccer Club" now `is_test=true`); this makes the committed script correct for future runs.

Relates to SB-85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
