### PR TITLE
feat(notifications): bracket follows on profile + push-disabled hint

### DIFF
--- a/frontend/src/__tests__/components/NotificationsCard.spec.js
+++ b/frontend/src/__tests__/components/NotificationsCard.spec.js
@@ -36,6 +36,19 @@ vi.mock('@/composables/useTeamFollows', () => ({
   }),
 }));
 
+// Stub useBracketFollows. Tests populate `mockBracketFollows` to verify the
+// "Brackets you follow" section + unfollow wiring.
+let mockBracketFollows;
+let unfollowBracketMock;
+vi.mock('@/composables/useBracketFollows', () => ({
+  useBracketFollows: () => ({
+    follows: computed(() => mockBracketFollows.value),
+    loading: ref(false),
+    ensureLoaded: vi.fn().mockResolvedValue(),
+    unfollow: unfollowBracketMock,
+  }),
+}));
+
 // Stub useNotificationPreferences with a controllable mock.
 let mockPrefs;
 let setPreferenceMock;
@@ -72,6 +85,8 @@ beforeEach(() => {
   setCardsMock = vi.fn().mockResolvedValue({ success: true });
   ensureLoadedMock = vi.fn().mockResolvedValue();
   mockFollows = ref([]);
+  mockBracketFollows = ref([]);
+  unfollowBracketMock = vi.fn().mockResolvedValue({ success: true });
 });
 
 describe('NotificationsCard preferences section (SB-57)', () => {
@@ -273,5 +288,59 @@ describe('NotificationsCard "Teams you follow" labels (SB-65)', () => {
 
     const item = wrapper.find('[data-testid="follow-item-7"]');
     expect(item.find('.follow-club').text()).toBe('Bayside FC');
+  });
+});
+
+describe('NotificationsCard "Brackets you follow" section', () => {
+  it('shows the empty state when no bracket follows', async () => {
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Brackets you follow');
+    expect(wrapper.text()).toContain(
+      "aren't following any tournament brackets"
+    );
+  });
+
+  it('renders a row labeled "tournament · bracket · age"', async () => {
+    mockBracketFollows.value = [
+      {
+        tournament_id: 7,
+        tournament_group: 'Bracket A',
+        age_group_id: 2,
+        tournament: { id: 7, name: 'TSC Bracket Test Cup' },
+        age_group: { id: 2, name: 'U14' },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const item = wrapper.find('[data-testid="bracket-follow-item-7-2"]');
+    expect(item.exists()).toBe(true);
+    expect(item.find('.follow-team').text()).toBe(
+      'TSC Bracket Test Cup · Bracket A · U14'
+    );
+  });
+
+  it('clicking Unfollow calls unfollow with the composite key', async () => {
+    mockBracketFollows.value = [
+      {
+        tournament_id: 7,
+        tournament_group: 'Bracket A',
+        age_group_id: 2,
+        tournament: { id: 7, name: 'TSC Bracket Test Cup' },
+        age_group: { id: 2, name: 'U14' },
+      },
+    ];
+
+    const wrapper = mount(NotificationsCard);
+    await flushPromises();
+
+    const item = wrapper.find('[data-testid="bracket-follow-item-7-2"]');
+    await item.find('.revoke-button').trigger('click');
+    await flushPromises();
+
+    expect(unfollowBracketMock).toHaveBeenCalledWith(7, 'Bracket A', 2);
   });
 });

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -783,6 +783,13 @@
               <span v-if="isBracketFollowed">✓ Following — Unfollow</span>
               <span v-else>🔔 Follow this bracket</span>
             </button>
+            <span
+              v-else-if="bracketNeedsPush"
+              class="sm:ml-auto text-xs text-gray-500"
+              data-testid="bracket-follow-push-hint"
+            >
+              🔔 Enable notifications in your profile to follow this bracket.
+            </span>
           </div>
 
           <TournamentBracket
@@ -862,6 +869,13 @@
               >
               <span v-else>🔔 Follow this bracket</span>
             </button>
+            <span
+              v-else-if="standingsNeedsPush"
+              class="sm:ml-auto text-xs text-gray-500"
+              data-testid="standings-bracket-follow-push-hint"
+            >
+              🔔 Enable notifications in your profile to follow this bracket.
+            </span>
           </div>
 
           <TournamentStandings :matches="standingsMatches" />
@@ -1223,13 +1237,25 @@ export default {
           ageRef.value
         );
       };
-      return { can, isFollowed, toggle };
+      // A bracket is selected and the user is signed in, but push isn't on yet —
+      // so `can` is false and the button is hidden. Surface a hint instead of
+      // showing nothing, pointing them at the profile to enable notifications.
+      const needsPush = computed(
+        () =>
+          authStore.isAuthenticated.value &&
+          !pushEnabled.value &&
+          selectedId.value != null &&
+          groupRef.value != null &&
+          ageRef.value != null
+      );
+      return { can, isFollowed, toggle, needsPush };
     };
 
     const bracketFollow = makeBracketFollow(bracketGroup, bracketAgeGroupId);
     const canFollowBracket = bracketFollow.can;
     const isBracketFollowed = bracketFollow.isFollowed;
     const toggleBracketFollow = bracketFollow.toggle;
