### PR TITLE
fix(bracket): show forfeit score in tournament bracket

### DIFF
--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -346,10 +346,13 @@ function isWinner(match, side) {
 function scoreCell(match, side) {
   // A not-yet-played match can carry a stored 0:0 (create defaults scores to 0,
   // and there is no write path to null them again). Only surface a score once the
-  // match is actually under way or final — otherwise it reads as a played 0:0 draw.
+  // match is actually under way or has a result — otherwise it reads as a played
+  // 0:0 draw. A forfeit carries a real result (e.g. 3:0), so it counts too; this
+  // mirrors the backend, which treats ('completed', 'forfeit') as result-bearing.
   if (
     match.match_status !== 'completed' &&
-    match.match_status !== 'in_progress'
+    match.match_status !== 'in_progress' &&
+    match.match_status !== 'forfeit'
   )
     return 'TBD';
   if (match.home_score == null || match.away_score == null) return 'TBD';


### PR DESCRIPTION
## Problem
Follow-up to #441. `scoreCell` in `TournamentBracket.vue` only surfaces a score when `match_status` is `completed` or `in_progress`. A **forfeited** bracket match (status `forfeit`, real result e.g. `3:0`) falls through to `TBD`, hiding its score.

## Fix
Also surface the score for `forfeit`. This mirrors the backend, which treats `('completed', 'forfeit')` as result-bearing everywhere — `standings.py`, `playoff_dao.py`, `match_dao.py`.

```js
if (
  match.match_status !== 'completed' &&
  match.match_status !== 'in_progress' &&
  match.match_status !== 'forfeit'
)
  return 'TBD';
```

## Notes
- 1 file, +5/−2. Lint clean (eslint).
- Pre-existing, out of scope: the frontend uses `in_progress` while the DB/backend enum uses `live` (`app.py:2602`). Tracking separately.

## Test plan
- [ ] Forfeited bracket match shows its score (e.g. `3` / `0`), not `TBD`
- [ ] Scheduled/unplayed match still shows `TBD`
- [ ] Completed match with PKs still shows `base (pk)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
