### PR TITLE
feat(notifications): score-first push titles + tap-to-open match

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "/Users/tomdrake/gitrepos/missing-table/.secrets.baseline"
+      "filename": "/Users/silverbeer/gitrepos/missing-table/.secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -630,7 +630,7 @@
         "filename": "frontend/src/App.vue",
         "hashed_secret": "e0b9cc756b1d68235a3be9e7c2c10c9474115c79",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 60
       }
     ],
     "helm/missing-table/values-dev.yaml.example": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T21:39:30Z"
+  "generated_at": "2026-05-31T19:53:56Z"
 }

--- a/backend/notifications/dispatcher.py
+++ b/backend/notifications/dispatcher.py
@@ -68,7 +68,10 @@ def _build_push_payload(event_type: str, match: dict, content: str) -> dict:
         "badge": "/pwa/icon-192.png",
         "tag": f"match-{match_id}-{event_type}",
         "data": {
-            "url": f"/?tab=live&matchId={match_id}",
+            # Deep link to the match detail. The SPA reads ?matchId= on load and
+            # opens MatchDetailView (works for completed matches too — unlike the
+            # old ?tab=live link, which nothing read). See App.vue (SB-86).
+            "url": f"/?matchId={match_id}",
             "matchId": match_id,
             "eventType": event_type,
         },

--- a/backend/notifications/formatters.py
+++ b/backend/notifications/formatters.py
@@ -27,10 +27,16 @@ def _matchup_line(match: dict) -> str:
     return f"{match.get('home_team_name', 'Home')} vs {match.get('away_team_name', 'Away')}"
 
 
-def _score_line(match: dict) -> str:
+def _score_inline(match: dict) -> str:
+    """Compact score for the headline, e.g. 'IFA 2-1 NEFC'.
+
+    Lives on the first line of the message because that line becomes the Web
+    Push *title* — the only field rendered prominently (and at all, on iOS) when
+    the notification is collapsed. The score must be there, not in the body.
+    """
     home = match.get("home_score") or 0
     away = match.get("away_score") or 0
-    return f"{match.get('home_team_name', 'Home')} {home} - {away} {match.get('away_team_name', 'Away')}"
+    return f"{match.get('home_team_name', 'Home')} {home}-{away} {match.get('away_team_name', 'Away')}"
 
 
 def _minute_str(event: dict) -> str:
@@ -92,11 +98,11 @@ def format_goal(event: dict, match: dict, tz: ZoneInfo) -> str:
 
     player = event.get("player_name") or "Unknown player"
     minute = _minute_str(event)
-    minute_suffix = f" {minute}" if minute else ""
+    minute_suffix = f" ({minute})" if minute else ""
 
-    lines = [f"{_EMOJI['goal']} GOAL — {_matchup_line(match)}"]
-    lines.append(f"{player} ({scoring_team}){minute_suffix}")
-    lines.append(_score_line(match))
+    # Headline = score (becomes the push title); scorer drops to the body.
+    lines = [f"{_EMOJI['goal']} {_score_inline(match)}{minute_suffix}"]
+    lines.append(f"{player} ({scoring_team})")
     return "\n".join(lines)
 
 
@@ -124,16 +130,17 @@ def format_card(event: dict, match: dict, tz: ZoneInfo) -> str:
 
 
 def format_halftime(match: dict, tz: ZoneInfo) -> str:
-    """Halftime has begun."""
-    lines = [f"{_EMOJI['halftime']} HALFTIME — {_matchup_line(match)}"]
-    lines.append(_score_line(match))
+    """Halftime has begun. Score-first headline."""
+    lines = [f"{_EMOJI['halftime']} HT · {_score_inline(match)}"]
+    tag = _tag(match)
+    if tag:
+        lines.append(tag)
     return "\n".join(lines)
 
 
 def format_fulltime(match: dict, tz: ZoneInfo) -> str:
-    """Final whistle."""
-    lines = [f"{_EMOJI['fulltime']} FULL TIME — {_matchup_line(match)}"]
-    lines.append(_score_line(match))
+    """Final whistle. Score-first headline."""
+    lines = [f"{_EMOJI['fulltime']} FT · {_score_inline(match)}"]
     tag = _tag(match)
     if tag:
         lines.append(tag)

--- a/backend/tests/integration/test_bracket_follow_delivery.py
+++ b/backend/tests/integration/test_bracket_follow_delivery.py
@@ -231,7 +231,7 @@ class TestBracketScorePushesFollower:
         sub, payload = sender.calls[0]
         assert sub["endpoint"] == world["subscription"]["endpoint"]
         text = f"{payload.get('title', '')}\n{payload.get('body', '')}"
-        assert "2 - 1" in text
+        assert "2-1" in text
 
         rows = _push_log_rows(world["admin"], world["match"]["id"], world["user_id"])
         assert len(rows) == 1

