### PR TITLE
fix(auth): logout revokes only the calling session, not all devices (SB-116)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -410,21 +410,21 @@
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 326
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "58a37cf13faaed3b81b3a1fce4872824eb4e57c4",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 724
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/03-architecture/authentication.md",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 781
+        "line_number": 783
       }
     ],
     "docs/04-testing/api-contract-testing.md": [
@@ -831,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T21:45:18Z"
+  "generated_at": "2026-06-07T13:50:34Z"
 }

--- a/backend/app.py
+++ b/backend/app.py
@@ -791,9 +791,13 @@ async def logout(
     implementation called sign_out() on the shared auth client, which
     revoked whatever session that client happened to hold — potentially a
     different user's (SB-115).
+
+    scope="local" is load-bearing (SB-116): gotrue's admin.sign_out
+    defaults to scope="global", which revokes EVERY session for the user —
+    logging out on one device logged the user out of all devices.
     """
     try:
-        auth_service_client.auth.admin.sign_out(credentials.credentials)
+        auth_service_client.auth.admin.sign_out(credentials.credentials, "local")
         return {"success": True, "message": "Logged out successfully"}
     except Exception as e:
         logger.error(f"Logout error: {e}", exc_info=True)

--- a/docs/03-architecture/authentication.md
+++ b/docs/03-architecture/authentication.md
@@ -138,9 +138,11 @@ The device still held the pre-rotation token, so its next refresh was rejected
 as "already used" and the user was forced to log in again (on every device).
 The stateless options mean: no stored session, no background refresh thread,
 no cross-request session bleed. Relatedly, `/api/auth/logout` revokes the
-*caller's own* JWT via `auth.admin.sign_out(jwt)` instead of calling
+*caller's own* JWT via `auth.admin.sign_out(jwt, "local")` instead of calling
 `sign_out()` on the shared client (which revoked whatever session that client
-happened to hold).
+happened to hold). The explicit `"local"` scope is load-bearing (SB-116):
+gotrue defaults to `scope="global"`, which revokes **every** session for the
+user — logging out on one device logged the user out everywhere.
 
 #### 3. **Frontend Changes**
 ```javascript


### PR DESCRIPTION
## Symptom

After SB-115 (#448) deployed, users were *still* getting logged out on all devices. Prod log timeline shows each `POST /api/auth/logout` followed by `Refresh Token Not Found` 401s from other sessions.

Fixes SB-116

## Root cause

SB-115 fixed logout to revoke the caller's own JWT via `auth.admin.sign_out(jwt)` — but gotrue's `admin.sign_out(jwt, scope)` **defaults to `scope="global"`**, revoking every session for the user. One logout anywhere → all devices' refresh tokens deleted → forced logins everywhere. Pre-SB-115 this never surfaced because the old logout was effectively a server-side no-op (it signed out the shared client's arbitrary session).

## Change

One line + docs: `admin.sign_out(credentials.credentials, "local")` — revokes only the calling session. Valid scopes per gotrue: `global` / `local` / `others`.

## Tests

- Existing auth unit suites pass (54/54 relevant; ruff clean).
- Verification after deploy: log out on one device → other devices must stay logged in across the next token refresh (~1h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)