### PR TITLE
fix(auth): don't drop a valid session on a transient refresh failure

### DIFF
--- a/frontend/src/__tests__/stores/auth.silent-refresh.spec.js
+++ b/frontend/src/__tests__/stores/auth.silent-refresh.spec.js
@@ -144,6 +144,47 @@ describe('auth store — silent refresh (SB-78)', () => {
     });
   });
 
+  describe('transient vs genuine refresh failures', () => {
+    it('preserves the refresh token when the network is down (fetch throws)', async () => {
+      global.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+      localStorage.setItem('refresh_token', 'r1');
+      localStorage.setItem('auth_token', 't1');
+
+      const result = await store.refreshSession();
+
+      expect(result.success).toBe(false);
+      expect(result.transient).toBe(true);
+      // The still-valid token must survive a connectivity blip (wake-from-sleep).
+      expect(localStorage.getItem('refresh_token')).toBe('r1');
+      expect(localStorage.getItem('auth_token')).toBe('t1');
+    });
+
+    it('preserves the refresh token on a 5xx server hiccup', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 503 });
+      localStorage.setItem('refresh_token', 'r1');
+
+      const result = await store.refreshSession();
+
+      expect(result.success).toBe(false);
+      expect(result.transient).toBe(true);
+      expect(localStorage.getItem('refresh_token')).toBe('r1');
+    });
+
+    it('clears auth state when the refresh token is genuinely rejected (401)', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 401 });
+      localStorage.setItem('refresh_token', 'r1');
+      localStorage.setItem('auth_token', 't1');
+
+      const result = await store.refreshSession();
+
+      expect(result.success).toBe(false);
+      expect(result.transient).toBe(false);
+      expect(localStorage.getItem('refresh_token')).toBeNull();
+      expect(localStorage.getItem('auth_token')).toBeNull();
+      expect(store.state.session).toBeNull();
+    });
+  });
+
   describe('proactive refresh timer', () => {
     it('refreshes the token when it is about to expire', async () => {
       vi.useFakeTimers();

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -656,8 +656,14 @@ export const useAuthStore = () => {
               }
             }
           }
+          if (refreshResult.transient) {
+            // Server unreachable on boot (offline / waking). Keep the
+            // still-valid tokens so a later reload restores the session rather
+            // than forcing a needless re-login.
+            return;
+          }
         }
-        // Refresh failed or no refresh token, clear storage
+        // Genuine auth failure or no refresh token — clear storage.
         localStorage.clear();
       } else {
         // Other error, clear storage
@@ -750,8 +756,15 @@ export const useAuthStore = () => {
           );
         }
       }
-      // Refresh failed or retry failed, force logout
       recordHttpRequest(endpoint, method, 401, duration);
+      // A transient refresh failure (network/5xx) leaves the refresh token
+      // intact — don't destroy the session over a blip; surface a retryable
+      // error so the caller can try again once connectivity returns.
+      if (refreshResult.transient) {
+        throw new Error('Could not reach the server. Please try again.');
+      }
+      // Genuine auth failure — refreshSession already cleared state; finish the
+      // logout for CSRF/Faro cleanup, then send the user back to login.
       await logout();
       throw new Error('Session expired. Please log in again.');
     }
@@ -796,6 +809,25 @@ export const useAuthStore = () => {
     return timeUntilExpiry < 5 * 60 * 1000;
   };
 
