### PR TITLE
fix(auth): stateless backend Supabase auth clients stop forced re-logins (SB-115)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "/Users/silverbeer/gitrepos/missing-table/.secrets.baseline"
+      "filename": "/Users/tomdrake/gitrepos/missing-table/.claude/worktrees/sb-115-stateless-auth-client/.secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -410,21 +410,21 @@
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 324
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "58a37cf13faaed3b81b3a1fce4872824eb4e57c4",
         "is_verified": false,
-        "line_number": 707
+        "line_number": 722
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 766
+        "line_number": 781
       }
     ],
     "docs/04-testing/api-contract-testing.md": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-31T19:53:56Z"
+  "generated_at": "2026-06-06T21:45:18Z"
 }

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,6 +7,7 @@ import httpx
 from dotenv import load_dotenv
 from fastapi import BackgroundTasks, Depends, FastAPI, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
 
 import r2_client
@@ -26,6 +27,7 @@ from auth import (
     require_admin_or_service_account,
     require_match_management_permission,
     require_team_manager_or_admin,
+    security,
     viewer_sees_test_content,
 )
 from constants import PLAYER_POSITIONS
@@ -234,19 +236,31 @@ tournament_dao = TournamentDAO(db_conn_holder_obj)
 # === Simple Redis Caching ===
 # Initialize Authentication Manager with a dedicated service client
 # This prevents login operations from modifying the client used for profile lookups
-from supabase import create_client
+from supabase import ClientOptions, create_client
+
+# Both auth clients MUST be stateless (SB-115). With the library defaults
+# (persist_session=True, auto_refresh_token=True), a session set by any
+# user's login/refresh is stored on the shared client and gotrue's
+# background thread silently refreshes it — rotating that user's refresh
+# token server-side. The device still holds the pre-rotation token, so its
+# next refresh is rejected as "already used" and the user is forced to log
+# in again. Stateless options mean: no stored session, no background
+# refresh thread, no cross-request session bleed.
+_STATELESS_AUTH_OPTIONS = ClientOptions(auto_refresh_token=False, persist_session=False)
 
 auth_service_client = create_client(
     os.getenv("SUPABASE_URL", ""),
     os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_ANON_KEY", ""),
+    options=_STATELESS_AUTH_OPTIONS,
 )
 auth_manager = AuthManager(auth_service_client)
 
-# Create a separate client for auth operations (login/signup/logout)
+# Create a separate client for auth operations (login/signup/refresh)
 # This prevents auth operations from modifying the client used by match_dao
 auth_ops_client = create_client(
     os.getenv("SUPABASE_URL", ""),
     os.getenv("SUPABASE_ANON_KEY", ""),  # Auth operations use anon key
+    options=_STATELESS_AUTH_OPTIONS,
 )
 
 
@@ -767,11 +781,19 @@ async def check_username_availability(username: str):
 
 
 @app.post("/api/auth/logout")
-async def logout(current_user: dict[str, Any] = Depends(get_current_user_required)):
-    """User logout endpoint."""
+async def logout(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    current_user: dict[str, Any] = Depends(get_current_user_required),
+):
+    """User logout endpoint.
+
+    Revokes the *caller's own* session via the admin API. The previous
+    implementation called sign_out() on the shared auth client, which
+    revoked whatever session that client happened to hold — potentially a
+    different user's (SB-115).
+    """
     try:
-        # Use auth_ops_client to avoid modifying the match_dao client
-        auth_ops_client.auth.sign_out()
+        auth_service_client.auth.admin.sign_out(credentials.credentials)
         return {"success": True, "message": "Logged out successfully"}
     except Exception as e:
         logger.error(f"Logout error: {e}", exc_info=True)