--- a/backend/tests/integration/test_notification_dispatch.py
+++ b/backend/tests/integration/test_notification_dispatch.py
@@ -222,7 +222,7 @@ class TestNotifierDirectInvocation:
 
         assert send_fn.call_count == 1
         msg = send_fn.call_args.args[2]
-        assert "GOAL" in msg
+        assert "⚽" in msg  # score-first goal headline (SB-86)
         assert "Scorer Smith" in msg
         assert "34'" in msg
 

--- a/backend/tests/integration/test_push_delivery_on_score.py
+++ b/backend/tests/integration/test_push_delivery_on_score.py
@@ -284,7 +284,7 @@ class TestTournamentScorePushesFollower:
         text = f"{payload.get('title', '')}\n{payload.get('body', '')}"
         assert world["home_team"]["name"] in text
         assert world["away_team"]["name"] in text
-        assert "0 - 1" in text
+        assert "0-1" in text
 
         # And it was logged as a fulltime send.
         rows = _push_log_rows(world["admin"], world["match"]["id"], world["user_id"])

--- a/backend/tests/unit/test_notification_formatters.py
+++ b/backend/tests/unit/test_notification_formatters.py
@@ -51,13 +51,12 @@ class TestFormatGoal:
     def test_home_goal(self):
         event = {"team_id": 10, "player_name": "Smith", "match_minute": 34, "extra_time": 0}
         text = format_goal(event, MATCH, ET)
-        assert "GOAL" in text
         assert "⚽" in text
         assert "Smith" in text
         assert "IFA" in text  # scoring team in the parens
         assert "34'" in text
-        # Score line present
-        assert "IFA 2 - 1 NEFC" in text
+        # Score is in the headline (first line = push title)
+        assert text.splitlines()[0] == "⚽ IFA 2-1 NEFC (34')"
 
     def test_away_goal_uses_away_team_name(self):
         event = {"team_id": 20, "player_name": "Jones", "match_minute": 78, "extra_time": 0}
@@ -74,8 +73,10 @@ class TestFormatGoal:
         event = {"team_id": 10, "player_name": "Alvarez"}
         text = format_goal(event, MATCH, ET)
         assert "Alvarez" in text
-        # No stray minute-prime character
+        # No stray minute-prime character, and no empty () suffix
         assert "'" not in text
+        assert "()" not in text
+        assert text.splitlines()[0] == "⚽ IFA 2-1 NEFC"
 
     def test_unknown_team_id_falls_back(self):
         event = {"team_id": 999, "player_name": "Ghost", "match_minute": 50}
@@ -106,15 +107,14 @@ class TestFormatCard:
 class TestFormatHalftimeAndFulltime:
     def test_halftime_shows_current_score(self):
         text = format_halftime(MATCH, ET)
-        assert "HALFTIME" in text
         assert "⏸" in text
-        assert "IFA 2 - 1 NEFC" in text
+        # Score in the headline (push title)
+        assert text.splitlines()[0] == "⏸ HT · IFA 2-1 NEFC"
 
     def test_fulltime_shows_final_score_and_tag(self):
         text = format_fulltime(MATCH, ET)
-        assert "FULL TIME" in text
         assert "🏁" in text
-        assert "IFA 2 - 1 NEFC" in text
+        assert text.splitlines()[0] == "🏁 FT · IFA 2-1 NEFC"
         assert "U14" in text
 
 
@@ -122,8 +122,9 @@ class TestFormatEventDispatcher:
     def test_goal_dispatches_to_format_goal(self):
         extra = {"team_id": 10, "player_name": "Smith", "match_minute": 34, "extra_time": 0}
         text = format_event("goal", MATCH, extra, ET)
-        assert "GOAL" in text
+        assert "⚽" in text
         assert "Smith" in text
+        assert "IFA 2-1 NEFC" in text
 
     @pytest.mark.parametrize("card_type", ["yellow_card", "red_card"])
     def test_card_dispatches_with_type(self, card_type):
@@ -146,9 +147,9 @@ class TestScoreEdgeCases:
     def test_zero_zero_score(self):
         match = {**MATCH, "home_score": 0, "away_score": 0}
         text = format_halftime(match, ET)
-        assert "IFA 0 - 0 NEFC" in text
+        assert "IFA 0-0 NEFC" in text
 
     def test_none_scores_render_as_zero(self):
         match = {**MATCH, "home_score": None, "away_score": None}
         text = format_halftime(match, ET)
-        assert "IFA 0 - 0 NEFC" in text
+        assert "IFA 0-0 NEFC" in text

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,33 @@
 <template>
   <div class="min-h-screen bg-slate-50">