+    const bracketNeedsPush = bracketFollow.needsPush;
 
     const standingsFollow = makeBracketFollow(
       standingsGroup,
@@ -1238,6 +1264,7 @@ export default {
     const canFollowStandingsBracket = standingsFollow.can;
     const isStandingsBracketFollowed = standingsFollow.isFollowed;
     const toggleStandingsBracketFollow = standingsFollow.toggle;
+    const standingsNeedsPush = standingsFollow.needsPush;
 
     // ── standings-mode computed state ──
     // Same pattern as bracket-mode, but keyed off group_stage matches
@@ -1329,9 +1356,11 @@ export default {
       canFollowBracket,
       isBracketFollowed,
       toggleBracketFollow,
+      bracketNeedsPush,
       canFollowStandingsBracket,
       isStandingsBracketFollowed,
       toggleStandingsBracketFollow,
+      standingsNeedsPush,
       tournaments,
       loading,
       error,

--- a/frontend/src/components/notifications/NotificationsCard.vue
+++ b/frontend/src/components/notifications/NotificationsCard.vue
@@ -190,6 +190,36 @@
         </li>
       </ul>
     </div>
+
+    <!-- Followed brackets (tournament + group + age group) -->
+    <div v-if="isSupported" class="follows-section">
+      <h4>Brackets you follow</h4>
+      <p v-if="!bracketFollows.length" class="follows-empty">
+        You aren't following any tournament brackets yet. Open a tournament's
+        Bracket or Standings view and tap "Follow this bracket" to get a push at
+        full time for every match in it.
+      </p>
+      <ul v-else class="follows-list">
+        <li
+          v-for="b in bracketFollows"
+          :key="`${b.tournament_id}:${b.tournament_group}:${b.age_group_id}`"
+          class="follow-item"
+          :data-testid="`bracket-follow-item-${b.tournament_id}-${b.age_group_id}`"
+        >
+          <div class="follow-item-main">
+            <span class="follow-team">{{ bracketPrimaryLabel(b) }}</span>
+            <span class="follow-item-sub">Full-time scores only</span>
+          </div>
+          <button
+            class="revoke-button"
+            :disabled="bracketLoading"
+            @click="onUnfollowBracket(b)"
+          >
+            Unfollow
+          </button>
+        </li>
+      </ul>
+    </div>
   </section>
 </template>
 
@@ -197,6 +227,7 @@
 import { ref, onMounted } from 'vue';
 import { usePushNotifications } from '../../composables/usePushNotifications';
 import { useTeamFollows } from '../../composables/useTeamFollows';
+import { useBracketFollows } from '../../composables/useBracketFollows';
 import { useNotificationPreferences } from '../../composables/useNotificationPreferences';
 
 const {
@@ -214,6 +245,15 @@ const {
 
 // Shared singleton (SB-55): same `follows` reactive list every FollowButton mutates.
 const { follows, refresh: refreshFollows } = useTeamFollows();
+
+// Bracket follows (tournament + group + age group). Same singleton the
+// tournament-page toggle mutates, so unfollowing here updates that toggle too.
+const {
+  follows: bracketFollows,
+  loading: bracketLoading,
+  ensureLoaded: ensureBracketFollowsLoaded,
+  unfollow: unfollowBracket,
+} = useBracketFollows();
 
 // Per-event preferences (SB-57).
 const {
@@ -234,9 +274,23 @@ async function refresh() {
   const [subs] = await Promise.all([
     listSubscriptions(),
     refreshFollows(),
+    ensureBracketFollowsLoaded(),
     ensurePreferencesLoaded(),
   ]);
   subscriptions.value = subs;
+}
+
+// "2026 National Academy Championships · Bracket A · U14"
+function bracketPrimaryLabel(b) {
+  const tourney = b.tournament?.name || `Tournament #${b.tournament_id}`;
+  const age = b.age_group?.name;
+  const parts = [tourney, b.tournament_group];
+  if (age) parts.push(age);
+  return parts.join(' · ');
+}
+
+async function onUnfollowBracket(b) {
+  await unfollowBracket(b.tournament_id, b.tournament_group, b.age_group_id);
 }
 
 async function onTogglePref(eventType, enabled) {


### PR DESCRIPTION
## Context

Completes the management UX for the follow-tournament feature (bracket follows). The core feature shipped in #430/#431 (follow a bracket → fulltime push), but two gaps remained: you couldn't **see or unfollow** your bracket follows from the profile, and the follow toggle silently **disappeared when push was disabled** with no explanation.

## Changes

### Profile — "Brackets you follow" (`NotificationsCard.vue`)
New section mirroring "Teams you follow": lists each bracket follow as **tournament · bracket · age** (e.g. "TSC Bracket Test Cup · Bracket A · U14") with a per-row **Unfollow** button. Sources the existing `GET /api/users/me/bracket-follows`; uses the same `useBracketFollows` singleton the tournament-page toggle mutates, so unfollowing here updates that toggle too. Includes an empty state.

### Push-disabled hint (`TournamentMatchCenter.vue`)
The follow toggle is gated on push being enabled, so it was hidden entirely for signed-in users who hadn't enabled notifications — looked like the feature was missing. Now, when a bracket is selected but push is off, both the Bracket and Standings views show a hint: *"🔔 Enable notifications in your profile to follow this bracket."* Implemented via a `needsPush` computed on the existing `makeBracketFollow` factory (no duplication).

## Tests
`NotificationsCard.spec.js`: empty state, row label, and unfollow-click wiring for the new section. Affected suites: NotificationsCard (13) + TournamentMatchCenter (5) + useBracketFollows (7) all pass. eslint clean.

Completes SB-84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
