### PR TITLE
feat(frontend): in-app "What's New" changelog page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,11 @@ jobs:
       - name: Build and push frontend
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          # Bring the repo-root CHANGELOG.md into the frontend build context so
+          # the "What's New" page can serve it at /changelog.md (the root file
+          # is outside frontend/'s Docker context). See copy-changelog.mjs.
+          cp CHANGELOG.md frontend/public/changelog.md 2>/dev/null \
+            || echo "No CHANGELOG.md — frontend will ship a placeholder."
           docker build \
             --build-arg VITE_FARO_URL="${{ secrets.VITE_FARO_URL }}" \
             -t ghcr.io/silverbeer/missing-table-frontend:${SHORT_SHA} \

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 coverage/
 test-results.json
 html-report/
+
+# Generated copy of repo-root CHANGELOG.md (see scripts/copy-changelog.mjs)
+public/changelog.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@grafana/faro-web-tracing": "^2.0.2",
         "@supabase/supabase-js": "^2.89.0",
         "html2canvas": "^1.4.1",
+        "marked": "^14.1.4",
         "vue": "^3.4.0",
         "web-vitals": "^5.1.0"
       },
@@ -7147,6 +7148,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "node scripts/copy-changelog.mjs",
     "dev": "vite",
+    "preserve": "node scripts/copy-changelog.mjs",
     "serve": "vite",
+    "prebuild": "node scripts/copy-changelog.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
@@ -27,6 +30,7 @@
     "@grafana/faro-web-tracing": "^2.0.2",
     "@supabase/supabase-js": "^2.89.0",
     "html2canvas": "^1.4.1",
+    "marked": "^14.1.4",
     "vue": "^3.4.0",
     "web-vitals": "^5.1.0"
   },

