### PR TITLE
docs: CHANGELOG + version bump to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable user-facing changes. Versions are `MAJOR.MINOR.PATCH` (the `.BUILD`
+suffix in the footer is the CI run number). Bumps are driven by the PR label
+gate — see [CLAUDE.md → Version Management](CLAUDE.md#version-management).
+
+## [1.4.0] — Follow tournament brackets + score-first notifications
+
+### Added
+- **Follow a tournament bracket** — follow a `(tournament, bracket, age group)`
+  and get a Web Push at full time for every match in it. Toggle on the
+  tournament Bracket and Standings views; manage/unfollow from the profile
+  ("Brackets you follow"). Respects existing per-event notification
+  preferences. (SB-84)
+- **`mt tournament` CLI** — `create` / `list` / `show` / `add-match` /
+  `remove-match` / `score` for seeding and scoring tournament brackets.
+
+### Changed
+- **Score-first push notifications** — the score is now the notification
+  headline (e.g. `🏁 FT · IFA 2-1 NEFC`, `⚽ IFA 2-1 NEFC (34')`), so it's
+  visible at a glance and on the lock screen. (SB-86)
+- **Tapping a match notification opens that match** (match detail overlay),
+  instead of landing on the standings tab. (SB-86)
+
+### Infrastructure
+- **Prod test partition** (`is_test`) — the TSC test world (league, clubs,
+  teams, tournaments, users) is hidden from real users while visible to test
+  users and admins. (SB-85)
+- **PR-label version gate** — merging a PR bumps `MAJOR.MINOR.PATCH` from its
+  `version:*` label.
+
+## [1.3.1]
+
+- Baseline prior to the changelog. See git history for earlier changes.


### PR DESCRIPTION
## Purpose

Bump the app version **`1.3.1` → `1.4.0`** and record the recent work in a new `CHANGELOG.md`.

The score-first notification feature (#437, `version:minor`) merged **before** the PR-label gate (#436) went live, so its minor bump was missed and `VERSION` stayed `1.3.1`. This PR carries the `version:minor` label so the now-live gate performs the bump — and serves as the **first end-to-end test of the gate**.

## Version change — what to expect on merge

| | |
|---|---|
| Current | `VERSION` = `1.3.1`, footer `1.3.1.<build>` |
| This PR's label | `version:minor` |
| Expected after merge | `VERSION` = **`1.4.0`** (minor +1, patch → 0) |

**On merge → CI `update-helm-values` job:**
1. Gate reads `version:minor` → runs `scripts/version-bump.sh minor` → `VERSION` `1.3.1` → `1.4.0`.
2. Writes `values-prod.yaml`: `version: "1.4.0"`, `buildId: "<run_number>"`, new image tags.
3. Commits `chore: Update image tags to <sha>` (body: `Version: 1.4.0`, `[skip ci]`) — diff includes **both** `VERSION` and `values-prod.yaml`.
4. ArgoCD deploys → `/api/version` → footer shows **`1.4.0.<N>`** (`<N>` = CI run number, jumps — not +1).

**Outcome signals:**
- **`1.4.0`** → gate works. ✅
- **`1.3.1`** (unchanged) → `GH_PAT` couldn't find the PR (`gh api .../pulls`) → step skipped.
- **`1.3.2`** (patch) → found the PR but couldn't read labels → fell through to the default-patch arm.

Either failure → widen `GH_PAT` to include pull-requests read.

## Change
- New `CHANGELOG.md` with the `1.4.0` entry (follow-tournament brackets, score-first notifications, tap-to-open, test partition, version gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