+    <!-- Deep-link match detail (from a push notification: ?matchId=). Overlays
+         everything; works for any match status. -->
+    <div
+      v-if="deepLinkMatchId"
+      class="fixed inset-0 z-50 bg-black/60 overflow-y-auto"
+      @click.self="closeDeepLinkMatch"
+    >
+      <div class="min-h-full flex items-start justify-center p-3 sm:p-6">
+        <div
+          class="relative w-full max-w-4xl bg-white rounded-lg shadow-2xl"
+          @click.stop
+        >
+          <button
+            type="button"
+            aria-label="Close match details"
+            class="absolute top-2 right-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+            @click="closeDeepLinkMatch"
+          >
+            ✕
+          </button>
+          <MatchDetailView
+            :matchId="deepLinkMatchId"
+            @back="closeDeepLinkMatch"
+          />
+        </div>
+      </div>
+    </div>
+
     <!-- PWA chrome: install prompt, offline indicator, update banner -->
     <IosInstallTooltip />
     <OfflineIndicator />
@@ -509,6 +537,7 @@ import { recordPageView, recordInviteRequest } from './faro';
 import MatchForm from './components/MatchForm.vue';
 import LeagueTable from './components/LeagueTable.vue';
 import MatchesView from './components/MatchesView.vue';
+import MatchDetailView from './components/MatchDetailView.vue';
 import GoalsLeaderboard from './components/GoalsLeaderboard.vue';
 import AuthNav from './components/AuthNav.vue';
 import LoginForm from './components/LoginForm.vue';
@@ -531,6 +560,7 @@ export default {
     MatchForm,
     LeagueTable,
     MatchesView,
+    MatchDetailView,
     GoalsLeaderboard,
     AuthNav,
     LoginForm,
@@ -551,6 +581,12 @@ export default {
     const authStore = useAuthStore();
     const adminAttention = useAdminAttentionCounts();
     const currentTab = ref('table');
+    // Deep link from a push notification: ?matchId=<id> opens MatchDetailView
+    // as an overlay (SB-86). Works for any match status, incl. completed.
+    const deepLinkMatchId = ref(null);
+    const closeDeepLinkMatch = () => {
+      deepLinkMatchId.value = null;
+    };
     const tableFilters = ref({
       ageGroupId: null,
       leagueId: null,
@@ -855,6 +891,18 @@ export default {
         window.history.replaceState({}, '', cleanUrl);
       }
 
+      // Deep link from a push notification: ?matchId=<id> → open the match.
+      const matchIdParam = urlParams.get('matchId');
+      if (matchIdParam && /^\d+$/.test(matchIdParam)) {
+        deepLinkMatchId.value = Number(matchIdParam);
+        // Strip matchId from the URL so a refresh/share doesn't re-trigger,
+        // preserving any invite code (mirrors the reset_token cleanup above).
+        const code = urlParams.get('code');
+        const cleanUrl =
+          window.location.pathname + (code ? `?code=${code}` : '');
+        window.history.replaceState({}, '', cleanUrl);
+      }
+
       // Start live match polling if authenticated
       if (authStore.isAuthenticated.value) {
         startLiveMatchPolling();
@@ -929,6 +977,8 @@ export default {
       authStore,
       adminAttention,
       currentTab,
+      deepLinkMatchId,
+      closeDeepLinkMatch,
       tableFilters,
       matchesFilters,
       availableTabs,


### PR DESCRIPTION
## Context

Makes match push notifications show the **score at a glance** and makes **tapping** one open the match. Implements SB-86.

Two problems today:
1. **Score buried.** For FT/goal/HT, the notification *title* (the bold headline — the only field reliably shown on iOS and when collapsed) was just the matchup; the score sat in the body, which truncates.
2. **Tap goes nowhere useful.** The payload pointed at `/?tab=live&matchId=`, but nothing in the app read those params — clicks landed on the standings tab. ("live" is also wrong for a completed bracket match.)

## Changes

**Score-first headlines** (`notifications/formatters.py`) — the first line becomes the push title:
- FT → `🏁 FT · IFA 2-1 NEFC`
- Goal → `⚽ IFA 2-1 NEFC (34')` (scorer moves to the body)
- HT → `⏸ HT · IFA 2-1 NEFC`
- Kickoff/cards unchanged (no score). Shared with Telegram/Discord → those improve too.

**Tap-to-open match:**
- Payload `url` → `/?matchId=<id>` (`dispatcher.py`).
- `App.vue` parses `matchId` on load → opens `MatchDetailView` as an overlay (any status, incl. completed), then strips the param.

## Notes
- Cross-platform-safe: title + body are the only universally-rendered fields; iOS PWA has no actions/image, so the score goes in the title.
- `.secrets.baseline` line refs shifted (fake test keys moved) — re-baselined, no real secrets.

## Tests
Formatter unit tests updated to the new headlines (20 pass). Dispatch/push/bracket integration assertions updated for the `2-1` format (29 pass). Full frontend suite 469 pass. ruff + eslint clean.

Fixes SB-86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