+  // Hard-clear all auth state. Only ever called on a *genuine* auth failure
+  // (missing or server-rejected refresh token) — never on a transient
+  // network/server blip, which would otherwise throw away a still-valid token.
+  const clearAuthState = () => {
+    setUser(null);
+    setSession(null);
+    setProfile(null);
+    localStorage.clear();
+  };
+
+  // Refresh the access token. Returns:
+  //   { success: true }
+  //   { success: false, transient: true }  — network down / 5xx / 429; the
+  //       refresh token is untouched so a later attempt can recover.
+  //   { success: false, transient: false } — refresh token genuinely rejected;
+  //       auth state is cleared and the user must log in again.
+  // The transient/genuine split exists because the proactive timer (and resume
+  // listeners) can fire on wake-from-sleep *before* connectivity is restored:
+  // a thrown fetch must NOT be mistaken for "your session is invalid". (SB-78)
   const refreshSession = async () => {
     // Single-flight: with refresh-token rotation enabled, two concurrent
     // refreshes would send the same token twice — the second send uses an
@@ -807,37 +839,61 @@ export const useAuthStore = () => {
       try {
         const refreshToken = localStorage.getItem('refresh_token');
         if (!refreshToken) {
+          // Nothing to refresh with — genuinely unauthenticated.
+          clearAuthState();
           recordSessionRefresh(false);
-          throw new Error('No refresh token');
+          return {
+            success: false,
+            transient: false,
+            error: 'No refresh token',
+          };
         }
 
-        const response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...getTraceHeaders(),
-          },
-          body: JSON.stringify({ refresh_token: refreshToken }),
-        });
-
-        if (!response.ok) {
+        let response;
+        try {
+          response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...getTraceHeaders(),
+            },
+            body: JSON.stringify({ refresh_token: refreshToken }),
+          });
+        } catch (networkError) {
+          // No response at all — almost always transient connectivity (e.g. the
+          // proactive timer firing on wake-from-sleep before wifi reconnects).
+          // Keep the still-valid refresh token; the next attempt recovers.
           recordSessionRefresh(false);
-          throw new Error('Token refresh failed');
+          return {
+            success: false,
+            transient: true,
+            error: networkError.message,
+          };
         }
 
-        const data = await response.json();
-        setSession(data.session);
+        if (response.ok) {
+          const data = await response.json();
+          setSession(data.session);
+          recordSessionRefresh(true);
+          return { success: true };
+        }
 
-        recordSessionRefresh(true);
-        return { success: true };
-      } catch (error) {
-        // Refresh failed, force logout
-        setUser(null);
-        setSession(null);
-        setProfile(null);
-        localStorage.clear();
         recordSessionRefresh(false);
-        return { success: false, error: error.message };
+        // Only a real auth rejection means the refresh token is dead. 5xx / 429
+        // are server-side hiccups, not the token's fault — retry later.
+        if (response.status === 401 || response.status === 403) {
+          clearAuthState();
+          return {
+            success: false,
+            transient: false,
+            error: 'Refresh token rejected',
+          };
+        }
+        return {
+          success: false,
+          transient: true,
+          error: `Token refresh failed: ${response.status}`,
+        };
       } finally {
         refreshInFlight = null;
       }


### PR DESCRIPTION
## Problem

Returning to a sleeping machine (e.g. the Mac mini) kicks you back to the login screen, despite the SB-78 "30-day idle" silent refresh.

## Root cause

`refreshSession()` treated **any** failure as a dead session. Its catch block ran `localStorage.clear()` and nulled the session on a thrown `fetch` or any non-OK response.

On wake-from-sleep, the proactive 60s timer (or a resume listener) fires `refreshSession()` **before wifi reconnects** → `fetch` throws → catch → a perfectly valid refresh token gets nuked → login screen.

Verified against prod:
- `auth.sessions.not_after` is `null` → no session timebox/inactivity cap.
- Refresh rotation works globally (362 rotated children) → endpoint is fine.

So the idle logouts were purely client-side over-eager clearing, not a server/Supabase setting.

## Fix

Split refresh outcomes:

| Outcome | Result | Token |
|---|---|---|
| network error / 5xx / 429 | `{ transient: true }` | **kept** — next attempt recovers |
| 401 / 403 (rejected) or no token | `{ transient: false }` | cleared, force re-login |

Callers updated:
- `apiCall()` — surfaces a retryable error instead of logging out on a transient failure.
- `initialize()` — keeps stored tokens on a transient boot failure rather than clearing them.

## Tests

Adds regression coverage for network-down (`fetch` throws), 5xx, and genuine-401 paths. Full `auth.silent-refresh.spec.js` suite: 12/12 pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
