### PR TITLE
feat(match-preview): unscope Recent Form + show tournament round

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2338,7 +2338,6 @@ async def get_match_preview(
     season_id: int | None = Query(None, description="Season ID for recent form and common opponents"),
     age_group_id: int | None = Query(None, description="Filter by age group"),
     recent_count: int = Query(5, ge=1, le=20, description="Number of recent matches per team"),
-    match_type_id: int | None = Query(None, description="If set, filters recent form to this match type"),
     current_user: dict[str, Any] = Depends(get_current_user_required),
 ):
     """Get match preview data for two teams.
@@ -2353,7 +2352,6 @@ async def get_match_preview(
             season_id=season_id,
             age_group_id=age_group_id,
             recent_count=recent_count,
-            match_type_id=match_type_id,
         )
 
         # Augment preview with QoP ranking data

--- a/backend/dao/match_dao.py
+++ b/backend/dao/match_dao.py
@@ -650,7 +650,6 @@ class MatchDAO(BaseDAO):
         season_id: int | None = None,
         age_group_id: int | None = None,
         recent_count: int = 5,
-        match_type_id: int | None = None,
     ) -> dict:
         """Get match preview data: recent form, common opponents, and head-to-head history.
 
@@ -660,7 +659,6 @@ class MatchDAO(BaseDAO):
             season_id: Season for recent form and common opponents (None = all seasons)
             age_group_id: Optional filter to restrict to a specific age group
             recent_count: How many recent matches to return per team
-            match_type_id: If set, restricts recent form to matches of this type
 
         Returns:
             Dict with home_team_recent, away_team_recent, common_opponents, head_to_head
@@ -701,7 +699,7 @@ class MatchDAO(BaseDAO):
                 "updated_at": match.get("updated_at"),
             }
 
