### PR TITLE
ci: PR-label gate for MAJOR.MINOR.PATCH version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,12 +195,40 @@ jobs:
       - name: Pull latest changes
         run: |
           git pull origin main
+      - name: Bump VERSION from PR label
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          # PR label gate for MAJOR.MINOR.PATCH (the .BUILD suffix is the CI
+          # run number, bumped on every deploy regardless). Label one of:
+          #   version:major | version:minor | version:patch | version:none
+          # No label defaults to patch so the version always advances on a
+          # real merge; version:none opts out (trivial/infra/docs).
+          PR=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -z "$PR" ]; then
+            echo "No PR for ${{ github.sha }} — skipping bump (build number still increments)."
+            exit 0
+          fi
+          LABELS=$(gh pr view "$PR" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+          echo "PR #$PR labels: ${LABELS//$'\n'/, }"
+          case "$LABELS" in
+            *version:major*) LEVEL="major" ;;
+            *version:minor*) LEVEL="minor" ;;
+            *version:patch*) LEVEL="patch" ;;
+            *version:none*)  LEVEL="";       echo "version:none → no MAJOR.MINOR.PATCH bump" ;;
+            *)               LEVEL="patch";  echo "No version label → defaulting to patch" ;;
+          esac
+          if [ -n "$LEVEL" ]; then
+            bash scripts/version-bump.sh "$LEVEL" >/dev/null
+            echo "Bumped VERSION ($LEVEL) → $(cat VERSION)"
+          fi
       - name: Update image tags and version info in values.yaml
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           VALUES_FILE="helm/missing-table/values-prod.yaml"
 
-          # Read version from VERSION file
+          # Read version from VERSION file (possibly just bumped above)
           VERSION=$(cat VERSION | tr -d '\n')
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -222,7 +250,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add helm/missing-table/values-prod.yaml
+          git add helm/missing-table/values-prod.yaml VERSION
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,20 +184,24 @@ helm upgrade missing-table ./missing-table --namespace missing-table -f ./missin
 
 ## Version Management
 
-**Claude creates all commits/PRs and decides version bumps.**
+Format: `MAJOR.MINOR.PATCH.BUILD` (e.g., `1.3.1.1041`), shown in the app footer via `/api/version`.
 
-Format: `MAJOR.MINOR.PATCH.BUILD` (e.g., `1.0.1.147`)
+- **`MAJOR.MINOR.PATCH`** lives in the `VERSION` file. Bumped automatically on merge to main by a **PR label gate** (CI job `update-helm-values` in `ci.yml`).
+- **`BUILD`** = the CI workflow `run_number`, written to `values-prod.yaml` `buildId` on every deploy. Always increments; not tied to the label.
 
-| Position | When to Increment |
-|----------|-------------------|
-| MAJOR | Breaking changes (API breaks, schema migrations, rewrites) |
-| MINOR | New features (new endpoints, UI features) |
-| PATCH | Bug fixes, refactoring, small improvements |
-| BUILD | Automatic (CI deployment) |
+### PR label gate — pick one label per PR
 
-```bash
-./scripts/version-bump.sh major|minor|patch
-```
+| Label | Effect on merge | Use for |
+|-------|-----------------|---------|
+| `version:major` | MAJOR +1, reset MINOR/PATCH | Breaking changes (API breaks, schema rewrites) |
+| `version:minor` | MINOR +1, reset PATCH | New features (endpoints, UI features) |
+| `version:patch` | PATCH +1 | Bug fixes, refactors, small improvements |
+| `version:none` | no MAJOR.MINOR.PATCH bump | Chore/infra/docs, image-tag commits |
+| *(no label)* | **defaults to `version:patch`** | so the version always advances on a real merge |
+
+CI reads the merged PR's label, runs `scripts/version-bump.sh <level>`, and commits the new `VERSION` alongside the image-tag update (`[skip ci]`). To switch the default from patch to "no bump", change the fallback `case` arm in `ci.yml`.
+
+Manual bump (local, rarely needed): `./scripts/version-bump.sh major|minor|patch`
 
 ---
 


### PR DESCRIPTION
## Context

The footer version is `MAJOR.MINOR.PATCH.BUILD`. `BUILD` (CI `run_number`) increments every deploy, but `MAJOR.MINOR.PATCH` (the `VERSION` file) only changed via a manual edit — so it sat frozen at `1.3.1` while features shipped. The documented "Claude decides bumps" policy wasn't enforced by anything.

This adds a **PR label gate** so version bumps are explicit per-PR and applied automatically on merge.

## How it works

In `ci.yml` job `update-helm-values` (runs on merge to main, commits to main via `GH_PAT`), a new step:
1. Finds the merged PR for the commit (`gh api .../commits/<sha>/pulls`).
2. Reads its `version:*` label.
3. Runs `scripts/version-bump.sh <level>` to edit `VERSION`.
4. The existing step writes the new version into `values-prod.yaml`; the commit step now stages `VERSION` too.

| Label | Effect |
|-------|--------|
| `version:major` | MAJOR +1 (breaking) |
| `version:minor` | MINOR +1 (feature) |
| `version:patch` | PATCH +1 (fix/refactor) |
| `version:none` | no bump (chore/infra/docs) |
| *(no label)* | **defaults to patch** — version always advances on a real merge |

`BUILD` is unchanged (still `run_number`, every deploy).

## Also
- Created the four `version:*` labels in the repo.
- Rewrote CLAUDE.md "Version Management" to document the gate (incl. how to flip the default to "no bump").

## Verify
Merge with a label → check the `chore: Update image tags…` commit bumps `VERSION` + `values-prod.yaml version-tag`; footer shows the new `MAJOR.MINOR.PATCH` next deploy. This PR is labeled `version:none` (infra) so it won't self-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
