### PR TITLE
fix(live): surface lineup save/load failures instead of failing silently (SB-118)

### DIFF
--- a/frontend/src/__tests__/components/live/LiveAdminControls.lineup-error.spec.js
+++ b/frontend/src/__tests__/components/live/LiveAdminControls.lineup-error.spec.js
@@ -1,0 +1,258 @@
+/**
+ * LiveAdminControls.vue — SB-118 error/retry surface
+ *
+ * Covers the three SB-118 behaviors:
+ *  (a) a failed fetchRosters prop renders the error div + Retry button
+ *      and leaves lineupsLoaded false (LineupManager not rendered)
+ *  (b) clicking Retry re-invokes the loaders; on success the error clears
+ *      and LineupManager is rendered
+ *  (c) handleSaveLineup with {success:false, error:'boom'} calls alert and
+ *      leaves savingLineup false after the call
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LiveAdminControls from '@/components/live/LiveAdminControls.vue';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseMatchState = {
+  home_team_id: 10,
+  away_team_id: 20,
+  home_team_name: 'Home FC',
+  away_team_name: 'Away FC',
+  home_score: 0,
+  away_score: 0,
+  age_group_name: 'U15',
+  half_duration: 45,
+};
+
+/**
+ * Mount the component with the lineup section already open so we don't need
+ * to click the toggle in every test. We open it by calling toggleLineupSection
+ * after mount (since Vue Test Utils can trigger the button click).
+ *
+ * Stubs LineupManager to keep the test lightweight and avoid its own
+ * internal setup (Supabase, formations config, etc.).
+ */
+const mountControls = async (propsOverrides = {}) => {
+  const wrapper = mount(LiveAdminControls, {
+    props: {
+      matchState: baseMatchState,
+      matchPeriod: 'Not Started',
+      ...propsOverrides,
+    },
+    global: {
+      stubs: {
+        LineupManager: {
+          name: 'LineupManager',
+          props: [
+            'teamId',
+            'teamName',
+            'ageGroupName',
+            'roster',
+            'initialLineup',
+            'saving',
+            'sportType',
+          ],
+          emits: ['save'],
+          template:
+            '<div class="lineup-manager-stub" data-testid="lineup-manager-stub" />',
+        },
+      },
+    },
+  });
+
+  // Open the lineup section so the conditional content is visible
+  await wrapper.find('.section-toggle').trigger('click');
+
+  return wrapper;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LiveAdminControls — SB-118 lineup error/retry', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── (a) failed load ──────────────────────────────────────────────────────
+  describe('when fetchRosters rejects on initial load', () => {
+    it('shows the lineup-error div with a Retry button', async () => {
+      const failingFetchRosters = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+
+      const wrapper = await mountControls({
+        fetchRosters: failingFetchRosters,
+      });
+
+      // Wait for the async loadLineupsAndRosters triggered by toggle
+      await vi.waitFor(() => wrapper.find('.lineup-error').exists());
+
+      expect(wrapper.find('.lineup-error').exists()).toBe(true);
+      expect(wrapper.find('.lineup-error').text()).toContain(
+        'Could not load lineups'
+      );
+      expect(wrapper.find('.retry-button').exists()).toBe(true);
+    });
+
+    it('does not render LineupManager when the load failed', async () => {
+      const failingFetchRosters = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+
+      const wrapper = await mountControls({
+        fetchRosters: failingFetchRosters,
+      });
+
+      await vi.waitFor(() => wrapper.find('.lineup-error').exists());
+
+      expect(wrapper.find('[data-testid="lineup-manager-stub"]').exists()).toBe(
+        false
+      );
+    });
+  });
+
+  // ── (b) retry succeeds ───────────────────────────────────────────────────
+  describe('when Retry is clicked and the second load succeeds', () => {
+    it('clears the error and renders LineupManager', async () => {
+      let callCount = 0;
+      const flakyFetchRosters = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.reject(new Error('blip'));
+        }
+        return Promise.resolve({ home: [], away: [] });
+      });
+
+      const fetchLineups = vi.fn().mockResolvedValue(undefined);
+
+      const wrapper = await mountControls({
+        fetchRosters: flakyFetchRosters,
+        fetchLineups,
+      });
+
+      // Wait for initial failure to surface
+      await vi.waitFor(() => wrapper.find('.lineup-error').exists());
+
+      // Click Retry
+      await wrapper.find('.retry-button').trigger('click');
+
+      // Wait for the error to clear
+      await vi.waitFor(() => !wrapper.find('.lineup-error').exists());
+
+      expect(wrapper.find('.lineup-error').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="lineup-manager-stub"]').exists()).toBe(
+        true
+      );
+    });
+
+    it('calls fetchRosters a second time when Retry is clicked', async () => {
+      let callCount = 0;
+      const flakyFetchRosters = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(new Error('blip'));
+        return Promise.resolve({ home: [], away: [] });
+      });
+
+      const fetchLineups = vi.fn().mockResolvedValue(undefined);
+
+      const wrapper = await mountControls({
+        fetchRosters: flakyFetchRosters,
+        fetchLineups,
+      });
+
+      await vi.waitFor(() => wrapper.find('.lineup-error').exists());
+      await wrapper.find('.retry-button').trigger('click');
+      await vi.waitFor(() => !wrapper.find('.lineup-error').exists());
+
+      expect(flakyFetchRosters).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── (c) save failure calls alert ─────────────────────────────────────────
+  describe('handleSaveLineup with {success:false}', () => {
+    it('calls window.alert with the error message', async () => {
+      const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+      const saveLineup = vi.fn().mockResolvedValue({
+        success: false,
+        error: 'boom',
+      });
+
+      // Mount with a working load path so we reach LineupManager
+      const fetchRosters = vi.fn().mockResolvedValue({ home: [], away: [] });
+      const fetchLineups = vi.fn().mockResolvedValue(undefined);
+
+      const wrapper = await mountControls({
+        fetchRosters,
+        fetchLineups,
+        saveLineup,
+      });
+
+      // Wait for lineup section to fully load (no error, LineupManager rendered)
+      await vi.waitFor(() =>
+        wrapper.find('[data-testid="lineup-manager-stub"]').exists()
+      );
+
+      // Trigger handleSaveLineup by emitting 'save' from the LineupManager stub.
+      // The template binds @save="handleSaveLineup(matchState.home_team_id, $event)".
+      const stub = wrapper.findComponent({ name: 'LineupManager' });
+      await stub.vm.$emit('save', {
+        formation_name: '4-3-3',
+        positions: [],
+      });
+
+      await vi.waitFor(() => alertSpy.mock.calls.length > 0);
+
+      expect(alertSpy).toHaveBeenCalledWith('boom');
+    });
+
+    it('resets savingLineup to false after a failed save', async () => {
+      vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+      const saveLineup = vi.fn().mockResolvedValue({
+        success: false,
+        error: 'boom',
+      });
+
+      const fetchRosters = vi.fn().mockResolvedValue({ home: [], away: [] });
+      const fetchLineups = vi.fn().mockResolvedValue(undefined);
+
+      const wrapper = await mountControls({
+        fetchRosters,
+        fetchLineups,
+        saveLineup,
+      });
+
+      await vi.waitFor(() =>
+        wrapper.find('[data-testid="lineup-manager-stub"]').exists()
+      );
+
+      const stub = wrapper.findComponent({ name: 'LineupManager' });
+      await stub.vm.$emit('save', {
+        formation_name: '4-3-3',
+        positions: [],
+      });
+
+      // After the async chain resolves, savingLineup must be false.
+      // We verify indirectly: the LineupManager stub must still exist
+      // (not in a loading / error state) and alert must have been called.
+      await vi.waitFor(() => expect(saveLineup).toHaveBeenCalled());
+
+      // savingLineup is an internal ref — confirm via prop that was passed to stub.
+      // Vue Test Utils exposes props on the stub component.
+      // After the finally block runs, saving prop should be false.
+      // Give the event loop one more tick.
+      await new Promise(r => setTimeout(r, 0));
+
+      const stubEl = wrapper.findComponent({ name: 'LineupManager' });
+      expect(stubEl.props('saving')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/__tests__/composables/useMatchLineup.spec.js
+++ b/frontend/src/__tests__/composables/useMatchLineup.spec.js
@@ -91,7 +91,9 @@ describe('useMatchLineup', () => {
       expect(mockAuthStore.apiRequest).not.toHaveBeenCalled();
     });
 
-    it('returns empty arrays on API error', async () => {
+    // SB-118: errors propagate so callers can show a retry UI instead of
+    // mistaking a failed fetch for an empty roster
+    it('rethrows on API error', async () => {
       mockAuthStore.apiRequest = vi.fn(() =>
         Promise.reject(new Error('Network error'))
       );
@@ -99,9 +101,7 @@ describe('useMatchLineup', () => {
       const matchData = ref(createMatchData());
       const { fetchTeamRosters } = useMatchLineup(1, matchData);
 
-      const result = await fetchTeamRosters();
-
-      expect(result).toEqual({ home: [], away: [] });
+      await expect(fetchTeamRosters()).rejects.toThrow('Network error');
     });
 
     // ── SB-68: age_group_id filter ──
@@ -196,6 +196,20 @@ describe('useMatchLineup', () => {
       await fetchLineups();
 
       expect(mockAuthStore.apiRequest).not.toHaveBeenCalled();
+    });
+
+    // SB-118: failed lineup fetch must propagate so callers can show a retry UI
+    it('rethrows when apiRequest rejects and resets lineupLoading to false', async () => {
+      mockAuthStore.apiRequest = vi.fn(() =>
+        Promise.reject(new Error('timeout'))
+      );
+
+      const matchData = ref(createMatchData());
+      const { fetchLineups, lineupLoading } = useMatchLineup(1, matchData);
+
+      await expect(fetchLineups()).rejects.toThrow('timeout');
+      // The finally block must have run — loading must not stay stuck
+      expect(lineupLoading.value).toBe(false);
     });
   });
 

--- a/frontend/src/components/live/LiveAdminControls.vue
+++ b/frontend/src/components/live/LiveAdminControls.vue
@@ -32,6 +32,12 @@
         <div v-if="lineupsLoading" class="lineup-loading">
           Loading lineups...
         </div>
+        <div v-else-if="lineupLoadError" class="lineup-error">
+          <p>{{ lineupLoadError }}</p>
+          <button @click="loadLineupsAndRosters" class="retry-button">
+            Retry
+          </button>
+        </div>
         <LineupManager
           v-else-if="activeLineupTab === 'home'"
           :team-id="matchState.home_team_id"
@@ -642,6 +648,7 @@ const showLineupSection = ref(false);
 const activeLineupTab = ref('home');
 const lineupsLoading = ref(false);
 const lineupsLoaded = ref(false);
+const lineupLoadError = ref(null);
 const savingLineup = ref(false);
 
 // Toggle lineup section
@@ -657,6 +664,7 @@ function toggleLineupSection() {
 // Load lineups and rosters
 async function loadLineupsAndRosters() {
   lineupsLoading.value = true;
+  lineupLoadError.value = null;
   try {
     // Load rosters if not already loaded
     if (props.fetchRosters && !rostersLoaded.value) {
@@ -673,7 +681,11 @@ async function loadLineupsAndRosters() {
 
     lineupsLoaded.value = true;
   } catch (err) {
+    // SB-118: leave lineupsLoaded false and surface the error so the user
+    // can retry — previously a failed load looked like an empty lineup.
     console.error('Failed to load lineups and rosters:', err);
+    lineupLoadError.value =
+      'Could not load lineups. Check your connection and retry.';
   } finally {
     lineupsLoading.value = false;
   }
@@ -693,9 +705,17 @@ async function handleSaveLineup(teamId, lineupData) {
 
     if (!result.success) {
       console.error('Failed to save lineup:', result.error);
+      alert(
+        result.error ||
+          'Failed to save lineup. Check your connection and try again.'
+      );
     }
   } catch (err) {
     console.error('Error saving lineup:', err);
+    alert(
+      err.message ||
+        'Failed to save lineup. Check your connection and try again.'
+    );
   } finally {
     savingLineup.value = false;
   }
@@ -1329,5 +1349,23 @@ function submitGoal() {
   text-align: center;
   padding: 40px;
   color: #aaa;
+}
+
+.lineup-error {
+  text-align: center;
+  padding: 24px;
+  color: #e94560;
+}
+
+.lineup-error .retry-button {
+  margin-top: 12px;
+  background: #e94560;
+  color: white;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+  min-height: 44px;
 }
 </style>

--- a/frontend/src/composables/useMatchLineup.js
+++ b/frontend/src/composables/useMatchLineup.js
@@ -60,8 +60,10 @@ export function useMatchLineup(matchId, matchData) {
         away: awayRoster.value,
       };
     } catch (err) {
+      // SB-118: propagate so callers can show an error + retry instead of
+      // silently treating a failed fetch as an empty roster.
       console.error('Error fetching rosters:', err);
-      return { home: [], away: [] };
+      throw err;
     }
   }
 
@@ -75,8 +77,9 @@ export function useMatchLineup(matchId, matchData) {
       );
       return response;
     } catch (err) {
+      // SB-118: propagate — a failed fetch is not the same as "no lineup"
       console.error('Error fetching lineup:', err);
-      return null;
+      throw err;
     }
   }
 
@@ -99,7 +102,9 @@ export function useMatchLineup(matchId, matchData) {
       homeLineup.value = homeResponse;
       awayLineup.value = awayResponse;
     } catch (err) {
+      // SB-118: propagate so callers can show an error + retry
       console.error('Error fetching lineups:', err);
+      throw err;
     } finally {
       lineupLoading.value = false;
     }

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -687,6 +687,28 @@ export const useAuthStore = () => {
     };
   };
 
+  // SB-118: abort hung requests (e.g. dead mobile signal) so callers fail
+  // fast instead of leaving saving/loading spinners stuck indefinitely.
+  const API_TIMEOUT_MS = 30000;
+
+  const fetchWithTimeout = async (endpoint, options = {}) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+    try {
+      // Caller-supplied signal (spread after ours) takes precedence
+      return await fetch(endpoint, { signal: controller.signal, ...options });
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        throw new Error(
+          'Request timed out. Check your connection and try again.'
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
   // NEW: Simple API call helper with auth headers
   const apiCall = async (endpoint, options = {}) => {
     const startTime = performance.now();
@@ -705,7 +727,7 @@ export const useAuthStore = () => {
       defaultHeaders.Authorization = `Bearer ${token}`;
     }
 
-    const response = await fetch(endpoint, {
+    const response = await fetchWithTimeout(endpoint, {
       ...options,
       cache: 'no-store',
       headers: {
@@ -724,7 +746,7 @@ export const useAuthStore = () => {
         const retryToken = localStorage.getItem('auth_token');
         if (retryToken) {
           defaultHeaders.Authorization = `Bearer ${retryToken}`;
-          const retryResponse = await fetch(endpoint, {
+          const retryResponse = await fetchWithTimeout(endpoint, {
             ...options,
             cache: 'no-store',
             headers: {


### PR DESCRIPTION
## Summary

During live scoring on a bad mobile connection, lineup edits silently failed: no error shown, Save button could stay disabled forever, and a failed roster load was treated as a successful empty load that never retried. There is no mid-game restriction on lineup edits — the failures were all network + silent error handling.

- **`useMatchLineup.js`**: `fetchTeamRosters` / `fetchLineup` / `fetchLineups` now rethrow instead of swallowing errors into empty rosters / null lineups. Callers (LiveAdminControls, MatchDetailView, PostMatchEditor) already gate their `loaded` flags inside try blocks — they just never received the errors before.
- **`stores/auth.js`**: `apiCall` requests (initial + 401-retry) now go through a 30s AbortController timeout, failing fast with "Request timed out. Check your connection and try again." instead of hanging spinners indefinitely.
- **`LiveAdminControls.vue`**: failed lineup load shows an inline error with a **Retry** button (`lineupsLoaded`/`rostersLoaded` stay false so retry actually refetches); failed lineup save alerts the user (matching the existing alert pattern in LiveMatchView). `savingLineup` always resets, and LineupManager's `hasChanges` survives a failed save so Save stays enabled for retry.

## Tests

- `useMatchLineup.spec.js` — error-propagation tests updated/added (rethrow + `lineupLoading` reset).
- `LiveAdminControls.spec.js` (new) — 6 tests: error UI on failed load, no LineupManager render, Retry refetches and clears error, alert on failed save, `savingLineup` reset.
- Frontend suite: **497 passed**. Lint clean.

Mobile-first note: this targets the exact in-stadium bad-signal scenario; verify on a throttled mobile browser before relying on it for a match.

Fixes SB-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)