### PR TITLE
fix(auth): pin Supabase session config to 30-day idle (SB-120)

### DIFF
--- a/backend/tests/unit/test_session_config.py
+++ b/backend/tests/unit/test_session_config.py
@@ -1,0 +1,58 @@
+"""Drift guard for Supabase session timeouts (SB-120).
+
+Users were force-logged-out roughly daily (distinct from the hourly SB-115
+bug). Root cause was a short session timeout: the `[auth.sessions]` block must
+express the SB-78 "30-day idle session" intent — a long `inactivity_timeout`
+and **no** `timebox` (a timebox force-logs-out on a fixed schedule regardless
+of activity, which is exactly the daily-logout failure mode).
+
+This pins the *local* config. Production session timeouts live in the Supabase
+Cloud dashboard (Auth → Sessions) and must be kept in sync — see
+docs/03-architecture/authentication.md.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+# backend/tests/unit/<this file> -> repo root is three parents up from backend/
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / "supabase" / "config.toml"
+
+# 30 days, in the hour-based duration units the Supabase CLI accepts.
+_THIRTY_DAYS_HOURS = 720
+
+
+def _parse_hours(duration: str) -> int:
+    """Parse a Supabase duration string like '720h' into whole hours."""
+    assert duration.endswith("h"), f"expected an hour-based duration, got {duration!r}"
+    return int(duration[:-1])
+
+
+def _sessions() -> dict:
+    with _CONFIG_PATH.open("rb") as fh:
+        config = tomllib.load(fh)
+    return config.get("auth", {}).get("sessions", {})
+
+
+class TestSessionConfig:
+    def test_config_file_exists(self):
+        assert _CONFIG_PATH.is_file(), f"missing {_CONFIG_PATH}"
+
+    def test_sessions_block_present(self):
+        assert _sessions(), "[auth.sessions] block must be set (uncommented), not left to defaults"
+
+    def test_inactivity_timeout_is_at_least_30_days(self):
+        sessions = _sessions()
+        assert "inactivity_timeout" in sessions, "inactivity_timeout must be pinned (SB-78 30-day idle)"
+        assert _parse_hours(sessions["inactivity_timeout"]) >= _THIRTY_DAYS_HOURS
+
+    def test_no_short_timebox(self):
+        # A timebox force-logs-out every session on a fixed schedule regardless
+        # of activity — the SB-120 daily-logout failure mode. It must be unset,
+        # or no shorter than the 30-day idle window.
+        sessions = _sessions()
+        if "timebox" in sessions:
+            assert _parse_hours(sessions["timebox"]) >= _THIRTY_DAYS_HOURS, (
+                "timebox would force-logout active users (SB-120); leave it unset"
+            )

--- a/docs/03-architecture/authentication.md
+++ b/docs/03-architecture/authentication.md
@@ -124,8 +124,25 @@ How it works (frontend `stores/auth.js`):
 
 **Supabase config.** Access-token TTL is `jwt_expiry = 3600` (local
 `supabase/config.toml`). The 30-day idle window is the refresh-token
-**inactivity timeout**, set in the **Supabase Cloud dashboard** for production
-(Auth → Sessions), not in the repo. Refresh-token rotation stays enabled.
+**inactivity timeout**. Refresh-token rotation stays enabled.
+
+- **Local:** pinned in `supabase/config.toml` `[auth.sessions]` as
+  `inactivity_timeout = "720h"` with **no `timebox`** (SB-120). A unit test
+  (`backend/tests/unit/test_session_config.py`) guards against drift.
+- **Production:** the same values live in the **Supabase Cloud dashboard**
+  (Auth → Sessions), *not* the repo, and must be kept in sync:
+
+  | Dashboard field | Required value | Why |
+  |---|---|---|
+  | `Inactivity timeout` | **30 days** (or unset) | The 30-day idle window. Anything shorter logs active users out early. |
+  | `Time-box user sessions` | **unset** (or ≥ 30 days) | A time-box force-logs-out on a fixed schedule regardless of activity. |
+  | `JWT expiry` | `3600` | Short-lived access token; longevity comes from the refresh token. |
+
+> **SB-120 incident:** users were force-logged-out roughly **daily** (distinct
+> from the hourly SB-115 bug). Root cause: a production session **time-box** /
+> short inactivity timeout in the dashboard silently capped the 30-day intent.
+> Fix = align the dashboard fields above; the repo config + test prevent the
+> local side from drifting again.
 
 ##### Backend auth clients must be stateless (SB-115)
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -203,11 +203,19 @@ max_frequency = "5s"
 # 4152127777 = "123456"
 
 # Configure logged in session timeouts.
-# [auth.sessions]
-# Force log out after the specified duration.
-# timebox = "24h"
-# Force log out if the user has been inactive longer than the specified duration.
-# inactivity_timeout = "8h"
+[auth.sessions]
+# 30-day idle session (SB-78 / SB-120). Users stay logged in as long as they are
+# active within any 30-day window; the refresh token keeps the session alive.
+inactivity_timeout = "720h"
+# Do NOT set `timebox`: a timebox force-logs-out every session after a fixed
+# duration regardless of activity. A short timebox (e.g. "24h") is exactly what
+# caused the daily forced re-logins in SB-120 — leave it unset.
+# timebox = "720h"
+#
+# NOTE: this block only governs LOCAL Supabase. Production runs cloud-hosted
+# Supabase, whose session timeouts live in the dashboard (Auth → Sessions) and
+# must be kept in sync with the values above. See
+# docs/03-architecture/authentication.md.
 
 # This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
 # [auth.hook.before_user_created]


### PR DESCRIPTION
## Summary

Fixes the **daily** forced re-logins (distinct from the **hourly** SB-115 bug, which is already fixed + deployed).

**Root cause:** the 30-day idle session promised by SB-78 is enforced by Supabase's refresh-token **inactivity timeout / time-box**. For production that lives in the Supabase Cloud dashboard — and it was set short (a `timebox`/inactivity ≈ 24h), silently capping the 30-day intent. Local `config.toml` had the `[auth.sessions]` block commented out entirely, so there was nothing pinning the intent on either side.

## Changes

- **`supabase/config.toml`** — uncomment + pin `[auth.sessions]` to `inactivity_timeout = "720h"` (30 days), explicitly **no `timebox`**, with a comment explaining why a short timebox is the daily-logout failure mode.
- **`docs/03-architecture/authentication.md`** — document the exact prod dashboard fields (Auth → Sessions) that must be kept in sync, as a table, plus the SB-120 incident note.
- **`backend/tests/unit/test_session_config.py`** — drift-guard test: asserts the sessions block is present, `inactivity_timeout >= 30d`, and no short `timebox`.

## ⚠️ Production action required (manual, not in this PR)

`config.toml` only governs **local** Supabase. To actually fix prod, set in the Supabase Cloud dashboard (Auth → Sessions):

| Field | Value |
|---|---|
| Inactivity timeout | **30 days** (or unset) |
| Time-box user sessions | **unset** (or ≥ 30 days) |
| JWT expiry | `3600` |

## Test plan

- [x] `uv run pytest tests/unit/test_session_config.py` — 4 passed
- [x] `uv run ruff check` — clean
- [ ] Verify prod dashboard fields post-merge

Fixes SB-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)