### PR TITLE
feat(leaderboard): per-tournament filter for goals

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4129,9 +4129,10 @@ async def get_goals_leaderboard(
     division_id: int | None = Query(None, description="Filter by division ID"),
     age_group_id: int | None = Query(None, description="Filter by age group ID"),
     match_type_id: int | None = Query(None, description="Filter by match type ID (e.g. 4 for Playoff)"),
+    tournament_id: int | None = Query(None, description="Filter by specific tournament ID"),
     limit: int = Query(50, description="Maximum results", ge=1, le=100),
 ):
-    """Get goals leaderboard - top scorers filtered by season/league/division/age group/match type."""
+    """Get goals leaderboard - top scorers filtered by season/league/division/age group/match type/tournament."""
     try:
         leaderboard = player_stats_dao.get_goals_leaderboard(
             season_id=season_id,
@@ -4139,6 +4140,7 @@ async def get_goals_leaderboard(
             division_id=division_id,
             age_group_id=age_group_id,
             match_type_id=match_type_id,
+            tournament_id=tournament_id,
             limit=limit,
         )
 
@@ -4149,6 +4151,7 @@ async def get_goals_leaderboard(
             division_id=division_id,
             age_group_id=age_group_id,
             match_type_id=match_type_id,
+            tournament_id=tournament_id,
             limit=limit,
             rows_returned=len(leaderboard),
         )

--- a/backend/dao/player_stats_dao.py
+++ b/backend/dao/player_stats_dao.py
@@ -194,7 +194,7 @@ class PlayerStatsDAO(BaseDAO):
             logger.error("stats_team_error", team_id=team_id, season_id=season_id, error=str(e))
             return []
 
-    @dao_cache("stats:leaderboard:goals:s{season_id}:l{league_id}:d{division_id}:a{age_group_id}:mt{match_type_id}:lim{limit}")
+    @dao_cache("stats:leaderboard:goals:s{season_id}:l{league_id}:d{division_id}:a{age_group_id}:mt{match_type_id}:t{tournament_id}:lim{limit}")
     def get_goals_leaderboard(
         self,
         season_id: int,
@@ -202,10 +202,11 @@ class PlayerStatsDAO(BaseDAO):
         division_id: int | None = None,
         age_group_id: int | None = None,
         match_type_id: int | None = None,
+        tournament_id: int | None = None,
         limit: int = 50,
     ) -> list[dict]:
         """
-        Get top goal scorers filtered by league/division/age group/match type.
+        Get top goal scorers filtered by league/division/age group/match type/tournament.
 
         Args:
             season_id: Season ID (required)
@@ -213,6 +214,7 @@ class PlayerStatsDAO(BaseDAO):
             division_id: Optional division filter
             age_group_id: Optional age group filter
             match_type_id: Optional match type filter (e.g. 4 for Playoff)
+            tournament_id: Optional specific tournament filter (matches.tournament_id)
             limit: Maximum results (default 50)
 
         Returns:
@@ -236,6 +238,7 @@ class PlayerStatsDAO(BaseDAO):
                         season_id,
                         match_status,
                         match_type_id,
+                        tournament_id,
                         division_id,
                         age_group_id,
                         division:divisions(
@@ -277,6 +280,11 @@ class PlayerStatsDAO(BaseDAO):
                 stats = [
                     s for s in stats
                     if s.get("match", {}).get("match_type_id") == match_type_id
+                ]
+            if tournament_id is not None:
+                stats = [
+                    s for s in stats
+                    if s.get("match", {}).get("tournament_id") == tournament_id
                 ]
             if league_id is not None:
                 # For matches with a division, check division.league_id directly.
@@ -339,6 +347,7 @@ class PlayerStatsDAO(BaseDAO):
                 division_id=division_id,
                 age_group_id=age_group_id,
                 match_type_id=match_type_id,
+                tournament_id=tournament_id,
             )
             raise
 

--- a/frontend/src/components/GoalsLeaderboard.vue
+++ b/frontend/src/components/GoalsLeaderboard.vue
@@ -106,6 +106,31 @@
         </div>
       </div>
 
+      <!-- Tournament Selector (only when Match Type = Tournament) -->
+      <div v-if="isTournamentSelected" data-testid="tournament-filter">
+        <h3 class="text-sm font-medium text-gray-700 mb-3">Tournament</h3>
+        <select
+          v-model="selectedTournamentId"
+          class="block w-full sm:max-w-md px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+          data-testid="tournament-select"
+        >
+          <option :value="null">All Tournaments</option>
+          <option
+            v-for="tournament in filteredTournaments"
+            :key="tournament.id"
+            :value="tournament.id"
+          >
+            {{ tournament.name }}
+          </option>
+        </select>
+        <p
+          v-if="filteredTournaments.length === 0"
+          class="mt-2 text-xs text-gray-500"
+        >
+          No tournaments for the selected age group.
+        </p>
+      </div>
+
       <!-- Season and Division Row -->
       <div
         class="flex flex-col sm:flex-row sm:space-x-6 space-y-4 sm:space-y-0"
@@ -284,7 +309,7 @@
 </template>
 
 <script>
-import { ref, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useAuthStore } from '../stores/auth';
 import { getApiBaseUrl } from '../config/api';
 import SupportEmailLink from '@/components/SupportEmailLink.vue';
@@ -303,13 +328,40 @@ export default {
     const allDivisions = ref([]);
     const seasons = ref([]);
     const matchTypes = ref([]);
+    const tournaments = ref([]);
     const selectedAgeGroupId = ref(null);
     const selectedLeagueId = ref(null);
     const selectedDivisionId = ref(null);
     const selectedSeasonId = ref(null);
     const selectedMatchTypeId = ref(null);
+    const selectedTournamentId = ref(null);
     const error = ref(null);
     const loading = ref(true);
+
+    // The match-type id for "Tournament" (seed data id=2, resolved by name).
+    const tournamentMatchTypeId = computed(() => {
+      const mt = matchTypes.value.find(m => m.name === 'Tournament');
+      return mt ? mt.id : null;
+    });
+
+    // Tournament dropdown is only shown when the Tournament match type is active.
+    const isTournamentSelected = computed(
+      () =>
+        tournamentMatchTypeId.value !== null &&
+        selectedMatchTypeId.value === tournamentMatchTypeId.value
+    );
+
+    // Only list tournaments whose age groups include the selected age group.
+    const filteredTournaments = computed(() => {
+      if (!selectedAgeGroupId.value) {
+        return tournaments.value;
+      }
+      return tournaments.value.filter(t =>
+        (t.age_groups || []).some(
+          ag => Number(ag.id) === Number(selectedAgeGroupId.value)
+        )
+      );
+    });
 
     const fetchAgeGroups = async () => {
       try {
@@ -357,6 +409,17 @@ export default {
         matchTypes.value = data.sort((a, b) => a.name.localeCompare(b.name));
       } catch (err) {
         console.error('Error fetching match types:', err);
+      }
+    };
+
+    const fetchTournaments = async () => {
+      try {
+        const data = await authStore.apiRequest(
+          `${getApiBaseUrl()}/api/tournaments`
+        );
+        tournaments.value = data.sort((a, b) => a.name.localeCompare(b.name));
+      } catch (err) {
+        console.error('Error fetching tournaments:', err);
       }
     };
 
@@ -444,6 +507,9 @@ export default {
         if (selectedMatchTypeId.value) {
           url += `&match_type_id=${selectedMatchTypeId.value}`;
         }
+        if (isTournamentSelected.value && selectedTournamentId.value) {
+          url += `&tournament_id=${selectedTournamentId.value}`;
+        }
 
         console.log('Fetching leaderboard:', url);
         const data = await authStore.apiRequest(url);
@@ -480,6 +546,27 @@ export default {
       selectedDivisionId.value = null;
     });
 
+    // Clear the tournament selection whenever the Tournament match type is
+    // deselected — keeps a stale tournament_id from leaking into other filters.
+    watch(selectedMatchTypeId, () => {
+      if (!isTournamentSelected.value) {
+        selectedTournamentId.value = null;
+      }
+    });
+
+    // If the age group changes and the chosen tournament no longer matches it,
+    // drop the selection so we never query a tournament outside the age group.
+    watch(selectedAgeGroupId, () => {
+      if (
+        selectedTournamentId.value &&
+        !filteredTournaments.value.some(
+          t => t.id === selectedTournamentId.value
+        )
+      ) {
+        selectedTournamentId.value = null;
+      }
+    });
+
     // Watch for changes in filters and refetch data
     watch(
       [
@@ -488,6 +575,7 @@ export default {
         selectedLeagueId,
         selectedDivisionId,
         selectedMatchTypeId,
+        selectedTournamentId,
       ],
       () => {
         if (selectedSeasonId.value) {
@@ -502,6 +590,7 @@ export default {
         fetchLeagues(),
         fetchSeasons(),
         fetchMatchTypes(),
+        fetchTournaments(),
       ]);
       await fetchDivisions();
       fetchLeaderboardData();
@@ -534,11 +623,15 @@ export default {
       divisions,
       seasons,
       matchTypes,
+      tournaments,
       selectedAgeGroupId,
       selectedLeagueId,
       selectedDivisionId,
       selectedSeasonId,
       selectedMatchTypeId,
+      selectedTournamentId,
+      isTournamentSelected,
+      filteredTournaments,
       formatSeasonDates,
       hasPlayerName,
       formatPlayerName,


### PR DESCRIPTION
## Summary
Adds a per-tournament filter to the Goals Leaderboard. When **Match Type = Tournament** is selected, a tournament dropdown appears (scoped to the selected age group) so users can view top scorers for a single tournament instead of all tournament matches.

## Changes
**Backend**
- `dao/player_stats_dao.py` — `get_goals_leaderboard` accepts optional `tournament_id`, filters `player_match_stats` by `matches.tournament_id`, and includes it in the cache key + error context.
- `app.py` — `/api/leaderboards/goals` exposes a `tournament_id` query param.

**Frontend** (`GoalsLeaderboard.vue`)
- Fetches active tournaments from `/api/tournaments`.
- Tournament dropdown renders only when Match Type = Tournament; list scoped to the selected age group; All Tournaments default with empty-state hint.
- Sends `tournament_id` only when a specific tournament is chosen.
- Clears the selection when leaving Tournament match type or when an age-group change orphans it.

## Notes
- Filtering done in Python (PostgREST nested-join quirk) — matches the existing leaderboard filter pattern.
- Lint clean: ruff + eslint.

## Test plan
- [ ] Leaderboard -> select Tournament match type -> dropdown appears
- [ ] Pick a tournament -> results narrow to that tournament's scorers
- [ ] Change age group -> tournament list re-scopes; orphaned pick resets
- [ ] Switch away from Tournament -> dropdown hides, filter clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