--- a/frontend/scripts/copy-changelog.mjs
+++ b/frontend/scripts/copy-changelog.mjs
@@ -1,0 +1,32 @@
+// Copy the repo-root CHANGELOG.md into the frontend's static assets so the
+// "What's New" page can fetch it at runtime (/changelog.md).
+//
+// Runs as a pre{dev,serve,build} hook. The repo-root file is outside the
+// frontend Docker build context, so CI also copies it explicitly before the
+// frontend image build (see .github/workflows/ci.yml). If the source is
+// missing (e.g. CHANGELOG.md not on this branch yet), write a placeholder so
+// the fetch returns 200 with an empty-state body instead of 404.
+
+import { existsSync, copyFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = resolve(here, '../../CHANGELOG.md');
+const destDir = resolve(here, '../public');
+const dest = resolve(destDir, 'changelog.md');
+
+mkdirSync(destDir, { recursive: true });
+
+if (existsSync(source)) {
+  copyFileSync(source, dest);
+  console.log(`[copy-changelog] ${source} → ${dest}`);
+} else if (existsSync(dest)) {
+  // Source not in context (e.g. inside the frontend Docker build, where the
+  // repo-root file isn't visible). CI copies CHANGELOG.md into public/ before
+  // the build, so keep that copy rather than clobbering it with a placeholder.
+  console.log(`[copy-changelog] source missing; keeping existing ${dest}`);
+} else {
+  writeFileSync(dest, '# Changelog\n\nNo entries yet.\n');
+  console.warn(`[copy-changelog] ${source} not found — wrote placeholder.`);
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -523,8 +523,11 @@
       </div>
 
       <!-- Version Footer -->
-      <VersionFooter />
+      <VersionFooter @open-whats-new="showWhatsNew = true" />
     </div>
+
+    <!-- What's New (changelog) overlay, launched from the footer version -->
+    <WhatsNewView v-if="showWhatsNew" @close="showWhatsNew = false" />
   </div>
 </template>
 
@@ -549,6 +552,7 @@ import AdminPanel from './components/AdminPanel.vue';
 import TournamentMatchCenter from './components/TournamentMatchCenter.vue';
 import QoPStandings from './components/QoPStandings.vue';
 import VersionFooter from './components/VersionFooter.vue';
+import WhatsNewView from './components/WhatsNewView.vue';
 import { LiveMatchView } from './components/live';
 import IosInstallTooltip from './components/IosInstallTooltip.vue';
 import OfflineIndicator from './components/OfflineIndicator.vue';
@@ -572,6 +576,7 @@ export default {
     TournamentMatchCenter,
     QoPStandings,
     VersionFooter,
+    WhatsNewView,
     LiveMatchView,
     IosInstallTooltip,
     OfflineIndicator,
@@ -587,6 +592,8 @@ export default {
     const closeDeepLinkMatch = () => {
       deepLinkMatchId.value = null;
     };
+    // "What's New" changelog overlay, opened from the footer version.
+    const showWhatsNew = ref(false);
     const tableFilters = ref({
       ageGroupId: null,
       leagueId: null,
@@ -979,6 +986,7 @@ export default {
       currentTab,
       deepLinkMatchId,
       closeDeepLinkMatch,
+      showWhatsNew,
       tableFilters,
       matchesFilters,
       availableTabs,

--- a/frontend/src/__tests__/components/WhatsNewView.spec.js
+++ b/frontend/src/__tests__/components/WhatsNewView.spec.js
@@ -1,0 +1,80 @@
+/**
+ * WhatsNewView tests — renders releases, chips unseen ones, marks seen on open.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+
+const loadMock = vi.fn().mockResolvedValue();
+const markAllSeenMock = vi.fn();
+const releasesRef = ref([]);
+let isNewImpl;
+
+vi.mock('@/composables/useChangelog', () => ({
+  useChangelog: () => ({
+    releases: releasesRef,
+    loaded: ref(true),
+    error: ref(null),
+    load: loadMock,
+    isNew: v => isNewImpl(v),
+    markAllSeen: markAllSeenMock,
+  }),
+}));
+
+import WhatsNewView from '@/components/WhatsNewView.vue';
+
+beforeEach(() => {
+  loadMock.mockClear();
+  markAllSeenMock.mockClear();
+  releasesRef.value = [
+    {
+      version: '1.4.0',
+      title: 'Brackets',
+      bodyHtml: '<ul><li>Follow</li></ul>',
+    },
+    { version: '1.3.1', title: '', bodyHtml: '<p>Baseline</p>' },
+  ];
+  isNewImpl = v => v === '1.4.0';
+});
+
+describe('WhatsNewView', () => {
+  it('renders a row per release with rendered body', async () => {
+    const wrapper = mount(WhatsNewView);
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="changelog-release-1.4.0"]').exists()
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="changelog-release-1.3.1"]').exists()
+    ).toBe(true);
+    expect(wrapper.html()).toContain('Follow'); // v-html body
+  });
+
+  it('chips only releases that are new since last-seen', async () => {
+    const wrapper = mount(WhatsNewView);
+    await flushPromises();
+
+    const chips = wrapper.findAll('[data-testid="changelog-new-chip"]');
+    expect(chips).toHaveLength(1);
+    const newRow = wrapper.find('[data-testid="changelog-release-1.4.0"]');
+    expect(newRow.find('[data-testid="changelog-new-chip"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('loads and marks all seen on open', async () => {
+    mount(WhatsNewView);
+    await flushPromises();
+    expect(loadMock).toHaveBeenCalled();
+    expect(markAllSeenMock).toHaveBeenCalled();
+  });
+
+  it('emits close on the close button', async () => {
+    const wrapper = mount(WhatsNewView);
+    await flushPromises();
+    await wrapper.find('[data-testid="whats-new-close"]').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/composables/useChangelog.spec.js
+++ b/frontend/src/__tests__/composables/useChangelog.spec.js
@@ -1,0 +1,125 @@
+/**
+ * useChangelog tests — parsing, version compare, seen-state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  useChangelog,
+  parseChangelog,
+  compareVersions,
+  _resetChangelogForTest,
+} from '@/composables/useChangelog';
+
+const SAMPLE = `# Changelog
+
+Preamble that should be ignored.
+
+## [1.4.0] — Follow brackets + score-first notifications
+
+### Added
+- Follow a tournament bracket.
+
+## [1.3.1]
+
+- Baseline.
+`;
+
+beforeEach(() => {
+  _resetChangelogForTest();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('parseChangelog', () => {
+  it('splits into releases newest-first, ignoring the preamble', () => {
+    const releases = parseChangelog(SAMPLE);
+    expect(releases.map(r => r.version)).toEqual(['1.4.0', '1.3.1']);
+    expect(releases[0].title).toBe(
+      'Follow brackets + score-first notifications'
+    );
+    // Body rendered to HTML by marked.
+    expect(releases[0].bodyHtml).toContain('<li>');
+    expect(releases[0].bodyHtml).toContain('Follow a tournament bracket');
+  });
+
+  it('handles a heading with no title', () => {
+    const releases = parseChangelog(SAMPLE);
+    expect(releases[1].version).toBe('1.3.1');
+    expect(releases[1].title).toBe('');
+  });
+});
+
+describe('compareVersions', () => {
+  it('orders dotted numeric versions', () => {
+    expect(compareVersions('1.4.0', '1.3.1')).toBe(1);
+    expect(compareVersions('1.3.1', '1.4.0')).toBe(-1);
+    expect(compareVersions('1.4.0', '1.4.0')).toBe(0);
+    expect(compareVersions('1.4.1', '1.4.0')).toBe(1);
+  });
+
+  it('treats garbage segments as zero without throwing', () => {
+    expect(() => compareVersions('x.y', '1.0')).not.toThrow();
+    expect(compareVersions('1.0', 'x.y')).toBe(1);
+  });
+});
+
+describe('useChangelog.load', () => {
+  it('fetches /changelog.md and populates releases', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(SAMPLE),
+    });
+
+    const { load, releases, loaded } = useChangelog();
+    await load();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/changelog.md',
+      expect.objectContaining({ cache: 'no-cache' })
+    );
+    expect(loaded.value).toBe(true);
+    expect(releases.value).toHaveLength(2);
+  });
+
+  it('sets error and empty releases on fetch failure', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    const { load, error, releases } = useChangelog();
+    await load();
+    expect(error.value).toContain('404');
+    expect(releases.value).toEqual([]);
+  });
+});
+
+describe('useChangelog seen-state', () => {
+  async function loaded() {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(SAMPLE),
+    });
+    const c = useChangelog();
+    await c.load();
+    return c;
+  }
+
+  it('isNew is false on first visit (nothing seen yet)', async () => {
+    const { isNew } = await loaded();
+    expect(isNew('1.4.0')).toBe(false);
+  });
+
+  it('isNew flags versions above the last-seen', async () => {
+    localStorage.setItem('mt.changelog.lastSeenVersion', '1.3.1');
+    const { isNew } = await loaded();
+    expect(isNew('1.4.0')).toBe(true);
+    expect(isNew('1.3.1')).toBe(false);
+  });
+
+  it('hasUnseen true when newest > last-seen, false once caught up', async () => {
+    localStorage.setItem('mt.changelog.lastSeenVersion', '1.3.1');
+    const c = await loaded();
+    expect(c.hasUnseen()).toBe(true);
+    c.markAllSeen();
+    expect(localStorage.getItem('mt.changelog.lastSeenVersion')).toBe('1.4.0');
+    expect(c.hasUnseen()).toBe(false);
+    expect(c.isNew('1.4.0')).toBe(false);
+  });
+});

--- a/frontend/src/components/VersionFooter.vue
+++ b/frontend/src/components/VersionFooter.vue
@@ -32,12 +32,20 @@
     <div class="version-container">
       <!-- Version info (left side) -->
       <div class="version-info">
-        <span v-if="version" class="version-text">
-          {{ version }}
+        <template v-if="version">
+          <button
+            type="button"
+            class="version-text version-button"
+            title="What's New"
+            data-testid="whats-new-trigger"
+            @click="$emit('open-whats-new')"
+          >
+            {{ version }}
+          </button>
           <span v-if="environment !== 'production'" class="environment-badge">
             {{ environment }}
           </span>
-        </span>
+        </template>
         <span v-else class="version-loading">Loading version...</span>
       </div>
 
@@ -75,6 +83,7 @@ import SupportEmailLink from '@/components/SupportEmailLink.vue';
 export default {
   name: 'VersionFooter',
   components: { SupportEmailLink },
+  emits: ['open-whats-new'],
   setup() {
     const authStore = useAuthStore();
     const version = ref(null);
@@ -203,6 +212,19 @@ export default {
   font-family: 'Courier New', monospace;
   font-size: 0.8125rem;
   color: #495057;
+}
+
+.version-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+
+.version-button:hover {
+  color: #0257fe;
 }
 
 .version-loading {

--- a/frontend/src/components/WhatsNewView.vue
+++ b/frontend/src/components/WhatsNewView.vue
@@ -1,0 +1,137 @@
+<template>
+  <div
+    class="fixed inset-0 z-50 bg-black/60 overflow-y-auto"
+    data-testid="whats-new-overlay"
+    @click.self="$emit('close')"
+  >
+    <div class="min-h-full flex items-start justify-center p-3 sm:p-6">
+      <div
+        class="relative w-full max-w-2xl bg-white rounded-lg shadow-2xl"
+        @click.stop
+      >
+        <button
+          type="button"
+          aria-label="Close what's new"
+          data-testid="whats-new-close"
+          class="absolute top-3 right-3 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+          @click="$emit('close')"
+        >
+          ✕
+        </button>
+
+        <div class="p-5 sm:p-7">
+          <h2 class="text-xl font-bold text-gray-900 mb-1">✨ What's New</h2>
+          <p class="text-sm text-gray-500 mb-5">
+            New features and improvements in Missing Table.
+          </p>
+
+          <p v-if="error" class="text-sm text-red-700">
+            Couldn't load the changelog: {{ error }}
+          </p>
+          <p
+            v-else-if="loaded && !releases.length"
+            class="text-sm text-gray-500"
+          >
+            No release notes yet — check back after the next update.
+          </p>
+
+          <div
+            v-for="r in releases"
+            :key="r.version"
+            class="changelog-release"
+            :data-testid="`changelog-release-${r.version}`"
+          >
+            <div class="flex items-baseline gap-2 flex-wrap">
+              <h3 class="text-base font-semibold text-gray-900">
+                {{ r.version }}
+              </h3>
+              <span v-if="r.title" class="text-sm text-gray-600">{{
+                r.title
+              }}</span>
+              <span
+                v-if="isNew(r.version)"
+                class="changelog-new-chip"
+                data-testid="changelog-new-chip"
+                >New</span
+              >
+            </div>
+            <!-- Content is repo-authored (trusted); rendered from CHANGELOG.md -->
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div class="changelog-body prose-sm" v-html="r.bodyHtml"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue';
+import { useChangelog } from '../composables/useChangelog';
+
+defineEmits(['close']);
+
+const { releases, loaded, error, load, isNew, markAllSeen } = useChangelog();
+
+onMounted(async () => {
+  await load();
+  // Opening the page counts as seeing the latest release.
+  markAllSeen();
+});
+</script>
+
+<style scoped>
+.changelog-release {
+  padding: 14px 0;
+  border-top: 1px solid #f3f4f6;
+}
+.changelog-release:first-of-type {
+  border-top: none;
+}
+.changelog-new-chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: #10b981;
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.changelog-body {
+  margin-top: 6px;
+  font-size: 14px;
+  color: #374151;
+  line-height: 1.5;
+}
+/* Lightweight markdown styling (no prose plugin dependency) */
+.changelog-body :deep(h3) {
+  font-size: 14px;
+  font-weight: 700;
+  margin: 12px 0 4px;
+  color: #111827;
+}
+.changelog-body :deep(ul) {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 6px 0;
+}
+.changelog-body :deep(li) {
+  margin: 3px 0;
+}
+.changelog-body :deep(a) {
+  color: #0257fe;
+  text-decoration: underline;
+}
+.changelog-body :deep(code) {
+  background: #f3f4f6;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.changelog-body :deep(strong) {
+  font-weight: 600;
+  color: #111827;
+}
+</style>

--- a/frontend/src/composables/useChangelog.js
+++ b/frontend/src/composables/useChangelog.js
@@ -1,0 +1,139 @@
+/**
+ * useChangelog — load + parse the in-app changelog ("What's New").
+ *
+ * Source of truth is the repo-root CHANGELOG.md, copied to /changelog.md at
+ * build time (scripts/copy-changelog.mjs). We fetch it, split it into release
+ * sections on the `## [version] — title` headings, and render each body to
+ * HTML with `marked`. "Seen" state is per-device in localStorage (matches
+ * IosInstallTooltip) — used to chip releases that are new since the last visit.
+ */
+
+import { ref } from 'vue';
+import { marked } from 'marked';
+
+const SEEN_KEY = 'mt.changelog.lastSeenVersion';
+
+const releases = ref([]);
+const loaded = ref(false);
+const loading = ref(false);
+const error = ref(null);
+
+// Heading form: "## [1.4.0] — Title"  or  "## [1.4.0]"
+const HEADING_RE = /^##\s*\[([^\]]+)\]\s*(?:[—-]\s*(.*))?$/;
+
+function parseChangelog(md) {
+  const lines = md.split('\n');
+  const out = [];
+  let current = null;
+  for (const line of lines) {
+    const m = line.match(HEADING_RE);
+    if (m) {
+      if (current) out.push(current);
+      current = { version: m[1].trim(), title: (m[2] || '').trim(), body: [] };
+    } else if (current) {
+      current.body.push(line);
+    }
+    // lines before the first release heading (the file's H1 + preamble) are ignored
+  }
+  if (current) out.push(current);
+  return out.map(r => ({
+    version: r.version,
+    title: r.title,
+    bodyHtml: marked.parse(r.body.join('\n').trim()),
+  }));
+}
+
+// Compare dotted numeric versions: 1 if a>b, -1 if a<b, 0 if equal.
+// Non-numeric/garbage segments sort as 0 so a malformed tag never crashes.
+function compareVersions(a, b) {
+  const pa = String(a)
+    .split('.')
+    .map(n => parseInt(n, 10) || 0);
+  const pb = String(b)
+    .split('.')
+    .map(n => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+function getLastSeen() {
+  try {
+    return localStorage.getItem(SEEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function useChangelog() {
+  const load = async () => {
+    if (loaded.value || loading.value) return;
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await fetch('/changelog.md', { cache: 'no-cache' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const md = await res.text();
+      releases.value = parseChangelog(md);
+      loaded.value = true;
+    } catch (err) {
+      error.value = err.message || String(err);
+      releases.value = [];
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  // A release is "new" if its version is strictly above the last-seen version.
+  // With nothing seen yet, nothing is chipped (avoids flagging the whole list
+  // as new on a user's first ever visit).
+  const isNew = version => {
+    const lastSeen = getLastSeen();
+    if (!lastSeen) return false;
+    return compareVersions(version, lastSeen) > 0;
+  };
+
+  // True when there is at least one release the user hasn't seen (newest >
+  // last-seen). Also true on first visit (lastSeen null) so the page is
+  // discoverable.
+  const hasUnseen = () => {
+    if (!releases.value.length) return false;
+    const lastSeen = getLastSeen();
+    if (!lastSeen) return true;
+    return compareVersions(releases.value[0].version, lastSeen) > 0;
+  };
+
+  const markAllSeen = () => {
+    if (!releases.value.length) return;
+    try {
+      localStorage.setItem(SEEN_KEY, releases.value[0].version);
+    } catch {
+      // private mode / storage disabled — best effort, ignore
+    }
+  };
+
+  return {
+    releases,
+    loaded,
+    loading,
+    error,
+    load,
+    isNew,
+    hasUnseen,
+    markAllSeen,
+  };
+}
+
+// Test-only: reset module-level singleton state.
+export function _resetChangelogForTest() {
+  releases.value = [];
+  loaded.value = false;
+  loading.value = false;
+  error.value = null;
+}
+
+// Exported for unit tests.
+export { parseChangelog, compareVersions };


### PR DESCRIPTION
## Context

We ship frequently and want to **communicate new features in-app**. This adds an in-app **"What's New"** page driven by the repo's `CHANGELOG.md` — no separate authoring tool, no DB. You already write `CHANGELOG.md` per release (now gated by the version label); the app renders that same file.

Phase 1 per the approved plan: **one dedicated page**, **localStorage** seen-state. (Out of scope: auto-modal on version bump, nav unread badge, per-user/cross-device seen, role targeting, admin authoring.)

## What it does
- Footer version becomes a **button** → opens a **"What's New"** overlay listing releases newest-first, rendered from markdown.
- Releases newer than the last-seen version get a **"New" chip**; opening the page marks them seen (per-device localStorage).
- Because entries are markdown, each release can include **how-to-enable steps and links**.

## Content pipeline
- Canonical: repo-root `CHANGELOG.md`.
- `scripts/copy-changelog.mjs` (pre `dev`/`serve`/`build`) copies it to `frontend/public/changelog.md` (gitignored) → served at `/changelog.md`.
- The root file is outside the frontend Docker context, so **CI** (`ci.yml`) copies `CHANGELOG.md` into `frontend/public/` before the frontend image build. The script preserves that copy rather than overwriting it with a placeholder.

## Notes
- Adds `marked` (lightweight) for rendering. Content is repo-authored/trusted → `v-html` is acceptable.
- **Depends on `CHANGELOG.md` being on main (#438).** Until that merges, the page shows a graceful empty state ("No release notes yet"). No errors either way.

## Tests
`useChangelog.spec.js` (parse, version-compare, seen-state) + `WhatsNewView.spec.js` (render, "New" chip, mark-seen, close). Full frontend suite **482 pass**; eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
