### PR TITLE
fix(live): allow free-text player entry for cards when no roster (SB-117)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3270,14 +3270,19 @@ async def post_live_card(
         if card.team_id not in [current_match["home_team_id"], current_match["away_team_id"]]:
             raise HTTPException(status_code=400, detail="Team must be one of the match participants")
 
-        # Validate player exists and is on the team
-        player = roster_dao.get_player_by_id(card.player_id)
-        if not player:
-            raise HTTPException(status_code=400, detail="Player not found")
-        if player["team_id"] != card.team_id:
-            raise HTTPException(status_code=400, detail="Player must be on the specified team")
-
-        player_name = player.get("display_name", f"#{player['jersey_number']}")
+        # Resolve player from roster when an ID is given; otherwise accept a
+        # free-text name/number (SB-117: opposing team may have no roster).
+        if card.player_id is not None:
+            player = roster_dao.get_player_by_id(card.player_id)
+            if not player:
+                raise HTTPException(status_code=400, detail="Player not found")
+            if player["team_id"] != card.team_id:
+                raise HTTPException(status_code=400, detail="Player must be on the specified team")
+            player_name = player.get("display_name", f"#{player['jersey_number']}")
+        else:
+            player_name = (card.player_name or "").strip()
+            if not player_name:
+                raise HTTPException(status_code=400, detail="Either player_id or player_name is required")
         card_label = "RED CARD" if card.card_type == "red_card" else "YELLOW CARD"
 
         card_message = f"{card_label}: {player_name}"
@@ -3306,13 +3311,15 @@ async def post_live_card(
             raise HTTPException(status_code=500, detail="Failed to create card event")
 
         # Update player card stats
-        stats = player_stats_dao.get_or_create_match_stats(card.player_id, match_id)
-        if stats:
-            card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
-            current_count = stats.get(card_field, 0)
-            player_stats_dao.client.table("player_match_stats").update(
-                {card_field: current_count + 1, "played": True}
-            ).eq("player_id", card.player_id).eq("match_id", match_id).execute()
+        # Player stats only track rostered players
+        if card.player_id is not None:
+            stats = player_stats_dao.get_or_create_match_stats(card.player_id, match_id)
+            if stats:
+                card_field = "red_cards" if card.card_type == "red_card" else "yellow_cards"
+                current_count = stats.get(card_field, 0)
+                player_stats_dao.client.table("player_match_stats").update(
+                    {card_field: current_count + 1, "played": True}
+                ).eq("player_id", card.player_id).eq("match_id", match_id).execute()
 
         logger.info(
             "live_card_recorded",

--- a/backend/models/live_match.py
+++ b/backend/models/live_match.py
@@ -47,7 +47,10 @@ class LiveCardEvent(BaseModel):
     """Model for recording a card event during a live match."""
 
     team_id: int = Field(..., description="ID of the team the player belongs to")
-    player_id: int = Field(..., description="ID of the carded player from roster")
+    player_id: int | None = Field(None, description="ID of the carded player from roster (preferred)")
+    player_name: str | None = Field(
+        None, max_length=200, description="Free-text player name/number when no roster is available"
+    )
     card_type: str = Field(..., pattern="^(yellow_card|red_card)$", description="Type of card: yellow_card or red_card")
     message: str | None = Field(None, max_length=500, description="Optional description (e.g., reason for card)")
 

--- a/backend/tests/unit/test_live_card_event_model.py
+++ b/backend/tests/unit/test_live_card_event_model.py
@@ -1,0 +1,140 @@
+"""
+LiveCardEvent model validation tests (SB-117).
+
+Covers the updated LiveCardEvent Pydantic model:
+  - player_id is now optional (was previously required)
+  - player_name accepts free-text up to 200 chars
+  - card_type still requires yellow_card or red_card
+  - At least one of player_id / player_name must be supplied (validation is
+    done at the endpoint level, not the model — so the model accepts both null)
+
+Pure model tests, no database or HTTP client required.
+
+Usage:
+    pytest tests/unit/test_live_card_event_model.py -v
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from models.live_match import LiveCardEvent
+
+
+@pytest.mark.unit
+class TestLiveCardEventPlayerIdOptional:
+    """player_id is optional — can be None or a positive int."""
+
+    def test_accepts_player_id_as_int(self):
+        event = LiveCardEvent(team_id=1, player_id=42, card_type="yellow_card")
+        assert event.player_id == 42
+
+    def test_accepts_player_id_as_none(self):
+        event = LiveCardEvent(team_id=1, player_id=None, card_type="yellow_card")
+        assert event.player_id is None
+
+    def test_player_id_defaults_to_none_when_omitted(self):
+        event = LiveCardEvent(team_id=1, card_type="yellow_card")
+        assert event.player_id is None
+
+
+@pytest.mark.unit
+class TestLiveCardEventPlayerNameFreeText:
+    """player_name accepts free-text strings up to 200 chars."""
+
+    def test_accepts_player_name_string(self):
+        event = LiveCardEvent(team_id=1, player_name="Striker 9", card_type="red_card")
+        assert event.player_name == "Striker 9"
+
+    def test_accepts_jersey_number_as_name(self):
+        event = LiveCardEvent(team_id=2, player_name="#7", card_type="yellow_card")
+        assert event.player_name == "#7"
+
+    def test_accepts_player_name_at_max_length(self):
+        long_name = "A" * 200
+        event = LiveCardEvent(team_id=1, player_name=long_name, card_type="yellow_card")
+        assert event.player_name == long_name
+
+    def test_rejects_player_name_exceeding_max_length(self):
+        with pytest.raises(ValidationError):
+            LiveCardEvent(team_id=1, player_name="B" * 201, card_type="yellow_card")
+
+    def test_accepts_player_name_as_none(self):
+        event = LiveCardEvent(team_id=1, player_name=None, card_type="yellow_card")
+        assert event.player_name is None
+
+    def test_player_name_defaults_to_none_when_omitted(self):
+        event = LiveCardEvent(team_id=1, card_type="yellow_card")
+        assert event.player_name is None
+
+
+@pytest.mark.unit
+class TestLiveCardEventBothPlayerFieldsPresent:
+    """Both player_id and player_name may be present simultaneously; the
+    endpoint decides precedence.  The model itself must not reject this."""
+
+    def test_accepts_both_player_id_and_player_name(self):
+        event = LiveCardEvent(
+            team_id=1,
+            player_id=5,
+            player_name="Alice",
+            card_type="yellow_card",
+        )
+        assert event.player_id == 5
+        assert event.player_name == "Alice"
+
+    def test_accepts_neither_player_field(self):
+        """Model allows both to be None — endpoint enforces at-least-one rule."""
+        event = LiveCardEvent(team_id=1, card_type="red_card")
+        assert event.player_id is None
+        assert event.player_name is None
+
+
+@pytest.mark.unit
+class TestLiveCardEventCardType:
+    """card_type must be yellow_card or red_card (unchanged behaviour)."""
+
+    @pytest.mark.parametrize("card_type", ["yellow_card", "red_card"])
+    def test_valid_card_types(self, card_type):
+        event = LiveCardEvent(team_id=1, player_id=1, card_type=card_type)
+        assert event.card_type == card_type
+
+    @pytest.mark.parametrize("card_type", ["yellow", "red", "blue_card", "", "Yellow_card"])
+    def test_invalid_card_types(self, card_type):
+        with pytest.raises(ValidationError):
+            LiveCardEvent(team_id=1, player_id=1, card_type=card_type)
+
+
+@pytest.mark.unit
+class TestLiveCardEventMessage:
+    """message is optional and accepts up to 500 chars."""
+
+    def test_accepts_optional_message(self):
+        event = LiveCardEvent(
+            team_id=1,
+            player_id=3,
+            card_type="yellow_card",
+            message="Dangerous tackle",
+        )
+        assert event.message == "Dangerous tackle"
+
+    def test_message_defaults_to_none(self):
+        event = LiveCardEvent(team_id=1, player_id=3, card_type="yellow_card")
+        assert event.message is None
+
+    def test_rejects_message_over_500_chars(self):
+        with pytest.raises(ValidationError):
+            LiveCardEvent(
+                team_id=1,
+                player_id=3,
+                card_type="yellow_card",
+                message="x" * 501,
+            )
+
+
+@pytest.mark.unit
+class TestLiveCardEventTeamId:
+    """team_id is required."""
+
+    def test_rejects_missing_team_id(self):
+        with pytest.raises(ValidationError):
+            LiveCardEvent(player_id=1, card_type="yellow_card")

--- a/frontend/src/__tests__/components/live/LiveAdminControls.spec.js
+++ b/frontend/src/__tests__/components/live/LiveAdminControls.spec.js
@@ -1,0 +1,309 @@
+/**
+ * LiveAdminControls.vue — card modal free-text player entry (SB-117).
+ *
+ * Covers:
+ *  (a) empty roster → free-text input visible, Record Card disabled until
+ *      name typed, enabled after
+ *  (b) submit with empty roster emits post-card with playerName set + playerId null
+ *  (c) roster present → selecting player enables submit, emits playerId with
+ *      playerName null
+ *  (d) "Other (type name)" option in roster select shows free-text input
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LiveAdminControls from '@/components/live/LiveAdminControls.vue';
+
+// LineupManager imports nothing that needs mocking for these tests, but we
+// stub it to avoid pulling in its own dependencies (roster-heavy UI not under
+// test here).
+vi.mock('@/components/live/LineupManager.vue', () => ({
+  default: { template: '<div />' },
+}));
+
+const baseMatchState = {
+  home_team_id: 1,
+  away_team_id: 2,
+  home_team_name: 'Home FC',
+  away_team_name: 'Away FC',
+  home_score: 0,
+  away_score: 0,
+  age_group_name: 'U15',
+  half_duration: 45,
+};
+
+/**
+ * Mounts the component with the clock running (1st Half) so the card button
+ * is visible. Extra props/overrides can be provided.
+ */
+const mountControls = (overrides = {}) =>
+  mount(LiveAdminControls, {
+    props: {
+      matchState: baseMatchState,
+      matchPeriod: '1st Half',
+      fetchRosters: vi.fn().mockResolvedValue({ home: [], away: [] }),
+      fetchLineups: vi.fn().mockResolvedValue(undefined),
+      saveLineup: vi.fn().mockResolvedValue({ success: true }),
+      homeLineup: null,
+      awayLineup: null,
+      sportType: 'soccer',
+      ...overrides,
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// Helpers to drive the card modal through common steps
+// ---------------------------------------------------------------------------
+
+/** Open the card modal via the "+ Card" button. */
+async function openCardModal(wrapper) {
+  await wrapper.find('.control-button.card').trigger('click');
+}
+
+// ---------------------------------------------------------------------------
+// Scenario (a) — empty roster
+// ---------------------------------------------------------------------------
+
+describe('LiveAdminControls card modal — empty roster (SB-117)', () => {
+  it('shows free-text input when the card team has no roster', async () => {
+    const wrapper = mountControls({
+      fetchRosters: vi.fn().mockResolvedValue({ home: [], away: [] }),
+    });
+
+    await openCardModal(wrapper);
+
+    // Trigger the watcher that loads rosters on modal open (flush promises)
+    await wrapper.vm.$nextTick();
+
+    // Set the cardTeamId directly through the internal ref so we can inspect
+    // the roster-dependent UI without needing an async roster load in tests.
+    wrapper.vm.showCardModal = true;
+    // Simulate home team selection; cardTeamRoster will be [] because homeRoster is []
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    await wrapper.vm.$nextTick();
+
+    // No roster → no <select>, only "No roster available" and a free-text input
+    expect(wrapper.find('#card-player-select').exists()).toBe(false);
+    expect(
+      wrapper.find('input[placeholder="Enter player name or number"]').exists()
+    ).toBe(true);
+  });
+
+  it('Record Card button is disabled with empty roster and no name typed', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    // cardPlayerName is '' by default → canSubmitCard false
+    await wrapper.vm.$nextTick();
+
+    const submitBtn = wrapper.find('.submit-button');
+    expect(submitBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('Record Card button becomes enabled once a name is typed (empty roster)', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.find(
+      'input[placeholder="Enter player name or number"]'
+    );
+    await input.setValue('Player 7');
+    await wrapper.vm.$nextTick();
+
+    const submitBtn = wrapper.find('.submit-button');
+    expect(submitBtn.attributes('disabled')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario (b) — submit with empty roster emits correct payload
+// ---------------------------------------------------------------------------
+
+describe('LiveAdminControls card modal — post-card emit with free-text player (SB-117)', () => {
+  it('emits post-card with playerName and playerId null when using free-text entry', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.away_team_id;
+    wrapper.vm.selectedCardType = 'red_card';
+    wrapper.vm.cardPlayerName = 'Keeper 1';
+    wrapper.vm.cardMessage = 'Dangerous foul';
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('.submit-button').trigger('click');
+
+    expect(wrapper.emitted('post-card')).toBeTruthy();
+    const [payload] = wrapper.emitted('post-card')[0];
+    expect(payload.playerId).toBeNull();
+    expect(payload.playerName).toBe('Keeper 1');
+    expect(payload.teamId).toBe(baseMatchState.away_team_id);
+    expect(payload.cardType).toBe('red_card');
+    expect(payload.message).toBe('Dangerous foul');
+  });
+
+  it('modal resets and closes after submit', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    wrapper.vm.cardPlayerName = 'Sub 15';
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('.submit-button').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.showCardModal).toBe(false);
+    expect(wrapper.vm.cardTeamId).toBeNull();
+    expect(wrapper.vm.cardPlayerName).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario (c) — roster present: selecting player enables submit, emits
+//               playerId with playerName null
+// ---------------------------------------------------------------------------
+
+describe('LiveAdminControls card modal — roster present (SB-117)', () => {
+  const mockRoster = [
+    { id: 10, jersey_number: 10, display_name: 'Alice' },
+    { id: 11, jersey_number: 11, display_name: 'Bob' },
+  ];
+
+  it('shows the player select when a roster is available', async () => {
+    const wrapper = mountControls();
+    // Pre-load homeRoster as if fetchRosters resolved
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('#card-player-select').exists()).toBe(true);
+  });
+
+  it('submit is disabled when no player is selected from roster', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    // cardPlayerId defaults to null → canSubmitCard false
+    await wrapper.vm.$nextTick();
+
+    const submitBtn = wrapper.find('.submit-button');
+    expect(submitBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('submit is enabled once a roster player is selected', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    wrapper.vm.cardPlayerId = 10; // select Alice
+    await wrapper.vm.$nextTick();
+
+    const submitBtn = wrapper.find('.submit-button');
+    expect(submitBtn.attributes('disabled')).toBeUndefined();
+  });
+
+  it('emits post-card with playerId set and playerName null when roster player chosen', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    wrapper.vm.cardPlayerId = 10;
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('.submit-button').trigger('click');
+
+    expect(wrapper.emitted('post-card')).toBeTruthy();
+    const [payload] = wrapper.emitted('post-card')[0];
+    expect(payload.playerId).toBe(10);
+    expect(payload.playerName).toBeNull();
+    expect(payload.teamId).toBe(baseMatchState.home_team_id);
+    expect(payload.cardType).toBe('yellow_card');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario (d) — "Other (type name)" option shows free-text input
+// ---------------------------------------------------------------------------
+
+describe('LiveAdminControls card modal — Other option (SB-117)', () => {
+  const mockRoster = [{ id: 5, jersey_number: 5, display_name: 'Dave' }];
+
+  it('shows free-text input when "Other" is selected', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.cardPlayerId = 'other';
+    await wrapper.vm.$nextTick();
+
+    // The free-text input should now be visible alongside the select
+    expect(
+      wrapper.find('input[placeholder="Enter player name or number"]').exists()
+    ).toBe(true);
+    // The select is also present (roster exists)
+    expect(wrapper.find('#card-player-select').exists()).toBe(true);
+  });
+
+  it('submit is disabled when Other is selected but name is empty', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    wrapper.vm.cardPlayerId = 'other';
+    wrapper.vm.cardPlayerName = '';
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.submit-button').attributes('disabled')).toBeDefined();
+  });
+
+  it('submit is enabled when Other is selected and name is provided', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    wrapper.vm.cardPlayerId = 'other';
+    wrapper.vm.cardPlayerName = 'Coach pick';
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.find('.submit-button').attributes('disabled')
+    ).toBeUndefined();
+  });
+
+  it('emits post-card with playerName and playerId null when Other name typed', async () => {
+    const wrapper = mountControls();
+    wrapper.vm.homeRoster = mockRoster;
+    wrapper.vm.rostersLoaded = true;
+    wrapper.vm.showCardModal = true;
+    wrapper.vm.cardTeamId = baseMatchState.home_team_id;
+    wrapper.vm.selectedCardType = 'yellow_card';
+    wrapper.vm.cardPlayerId = 'other';
+    wrapper.vm.cardPlayerName = 'Sub 99';
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('.submit-button').trigger('click');
+
+    expect(wrapper.emitted('post-card')).toBeTruthy();
+    const [payload] = wrapper.emitted('post-card')[0];
+    expect(payload.playerId).toBeNull();
+    expect(payload.playerName).toBe('Sub 99');
+    expect(payload.cardType).toBe('yellow_card');
+  });
+});

--- a/frontend/src/components/live/LiveAdminControls.vue
+++ b/frontend/src/components/live/LiveAdminControls.vue
@@ -348,8 +348,17 @@
             >
               {{ formatPlayerOption(player) }}
             </option>
+            <option value="other">Other (type name)</option>
           </select>
           <div v-else class="no-roster-message">No roster available</div>
+          <!-- Fallback text input when "Other" is selected or no roster -->
+          <input
+            v-if="cardPlayerId === 'other' || cardTeamRoster.length === 0"
+            v-model="cardPlayerName"
+            type="text"
+            placeholder="Enter player name or number"
+            class="text-input mt-2"
+          />
         </div>
 
         <div class="form-group">
@@ -559,6 +568,7 @@ const rostersLoaded = ref(false);
 const showCardModal = ref(false);
 const cardTeamId = ref(null);
 const cardPlayerId = ref(null);
+const cardPlayerName = ref('');
 const selectedCardType = ref('yellow_card');
 const cardMessage = ref('');
 
@@ -815,18 +825,25 @@ const cardTeamRoster = computed(() => {
 });
 
 const canSubmitCard = computed(() => {
-  return cardTeamId.value && cardPlayerId.value && selectedCardType.value;
+  if (!cardTeamId.value || !selectedCardType.value) return false;
+  // Player selected from roster
+  if (cardPlayerId.value && cardPlayerId.value !== 'other') return true;
+  // "Other" or no roster — need a manual name/number
+  if (cardPlayerName.value.trim()) return true;
+  return false;
 });
 
 function selectCardTeam(teamId) {
   cardTeamId.value = teamId;
   cardPlayerId.value = null;
+  cardPlayerName.value = '';
 }
 
 function closeCardModal() {
   showCardModal.value = false;
   cardTeamId.value = null;
   cardPlayerId.value = null;
+  cardPlayerName.value = '';
   selectedCardType.value = 'yellow_card';
   cardMessage.value = '';
 }
@@ -834,9 +851,20 @@ function closeCardModal() {
 function submitCard() {
   if (!canSubmitCard.value) return;
 
+  // Determine player info to send (mirrors submitGoal)
+  let playerId = null;
+  let playerName = null;
+
+  if (cardPlayerId.value && cardPlayerId.value !== 'other') {
+    playerId = cardPlayerId.value;
+  } else {
+    playerName = cardPlayerName.value.trim();
+  }
+
   emit('post-card', {
     teamId: cardTeamId.value,
-    playerId: cardPlayerId.value,
+    playerId,
+    playerName,
     cardType: selectedCardType.value,
     message: cardMessage.value.trim() || null,
   });

--- a/frontend/src/components/live/LiveMatchView.vue
+++ b/frontend/src/components/live/LiveMatchView.vue
@@ -137,8 +137,20 @@ async function handlePostGoal({ teamId, playerName, message, playerId }) {
   }
 }
 
-async function handlePostCard({ teamId, playerId, cardType, message }) {
-  const result = await postCard(teamId, playerId, cardType, message);
+async function handlePostCard({
+  teamId,
+  playerId,
+  playerName,
+  cardType,
+  message,
+}) {
+  const result = await postCard(
+    teamId,
+    playerId,
+    cardType,
+    message,
+    playerName
+  );
   if (!result.success) {
     alert(result.error || 'Failed to record card');
   }

--- a/frontend/src/composables/useLiveMatch.js
+++ b/frontend/src/composables/useLiveMatch.js
@@ -393,13 +393,24 @@ export function useLiveMatch(matchId) {
     }
   }
 
-  async function postCard(teamId, playerId, cardType, message = null) {
+  async function postCard(
+    teamId,
+    playerId,
+    cardType,
+    message = null,
+    playerName = null
+  ) {
     try {
       const cardData = {
         team_id: teamId,
-        player_id: playerId,
         card_type: cardType,
       };
+      if (playerId != null) {
+        cardData.player_id = playerId;
+      }
+      if (playerName) {
+        cardData.player_name = playerName;
+      }
       if (message) {
         cardData.message = message;
       }


### PR DESCRIPTION
## Summary

During live scoring, recording a card for a team with no roster loaded was impossible: the card modal only offered a roster select, and with an empty roster the Record Card button was permanently disabled. Backend also hard-required a rostered `player_id`.

This mirrors the goal modal's existing pattern on the card modal:

- **Frontend** (`LiveAdminControls.vue`): roster select gains an "Other (type name)" option; a free-text input appears when "Other" is selected or the roster is empty. `canSubmitCard` accepts either a roster pick or a non-empty manual name/number. `post-card` now emits `playerName` alongside `playerId`.
- **Composable** (`useLiveMatch.js`): `postCard` omits `player_id` when null and sends `player_name` when provided.
- **Backend** (`models/live_match.py`, `app.py`): `LiveCardEvent.player_id` optional, `player_name` (max 200) accepted instead. Requires at least one of the two (400 otherwise). `player_match_stats` increment skipped for unrostered players (stats only track rostered players).

## Tests

- `frontend/src/__tests__/components/live/LiveAdminControls.spec.js` — 13 new component tests: empty-roster input visibility/gating, emit shapes for manual vs roster entry, "Other" option behavior. Frontend suite: **503 passed**.
- `backend/tests/unit/test_live_card_event_model.py` — 22 new model validation tests. **22 passed.**
- Lint (eslint, ruff): clean.

Fixes SB-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)