-        def build_base_query(team_id: int, filter_match_type: bool = False):
+        def build_base_query(team_id: int):
             q = (
                 self.client.table("matches")
                 .select(select_str)
@@ -712,8 +710,6 @@ class MatchDAO(BaseDAO):
                 q = q.eq("season_id", season_id)
             if age_group_id:
                 q = q.eq("age_group_id", age_group_id)
-            if filter_match_type and match_type_id:
-                q = q.eq("match_type_id", match_type_id)
             return q
 
         def birth_year(age_group_name: str | None, season_name: str | None) -> int | None:
@@ -734,15 +730,15 @@ class MatchDAO(BaseDAO):
             return end_year - age_num
 
         try:
-            # --- Recent form for each team (filtered to the same match type) ---
+            # --- Recent form for each team (all match types) ---
             home_resp = (
-                build_base_query(home_team_id, filter_match_type=True)
+                build_base_query(home_team_id)
                 .order("match_date", desc=True)
                 .limit(recent_count)
                 .execute()
             )
             away_resp = (
-                build_base_query(away_team_id, filter_match_type=True)
+                build_base_query(away_team_id)
                 .order("match_date", desc=True)
                 .limit(recent_count)
                 .execute()

--- a/frontend/src/__tests__/components/MatchDetailView.spec.js
+++ b/frontend/src/__tests__/components/MatchDetailView.spec.js
@@ -371,6 +371,36 @@ describe('MatchDetailView', () => {
       expect(wrapper.text()).toContain('Northeast');
     });
 
+    it('displays the tournament round (not division) for tournament matches', async () => {
+      const match = createMockMatch({
+        match_type_name: 'Tournament',
+        tournament_round: 'quarterfinal',
+        division_name: 'Northeast',
+      });
+      mockAuthStore.apiRequest = vi.fn(() => Promise.resolve(match));
+      const wrapper = mountMatchDetailView();
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Round');
+      expect(wrapper.text()).toContain('Quarterfinal');
+      // Division label/value suppressed for tournament matches
+      expect(wrapper.text()).not.toContain('Northeast');
+    });
+
+    it('does not show a round row for tournament matches without a round', async () => {
+      const match = createMockMatch({
+        match_type_name: 'Tournament',
+        tournament_round: null,
+        division_name: 'Northeast',
+      });
+      mockAuthStore.apiRequest = vi.fn(() => Promise.resolve(match));
+      const wrapper = mountMatchDetailView();
+      await flushPromises();
+
+      // No round, and division stays suppressed for tournaments
+      expect(wrapper.text()).not.toContain('Northeast');
+    });
+
     it('displays league when available', async () => {
       const match = createMockMatch({
         division: { leagues: { name: 'Homegrown' } },

--- a/frontend/src/__tests__/utils/tournamentRounds.spec.js
+++ b/frontend/src/__tests__/utils/tournamentRounds.spec.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TOURNAMENT_ROUNDS,
+  ROUND_LABELS_SHORT,
+  ROUND_LABELS_LONG,
+  roundLabel,
+} from '@/utils/tournamentRounds';
+
+describe('tournamentRounds util', () => {
+  it('derives short label maps from the canonical source', () => {
+    expect(ROUND_LABELS_SHORT.quarterfinal).toBe('QF');
+    expect(ROUND_LABELS_SHORT.round_of_16).toBe('R16');
+  });
+
+  it('derives long label maps from the canonical source', () => {
+    expect(ROUND_LABELS_LONG.quarterfinal).toBe('Quarterfinal');
+    expect(ROUND_LABELS_LONG.round_of_16).toBe('Round of 16');
+  });
+
+  it('keeps short and long maps in sync with the canonical keys', () => {
+    const keys = Object.keys(TOURNAMENT_ROUNDS);
+    expect(Object.keys(ROUND_LABELS_SHORT)).toEqual(keys);
+    expect(Object.keys(ROUND_LABELS_LONG)).toEqual(keys);
+  });
+
+  it('roundLabel returns the long label by default', () => {
+    expect(roundLabel('semifinal')).toBe('Semifinal');
+  });
+
+  it('roundLabel returns the short label when requested', () => {
+    expect(roundLabel('semifinal', { short: true })).toBe('SF');
+  });
+
+  it('roundLabel returns null for unknown or empty rounds', () => {
+    expect(roundLabel('not_a_round')).toBeNull();
+    expect(roundLabel(null)).toBeNull();
+    expect(roundLabel(undefined)).toBeNull();
+  });
+});

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -375,7 +375,20 @@
                     }}</span>
                   </div>
                   <div
-                    v-if="
+                    v-if="isTournament && tournamentRoundLabel"
+                    class="detail-item"
+                  >
+                    <span
+                      class="text-[10px] text-slate-500 uppercase tracking-wider"
+                      >Round</span
+                    >
+                    <span class="text-xs font-medium text-white">{{
+                      tournamentRoundLabel
+                    }}</span>
+                  </div>
+                  <div
+                    v-else-if="
+                      !isTournament &&
                       match.division_name &&
                       match.match_type_name !== 'Friendly'
                     "
@@ -552,7 +565,6 @@
               :awayTeamName="match.away_team_name"
               :seasonId="match.season_id"
               :ageGroupId="match.age_group_id"
-              :matchTypeId="match.match_type_id"
             />
           </div>
 
@@ -726,6 +738,7 @@ import LineupManager from './live/LineupManager.vue';
 import PostMatchEditor from './PostMatchEditor.vue';
 import MatchPreview from './MatchPreview.vue';
 import IgShareModal from './IgShareModal.vue';
+import { roundLabel } from '../utils/tournamentRounds';
 
 export default {
   name: 'MatchDetailView',
@@ -787,6 +800,14 @@ export default {
     const leagueName = computed(() => {
       return match.value?.division?.leagues?.name || null;
     });
+
+    // Tournament matches have no division; show the bracket round instead.
+    const isTournament = computed(
+      () => match.value?.match_type_name === 'Tournament'
+    );
+    const tournamentRoundLabel = computed(() =>
+      roundLabel(match.value?.tournament_round)
+    );
 
     // Determine sport type from match data
     const sportType = computed(() => {
@@ -1155,6 +1176,8 @@ export default {
       homeTeamColor,
       awayTeamColor,
       leagueName,
+      isTournament,
+      tournamentRoundLabel,
       sportType,
       statusBadgeClass,
       getTeamInitials,

--- a/frontend/src/components/MatchPreview.vue
+++ b/frontend/src/components/MatchPreview.vue
@@ -492,7 +492,6 @@ const props = defineProps({
   /** How many recent matches to fetch per team */
   recentCount: { type: Number, default: 5 },
   /** If set, restricts recent form to matches of this type (e.g. League only) */
-  matchTypeId: { type: Number, default: null },
 });
 
 // ─── State ────────────────────────────────────────────────────────────────────
@@ -547,7 +546,6 @@ async function fetchPreview() {
     const params = new URLSearchParams();
     if (props.seasonId) params.set('season_id', props.seasonId);
     if (props.ageGroupId) params.set('age_group_id', props.ageGroupId);
-    if (props.matchTypeId) params.set('match_type_id', props.matchTypeId);
     params.set('recent_count', props.recentCount);
 
     const url = `${getApiBaseUrl()}/api/matches/preview/${props.homeTeamId}/${props.awayTeamId}?${params}`;
@@ -593,13 +591,7 @@ async function fetchPreview() {
 
 // Refetch when key props change
 watch(
-  () => [
-    props.homeTeamId,
-    props.awayTeamId,
-    props.seasonId,
-    props.ageGroupId,
-    props.matchTypeId,
-  ],
+  () => [props.homeTeamId, props.awayTeamId, props.seasonId, props.ageGroupId],
   () => fetchPreview(),
   { immediate: false }
 );

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -894,6 +894,7 @@ import TournamentStandings from './TournamentStandings.vue';
 import MatchDetailView from './MatchDetailView.vue';
 import { useBracketFollows } from '../composables/useBracketFollows';
 import { usePushNotifications } from '../composables/usePushNotifications';
+import { ROUND_LABELS_SHORT as ROUND_LABELS } from '../utils/tournamentRounds';
 
 const KNOCKOUT_ROUNDS = new Set([
   'round_of_32',
@@ -911,16 +912,6 @@ const BRACKET_ROUNDS = new Set([
   'semifinal',
   'final',
 ]);
-
-const ROUND_LABELS = {
-  group_stage: 'Group Stage',
-  round_of_32: 'R32',
-  round_of_16: 'R16',
-  quarterfinal: 'QF',
-  semifinal: 'SF',
-  third_place: '3rd Place',
-  final: 'Final',
-};
 
 export default {
   name: 'TournamentMatchCenter',

--- a/frontend/src/components/admin/AdminTournaments.vue
+++ b/frontend/src/components/admin/AdminTournaments.vue
@@ -668,16 +668,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { getApiBaseUrl } from '../../config/api';
-
-const ROUND_LABELS = {
-  group_stage: 'Group Stage',
-  round_of_32: 'Round of 32',
-  round_of_16: 'Round of 16',
-  quarterfinal: 'Quarterfinal',
-  semifinal: 'Semifinal',
-  third_place: 'Third Place',
-  final: 'Final',
-};
+import { ROUND_LABELS_LONG as ROUND_LABELS } from '../../utils/tournamentRounds';
 
 export default {
   name: 'AdminTournaments',

--- a/frontend/src/utils/tournamentRounds.js
+++ b/frontend/src/utils/tournamentRounds.js
@@ -1,0 +1,31 @@
+// Single source of truth for tournament round display labels.
+//
+// Matches carry a `tournament_round` key (e.g. "quarterfinal"). Different
+// surfaces want different verbosity:
+//   - compact bracket / match-center views use short labels ("QF")
+//   - admin and detail views use full labels ("Quarterfinal")
+
+export const TOURNAMENT_ROUNDS = {
+  group_stage: { short: 'Group Stage', long: 'Group Stage' },
+  round_of_32: { short: 'R32', long: 'Round of 32' },
+  round_of_16: { short: 'R16', long: 'Round of 16' },
+  quarterfinal: { short: 'QF', long: 'Quarterfinal' },
+  semifinal: { short: 'SF', long: 'Semifinal' },
+  third_place: { short: '3rd Place', long: 'Third Place' },
+  final: { short: 'Final', long: 'Final' },
+};
+
+export const ROUND_LABELS_SHORT = Object.fromEntries(
+  Object.entries(TOURNAMENT_ROUNDS).map(([key, { short }]) => [key, short])
+);
+
+export const ROUND_LABELS_LONG = Object.fromEntries(
+  Object.entries(TOURNAMENT_ROUNDS).map(([key, { long }]) => [key, long])
+);
+
+// Resolve a round key to a label. Returns null for unknown/empty rounds.
+export function roundLabel(round, { short = false } = {}) {
+  const entry = TOURNAMENT_ROUNDS[round];
+  if (!entry) return null;
+  return short ? entry.short : entry.long;
+}


### PR DESCRIPTION
## Summary
Improves the matchup preview view (SB-107). Two UX fixes.

### 1. Recent Form no longer scoped to match type
Recent Form filtered each team's results to the **same match type** as the upcoming match. A team with no completed matches of that type (plays league, not tournaments) showed *"No recent matches"* despite a full history — confusing for two same-division teams.

Now shows the last N completed/forfeit matches across **all** match types (still season + age-group scoped). Common Opponents and Head-to-Head unchanged.

Removes the now-unused `match_type_id` param end-to-end: preview endpoint, `match_dao.get_match_preview`, and the `MatchPreview` prop/fetch/watch.

### 2. Tournament Round instead of "Division: Unknown"
Tournament fixtures have no division, so the Match Details card showed `Division: Unknown`. For Tournament matches it now shows the bracket **Round** (e.g. "Quarterfinal").

Round-label maps were duplicated in `TournamentMatchCenter.vue` (short: `QF`) and `AdminTournaments.vue` (long: `Quarterfinal`) — extracted to a shared `utils/tournamentRounds.js` (`ROUND_LABELS_SHORT`, `ROUND_LABELS_LONG`, `roundLabel`). Both surfaces keep their existing label style.

## Testing
- ✅ `MatchDetailView.spec.js` — round shown / division suppressed for tournaments
- ✅ `tournamentRounds.spec.js` — util label maps + `roundLabel`
- ✅ TournamentMatchCenter + qop_rankings suites pass; ruff + eslint clean

## Not covered
No backend integration test for "recent form returns mixed match types" — the preview endpoint has no existing integration harness and such a test would be brittle against seed data. The change is a filter removal verified by frontend coverage + param cleanup.

## Mobile
Match Details card is the same responsive grid; Round row swaps in for Division with no layout change. Worth a mobile spot-check on a tournament match.

Fixes SB-107

🤖 Generated with [Claude Code](https://claude.com/claude-code)