### PR TITLE
feat(tournaments): logo upload UI, aspect-safe variants, share-card logo chip (SB-114)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4619,6 +4619,32 @@ async def update_club(club_id: int, club: Club, current_user: dict[str, Any] = D
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+def _upload_logo_png_variants(storage, bucket: str, base_name: str, content: bytes) -> None:
+    """Upload 64px/128px PNG size variants, preserving aspect ratio.
+
+    The source is fit inside a transparent square canvas (centered) so
+    non-square logos are not distorted. Share cards can then pull a small
+    render without downsampling the full asset at render time.
+    """
+    from io import BytesIO
+
+    from PIL import Image as PILImage
+
+    base_img = PILImage.open(BytesIO(content)).convert("RGBA")
+    for suffix, px in [("_sm", 64), ("_md", 128)]:
+        thumb = base_img.copy()
+        thumb.thumbnail((px, px), PILImage.LANCZOS)
+        canvas = PILImage.new("RGBA", (px, px), (0, 0, 0, 0))
+        canvas.paste(thumb, ((px - thumb.width) // 2, (px - thumb.height) // 2))
+        buf = BytesIO()
+        canvas.save(buf, "PNG")
+        storage.from_(bucket).upload(
+            f"{base_name}{suffix}.png",
+            buf.getvalue(),
+            file_options={"content-type": "image/png", "upsert": "true"},
+        )
+
+
 @app.post("/api/clubs/{club_id}/logo")
 async def upload_club_logo(
     club_id: int,
@@ -4664,21 +4690,7 @@ async def upload_club_logo(
 
         # Generate and upload size variants (_sm=64px, _md=128px) for PNGs
         if ext == "png":
-            from io import BytesIO
-
-            from PIL import Image as PILImage
-
-            base_img = PILImage.open(BytesIO(content))
-            for suffix, px in [("_sm", 64), ("_md", 128)]:
-                variant = base_img.resize((px, px), PILImage.LANCZOS)
-                buf = BytesIO()
-                variant.save(buf, "PNG")
-                variant_path = f"{club_id}{suffix}.png"
-                storage.from_("club-logos").upload(
-                    variant_path,
-                    buf.getvalue(),
-                    file_options={"content-type": "image/png", "upsert": "true"},
-                )
+            _upload_logo_png_variants(storage, "club-logos", str(club_id), content)
             logger.info(f"Uploaded size variants for club {club_id}")
 
         # Get public URL (points to base image)
@@ -6795,21 +6807,7 @@ async def admin_upload_tournament_logo(
 
         # Size variants — only for PNGs, same as club logos.
         if ext == "png":
-            from io import BytesIO
-
-            from PIL import Image as PILImage
-
-            base_img = PILImage.open(BytesIO(content))
-            for suffix, px in [("_sm", 64), ("_md", 128)]:
-                variant = base_img.resize((px, px), PILImage.LANCZOS)
-                buf = BytesIO()
-                variant.save(buf, "PNG")
-                variant_path = f"{tournament_id}{suffix}.png"
-                storage.from_("tournament-logos").upload(
-                    variant_path,
-                    buf.getvalue(),
-                    file_options={"content-type": "image/png", "upsert": "true"},
-                )
+            _upload_logo_png_variants(storage, "tournament-logos", str(tournament_id), content)
             logger.info(f"Uploaded size variants for tournament {tournament_id}")
 
         public_url = storage.from_("tournament-logos").get_public_url(file_path)

--- a/backend/tests/unit/test_logo_variants.py
+++ b/backend/tests/unit/test_logo_variants.py
@@ -1,0 +1,88 @@
+"""Unit tests for the shared logo size-variant helper (SB-114).
+
+The previous variant code resized non-square logos straight to (px, px),
+squashing them. The helper must fit the source inside a transparent square
+canvas instead — the NAC tournament logo (347x431) was the motivating case.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from PIL import Image as PILImage
+
+from app import _upload_logo_png_variants
+
+
+class FakeBucket:
+    def __init__(self, store):
+        self._store = store
+
+    def upload(self, path, content, file_options=None):
+        self._store[path] = {"content": content, "file_options": file_options}
+
+
+class FakeStorage:
+    def __init__(self):
+        self.uploads = {}
+
+    def from_(self, bucket):
+        return FakeBucket(self.uploads)
+
+
+def _make_png_bytes(width: int, height: int, mode: str = "RGBA") -> bytes:
+    img = PILImage.new(mode, (width, height), color=(10, 20, 30, 255))
+    buf = BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _open(data: bytes) -> PILImage.Image:
+    return PILImage.open(BytesIO(data))
+
+
+class TestUploadLogoPngVariants:
+    def test_uploads_sm_and_md_variants(self):
+        storage = FakeStorage()
+        _upload_logo_png_variants(storage, "tournament-logos", "6", _make_png_bytes(347, 431))
+
+        assert set(storage.uploads) == {"6_sm.png", "6_md.png"}
+        assert _open(storage.uploads["6_sm.png"]["content"]).size == (64, 64)
+        assert _open(storage.uploads["6_md.png"]["content"]).size == (128, 128)
+
+    def test_non_square_source_is_not_distorted(self):
+        # A tall source must keep its aspect ratio: the visible (opaque)
+        # region of the square canvas should be narrower than it is tall.
+        storage = FakeStorage()
+        _upload_logo_png_variants(storage, "tournament-logos", "6", _make_png_bytes(347, 431))
+
+        variant = _open(storage.uploads["6_md.png"]["content"])
+        left, upper, right, lower = variant.getchannel("A").getbbox()
+        visible_w, visible_h = right - left, lower - upper
+        assert visible_h == 128  # tall axis fills the canvas
+        assert visible_w < 128  # short axis is letterboxed, not stretched
+        # Centered horizontally (allow 1px rounding)
+        assert abs(left - (128 - right)) <= 1
+
+    def test_square_source_fills_canvas(self):
+        storage = FakeStorage()
+        _upload_logo_png_variants(storage, "club-logos", "12", _make_png_bytes(500, 500))
+
+        variant = _open(storage.uploads["12_md.png"]["content"])
+        assert variant.getchannel("A").getbbox() == (0, 0, 128, 128)
+
+    def test_rgb_source_is_converted(self):
+        # JPG-ish RGB content saved as PNG must not crash the RGBA paste.
+        storage = FakeStorage()
+        _upload_logo_png_variants(storage, "club-logos", "3", _make_png_bytes(300, 200, mode="RGB"))
+
+        variant = _open(storage.uploads["3_sm.png"]["content"])
+        assert variant.size == (64, 64)
+        assert variant.mode == "RGBA"
+
+    def test_upserts_with_png_content_type(self):
+        storage = FakeStorage()
+        _upload_logo_png_variants(storage, "tournament-logos", "6", _make_png_bytes(100, 100))
+
+        opts = storage.uploads["6_sm.png"]["file_options"]
+        assert opts == {"content-type": "image/png", "upsert": "true"}

--- a/docs/features/CLUB_LOGO_SYSTEM.md
+++ b/docs/features/CLUB_LOGO_SYSTEM.md
@@ -25,6 +25,11 @@ The `enrich` command successfully finds club websites, but the logos it captures
 - **Frontend auto-selects** the right variant based on the `size` prop, with fallback to base URL on 404
 - **Naming**: `{slug}.png` (base), `{slug}_sm.png`, `{slug}_md.png` where slug = lowercase, hyphens for spaces, accents stripped
   - `inter-miami-cf.png`, `inter-miami-cf_sm.png`, `inter-miami-cf_md.png`
+- **Server-side variants**: the upload endpoints (`POST /api/clubs/{id}/logo`, `POST /api/admin/tournaments/{id}/logo`) generate `_sm`/`_md` via `_upload_logo_png_variants` in `backend/app.py`. Non-square sources are fit inside a transparent square canvas (centered, aspect ratio preserved — never stretched). SB-114.
+
+### Tournament Logos
+
+Tournament logos follow the same convention in the `tournament-logos` bucket, keyed by tournament id (`6.png`, `6_sm.png`, `6_md.png`). Upload via **Admin → Tournaments → Edit → Logo** or the API endpoint. Square PNG with transparent background looks best — IG share cards render the logo inside a white rounded chip (background-image, not `<img>`, for html2canvas fidelity).
 
 ### Storage Convention
 

--- a/frontend/src/__tests__/components/IgShareTemplates.spec.js
+++ b/frontend/src/__tests__/components/IgShareTemplates.spec.js
@@ -288,9 +288,11 @@ describe('tournament logo (all templates)', () => {
           tournament_round: template === 'tournament-round' ? 'final' : null,
         }),
       });
-      const img = wrapper.find('[data-testid="ig-tournament-logo"]');
-      expect(img.exists()).toBe(true);
-      expect(img.attributes('src')).toBe(LOGO_URL);
+      // Rendered as a background-image div (not <img>) inside a white
+      // chip so html2canvas honors contain and dark logos stay legible.
+      const logo = wrapper.find('[data-testid="ig-tournament-logo"]');
+      expect(logo.exists()).toBe(true);
+      expect(logo.attributes('style')).toContain(LOGO_URL);
     });
 
     it(`omits the logo slot on ${template} when tournament_logo_url is absent`, () => {

--- a/frontend/src/components/admin/AdminTournaments.vue
+++ b/frontend/src/components/admin/AdminTournaments.vue
@@ -331,6 +331,63 @@
               ></textarea>
             </div>
 
+            <!-- Logo -->
+            <div class="mb-4">
+              <label class="block text-sm font-medium text-gray-700 mb-1"
+                >Logo</label
+              >
+              <div class="flex items-center gap-4">
+                <!-- Preview -->
+                <img
+                  v-if="tLogoPreview || editingTournament?.logo_url"
+                  :src="tLogoPreview || editingTournament.logo_url"
+                  alt="Tournament logo preview"
+                  class="w-16 h-16 rounded-md object-contain border border-gray-200 bg-white p-1"
+                  data-testid="tournament-logo-preview"
+                />
+                <div
+                  v-else
+                  class="w-16 h-16 rounded-md bg-gray-100 flex items-center justify-center"
+                >
+                  <svg
+                    class="w-8 h-8 text-gray-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                  </svg>
+                </div>
+                <!-- Upload button -->
+                <div class="flex-1">
+                  <input
+                    type="file"
+                    ref="tLogoInput"
+                    @change="handleTournamentLogoSelect"
+                    accept="image/png,image/jpeg,image/jpg"
+                    class="hidden"
+                  />
+                  <button
+                    type="button"
+                    @click="$refs.tLogoInput.click()"
+                    :disabled="tUploadingLogo"
+                    class="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+                  >
+                    {{ tUploadingLogo ? 'Uploading...' : 'Choose Image' }}
+                  </button>
+                  <p class="mt-1 text-xs text-gray-500">
+                    PNG or JPG, max 2MB. Square with transparent background
+                    looks best on share cards.
+                  </p>
+                </div>
+              </div>
+            </div>
+
             <!-- Active -->
             <div class="mb-6 flex items-center gap-2">
               <input
@@ -706,6 +763,9 @@ export default {
     const editingTournament = ref(null);
     const tFormLoading = ref(false);
     const tForm = ref(emptyTournamentForm());
+    const tLogoPreview = ref(null);
+    const tSelectedLogoFile = ref(null);
+    const tUploadingLogo = ref(false);
 
     // ── match modal ──
     const showMatchModal = ref(false);
@@ -856,6 +916,8 @@ export default {
     const openCreateTournament = () => {
       editingTournament.value = null;
       tForm.value = emptyTournamentForm();
+      tLogoPreview.value = null;
+      tSelectedLogoFile.value = null;
       showTournamentModal.value = true;
     };
 
@@ -870,7 +932,69 @@ export default {
         age_group_ids: (tournament.age_groups || []).map(ag => ag.id),
         is_active: tournament.is_active,
       };
+      tLogoPreview.value = null;
+      tSelectedLogoFile.value = null;
       showTournamentModal.value = true;
+    };
+
+    const handleTournamentLogoSelect = event => {
+      const file = event.target.files[0];
+      if (!file) return;
+
+      const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
+      if (!allowedTypes.includes(file.type)) {
+        error.value = 'Invalid file type. Please select a PNG or JPG image.';
+        return;
+      }
+
+      const maxSize = 2 * 1024 * 1024;
+      if (file.size > maxSize) {
+        error.value = `File too large. Maximum size is 2MB. Your file: ${(file.size / 1024 / 1024).toFixed(2)}MB`;
+        return;
+      }
+
+      tSelectedLogoFile.value = file;
+
+      const reader = new FileReader();
+      reader.onload = e => {
+        tLogoPreview.value = e.target.result;
+      };
+      reader.readAsDataURL(file);
+      error.value = null;
+    };
+
+    const uploadTournamentLogo = async tournamentId => {
+      if (!tSelectedLogoFile.value || !tournamentId) return;
+
+      tUploadingLogo.value = true;
+      try {
+        const formData = new FormData();
+        formData.append('file', tSelectedLogoFile.value);
+
+        // Use fetch directly for file upload - don't set Content-Type
+        // (browser sets it automatically with multipart boundary)
+        const token = localStorage.getItem('auth_token');
+        const fetchResponse = await fetch(
+          `${getApiBaseUrl()}/api/admin/tournaments/${tournamentId}/logo`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+            body: formData,
+          }
+        );
+
+        if (!fetchResponse.ok) {
+          const errorData = await fetchResponse.json();
+          throw new Error(errorData.detail || 'Failed to upload logo');
+        }
+
+        tLogoPreview.value = null;
+        tSelectedLogoFile.value = null;
+      } finally {
+        tUploadingLogo.value = false;
+      }
     };
 
     const saveTournament = async () => {
@@ -881,17 +1005,26 @@ export default {
         if (!payload.location) payload.location = null;
         if (!payload.description) payload.description = null;
 
+        let tournamentId;
         if (editingTournament.value) {
+          tournamentId = editingTournament.value.id;
           await authStore.apiRequest(
-            `${getApiBaseUrl()}/api/admin/tournaments/${editingTournament.value.id}`,
+            `${getApiBaseUrl()}/api/admin/tournaments/${tournamentId}`,
             { method: 'PUT', body: JSON.stringify(payload) }
           );
         } else {
-          await authStore.apiRequest(
+          const created = await authStore.apiRequest(
             `${getApiBaseUrl()}/api/admin/tournaments`,
             { method: 'POST', body: JSON.stringify(payload) }
           );
+          tournamentId = created?.id;
         }
+
+        // Upload logo after save so create mode has an id to attach to
+        if (tSelectedLogoFile.value && tournamentId) {
+          await uploadTournamentLogo(tournamentId);
+        }
+
         await fetchTournaments();
         closeTournamentModal();
       } catch (err) {
@@ -927,6 +1060,8 @@ export default {
       showTournamentModal.value = false;
       editingTournament.value = null;
       tForm.value = emptyTournamentForm();
+      tLogoPreview.value = null;
+      tSelectedLogoFile.value = null;
     };
 
     // ─────────────────────────────────────────────
@@ -1091,6 +1226,9 @@ export default {
       editingTournament,
       tFormLoading,
       tForm,
+      tLogoPreview,
+      tUploadingLogo,
+      handleTournamentLogoSelect,
       // match modal
       showMatchModal,
       editingMatch,

--- a/frontend/src/components/ig/IgOverlay.vue
+++ b/frontend/src/components/ig/IgOverlay.vue
@@ -97,14 +97,16 @@
           {{ metaLabel }}
         </span>
         <MlsNextBadge v-if="isHomegrownLeague" class="ig-mls-badge" />
-        <img
-          v-if="tournamentLogoUrl"
-          :src="tournamentLogoUrl"
-          class="ig-tournament-logo"
-          data-testid="ig-tournament-logo"
-          alt=""
-          crossorigin="anonymous"
-        />
+        <!-- White chip + background-image (not <img>) so dark logos stay
+             legible on the dark card and html2canvas renders contain
+             correctly — see [[feedback-html2canvas-object-fit]]. -->
+        <div v-if="tournamentLogoUrl" class="ig-tournament-logo">
+          <div
+            class="ig-tournament-logo-img"
+            data-testid="ig-tournament-logo"
+            :style="{ backgroundImage: `url(${tournamentLogoUrl})` }"
+          ></div>
+        </div>
       </div>
     </div>
 
@@ -344,8 +346,20 @@ export default {
 .ig-tournament-logo {
   height: 108px;
   width: 108px;
-  object-fit: contain;
   margin-left: 12px;
+  padding: 10px;
+  box-sizing: border-box;
+  background: #ffffff;
+  border-radius: 14px;
+  flex-shrink: 0;
+}
+
+.ig-tournament-logo-img {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .ig-chip {

--- a/frontend/src/components/ig/IgSplit.vue
+++ b/frontend/src/components/ig/IgSplit.vue
@@ -35,14 +35,16 @@
             <span class="meta" data-testid="ig-meta">{{ metaLabel }}</span>
           </div>
           <MlsNextBadge v-if="isHomegrownLeague" class="mls-badge" />
-          <img
-            v-if="tournamentLogoUrl"
-            :src="tournamentLogoUrl"
-            class="tournament-logo"
-            data-testid="ig-tournament-logo"
-            alt=""
-            crossorigin="anonymous"
-          />
+          <!-- White chip + background-image (not <img>) so dark logos stay
+               legible and html2canvas renders contain correctly — see
+               [[feedback-html2canvas-object-fit]]. -->
+          <div v-if="tournamentLogoUrl" class="tournament-logo">
+            <div
+              class="tournament-logo-img"
+              data-testid="ig-tournament-logo"
+              :style="{ backgroundImage: `url(${tournamentLogoUrl})` }"
+            ></div>
+          </div>
         </div>
       </div>
 
@@ -299,9 +301,20 @@ export default {
 .tournament-logo {
   height: 88px;
   width: 88px;
-  object-fit: contain;
   flex-shrink: 0;
   margin-left: 8px;
+  padding: 8px;
+  box-sizing: border-box;
+  background: #ffffff;
+  border-radius: 12px;
+}
+
+.tournament-logo-img {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .brand-mark {

--- a/frontend/src/components/ig/IgStadium.vue
+++ b/frontend/src/components/ig/IgStadium.vue
@@ -18,14 +18,16 @@
         >missingtable.com</span
       >
       <MlsNextBadge v-if="isHomegrownLeague" class="brand-band-badge" />
-      <img
-        v-if="tournamentLogoUrl"
-        :src="tournamentLogoUrl"
-        class="tournament-logo"
-        data-testid="ig-tournament-logo"
-        alt=""
-        crossorigin="anonymous"
-      />
+      <!-- White chip + background-image (not <img>) so dark logos stay
+           legible and html2canvas renders contain correctly — see
+           [[feedback-html2canvas-object-fit]]. -->
+      <div v-if="tournamentLogoUrl" class="tournament-logo">
+        <div
+          class="tournament-logo-img"
+          data-testid="ig-tournament-logo"
+          :style="{ backgroundImage: `url(${tournamentLogoUrl})` }"
+        ></div>
+      </div>
       <span class="meta" data-testid="ig-meta">{{ metaLabel }}</span>
     </div>
 
@@ -227,8 +229,20 @@ export default {
 .tournament-logo {
   height: 84px;
   width: 84px;
-  object-fit: contain;
   margin-right: 16px;
+  padding: 8px;
+  box-sizing: border-box;
+  background: #ffffff;
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+.tournament-logo-img {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .meta {

--- a/frontend/src/components/ig/IgTournamentRound.vue
+++ b/frontend/src/components/ig/IgTournamentRound.vue
@@ -46,14 +46,16 @@
             </span>
           </div>
           <MlsNextBadge v-if="isHomegrownLeague" class="mls-badge" />
-          <img
-            v-if="tournamentLogoUrl"
-            :src="tournamentLogoUrl"
-            class="tournament-logo"
-            data-testid="ig-tournament-logo"
-            alt=""
-            crossorigin="anonymous"
-          />
+          <!-- White chip + background-image (not <img>) so dark logos stay
+               legible and html2canvas renders contain correctly — see
+               [[feedback-html2canvas-object-fit]]. -->
+          <div v-if="tournamentLogoUrl" class="tournament-logo">
+            <div
+              class="tournament-logo-img"
+              data-testid="ig-tournament-logo"
+              :style="{ backgroundImage: `url(${tournamentLogoUrl})` }"
+            ></div>
+          </div>
         </div>
       </div>
 
@@ -272,9 +274,20 @@ export default {
 .tournament-logo {
   height: 88px;
   width: 88px;
-  object-fit: contain;
   flex-shrink: 0;
   margin-left: 8px;
+  padding: 8px;
+  box-sizing: border-box;
+  background: #ffffff;
+  border-radius: 12px;
+}
+
+.tournament-logo-img {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .brand-mark {


### PR DESCRIPTION
## Problem

The NAC tournament logo rendered as a tiny white box on IG share cards and the Tournaments page. Root cause: the prod asset was a broken 668×1218 image containing two copies of the logo plus huge whitespace — `object-fit: contain` in an 88–108px box renders it microscopic. The bad asset slipped in because there was no admin UI to upload tournament logos (raw API call only).

Fixes SB-114

## Changes

### Admin logo upload UI
- `AdminTournaments.vue`: logo upload + preview in the tournament modal (create and edit), mirroring the AdminClubs flow. Calls the existing `POST /api/admin/tournaments/{id}/logo`. On create, the logo uploads right after the tournament is created.

### Aspect-ratio-safe size variants (backend)
- Extracted `_upload_logo_png_variants`, shared by the club and tournament logo endpoints. Previously both resized `_sm`/`_md` variants straight to `(px, px)`, squashing non-square sources (the NAC logo is 347×431). Now the source is fit inside a transparent square canvas, centered.

### Share-card logo polish
- All four IG templates (`IgOverlay`, `IgSplit`, `IgStadium`, `IgTournamentRound`) now render the tournament logo as a background-image div inside a white rounded chip:
  - html2canvas ignores `object-fit` on `<img>` (would stretch in the downloaded PNG) — background-size: contain is honored.
  - The white chip keeps dark/transparent logos legible on dark card backgrounds.

## Tests

- New `backend/tests/unit/test_logo_variants.py` (5 tests): variant dimensions, no distortion for non-square sources, centering, RGB→RGBA conversion, upsert options.
- `IgShareTemplates.spec.js` updated for the background-image render; full frontend suite 490/490 passing.
- Lint clean (eslint + ruff).

## Follow-up (separate, no deploy needed)

Re-upload the clean NAC logo asset to prod via the logo endpoint — the broken asset is data, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)