--- a/backend/tests/unit/test_stateless_auth_client.py
+++ b/backend/tests/unit/test_stateless_auth_client.py
@@ -1,0 +1,31 @@
+"""Unit tests for stateless backend auth clients (SB-115).
+
+The shared `auth_ops_client` previously used library defaults
+(persist_session=True, auto_refresh_token=True). Any user's login/refresh
+stored their session on the shared client, and gotrue's background thread
+silently refreshed it — rotating that user's refresh token server-side.
+The device still held the pre-rotation token, so its next refresh was
+rejected ("already used") and the user was forced to log in again on
+every device.
+
+These tests pin the stateless configuration so the defaults can't creep
+back in via a refactor.
+"""
+
+from __future__ import annotations
+
+import app as app_module
+
+
+class TestStatelessAuthClients:
+    def test_auth_ops_client_does_not_auto_refresh(self):
+        assert app_module.auth_ops_client.options.auto_refresh_token is False
+
+    def test_auth_ops_client_does_not_persist_session(self):
+        assert app_module.auth_ops_client.options.persist_session is False
+
+    def test_auth_service_client_does_not_auto_refresh(self):
+        assert app_module.auth_service_client.options.auto_refresh_token is False
+
+    def test_auth_service_client_does_not_persist_session(self):
+        assert app_module.auth_service_client.options.persist_session is False

--- a/docs/03-architecture/authentication.md
+++ b/docs/03-architecture/authentication.md
@@ -127,6 +127,21 @@ How it works (frontend `stores/auth.js`):
 **inactivity timeout**, set in the **Supabase Cloud dashboard** for production
 (Auth → Sessions), not in the repo. Refresh-token rotation stays enabled.
 
+##### Backend auth clients must be stateless (SB-115)
+
+The backend's shared Supabase clients (`auth_ops_client`, `auth_service_client`
+in `app.py`) are created with `ClientOptions(auto_refresh_token=False,
+persist_session=False)`. With the library defaults, any user's login/refresh
+stored their session on the shared client and gotrue's background thread
+silently refreshed it — **rotating that user's refresh token server-side**.
+The device still held the pre-rotation token, so its next refresh was rejected
+as "already used" and the user was forced to log in again (on every device).
+The stateless options mean: no stored session, no background refresh thread,
+no cross-request session bleed. Relatedly, `/api/auth/logout` revokes the
+*caller's own* JWT via `auth.admin.sign_out(jwt)` instead of calling
+`sign_out()` on the shared client (which revoked whatever session that client
+happened to hold).
+
 #### 3. **Frontend Changes**
 ```javascript
 // NEW APPROACH - Backend API calls


### PR DESCRIPTION
## Symptom

Forced re-logins roughly hourly on every device (Pixel 10, MacBook Air, Mac mini) despite the SB-78 silent-refresh stack working correctly client-side.

Fixes SB-115

## Root cause

`auth_ops_client` in `backend/app.py` is one **global** Supabase client with library-default options (`persist_session=True`, `auto_refresh_token=True`), shared across all users' auth requests:

1. Any `/api/auth/refresh` call stores that user's session on the shared client; gotrue's background thread takes ownership.
2. The backend thread silently refreshes the session server-side → Supabase **rotates the refresh token**; the rotated token exists only in backend memory.
3. The device later refreshes with its now-stale token (outside GoTrue's 10s reuse window) → "already used" → 401 → the frontend correctly treats it as a genuine auth failure and logs out.
4. Every login/refresh by any user replaces the shared session, so the breakage is random and hits all devices/users.

## Changes

- `auth_ops_client` + `auth_service_client` created with `ClientOptions(auto_refresh_token=False, persist_session=False)`: no stored session, no background refresh thread, no cross-request session bleed. Comment block in `app.py` documents why these must stay stateless.
- `/api/auth/logout` now revokes the **caller's own** JWT via `auth.admin.sign_out(jwt)`. Previously it called `sign_out()` on the shared client, revoking whatever session the client happened to hold — potentially a different user's.
- Unit tests pin the stateless options so defaults can't creep back in (`tests/unit/test_stateless_auth_client.py`).
- Docs: `docs/03-architecture/authentication.md` gains an SB-115 section under the SB-78 silent-refresh notes.

## Tests

- 4 new unit tests; full backend unit suite 474/474 passing.
- Ruff clean.
- `.secrets.baseline` diff is line-number/timestamp churn only (no new secrets).

## Verification after deploy

Stay logged in across >1h on two devices; no login prompt should appear. `auth_refresh_success` log lines should continue while "Invalid refresh token" errors disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)