### PR TITLE
fix(bracket): hide score for unplayed bracket matches

### DIFF
--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -344,6 +344,14 @@ function isWinner(match, side) {
 }
 
 function scoreCell(match, side) {
+  // A not-yet-played match can carry a stored 0:0 (create defaults scores to 0,
+  // and there is no write path to null them again). Only surface a score once the
+  // match is actually under way or final — otherwise it reads as a played 0:0 draw.
+  if (
+    match.match_status !== 'completed' &&
+    match.match_status !== 'in_progress'
+  )
+    return 'TBD';
   if (match.home_score == null || match.away_score == null) return 'TBD';
   const base = side === 'home' ? match.home_score : match.away_score;
   if (match.home_penalty_score != null && match.away_penalty_score != null) {


### PR DESCRIPTION
## Problem
Tournament match creation defaults `home_score`/`away_score` to `0` when no score is supplied, and there is **no API/CLI/DAO path to null them again** (all skip `None`). A scheduled bracket match — e.g. a Final whose two teams are set but the game hasn't kicked off — therefore rendered as a played **0:0 draw** in the bracket view.

## Fix
Gate `scoreCell` in `TournamentBracket.vue` on `match_status`: only surface a score once the match is `in_progress` or `completed`; otherwise show **TBD**. The status-based text-color logic already special-cased `completed`, so this aligns the score display with it.

## Context
Surfaced while loading the **U19 MLS NEXT Cup Championship** bracket — the Final (St. Louis CITY SC vs Columbus Crew) is scheduled but not yet played, and showed `0:0`.

## Test plan
- Bracket Final cell with `match_status=scheduled` → shows `TBD`
- Completed match → unchanged (score + pens)
- In-progress match → shows live score

🤖 Generated with [Claude Code](https://claude.com/claude-code)