### PR TITLE
test(pwa): cover iOS Add-to-Home-Screen tooltip (SB-121)

### DIFF
--- a/frontend/src/__tests__/components/IosInstallTooltip.spec.js
+++ b/frontend/src/__tests__/components/IosInstallTooltip.spec.js
@@ -1,0 +1,160 @@
+/**
+ * IosInstallTooltip.vue tests (SB-121).
+ *
+ * The tooltip nudges iOS Safari users to "Add to Home Screen" (Apple gives
+ * PWAs no automatic install prompt). It must appear ONLY for iOS Safari users
+ * who haven't installed yet and haven't recently dismissed it.
+ *
+ * We drive the real utils/pwa helpers via stubbed navigator/matchMedia (those
+ * helpers have their own unit tests in utils/pwa.spec.js) rather than mocking
+ * the module — this exercises the component + helpers together.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import IosInstallTooltip from '@/components/IosInstallTooltip.vue';
+
+const STORAGE_KEY = 'mt.iosInstallTooltip.dismissedAt';
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+const IOS_SAFARI_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const ANDROID_CHROME_UA =
+  'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36';
+
+function stubEnv({
+  userAgent,
+  platform,
+  maxTouchPoints,
+  standalone,
+  standaloneMatches,
+}) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    value: maxTouchPoints,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'standalone', {
+    value: standalone,
+    configurable: true,
+  });
+  window.matchMedia = query => ({
+    matches: query === '(display-mode: standalone)' ? standaloneMatches : false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  });
+}
+
+const iosSafariNotInstalled = () =>
+  stubEnv({
+    userAgent: IOS_SAFARI_UA,
+    platform: 'iPhone',
+    maxTouchPoints: 5,
+    standalone: false,
+    standaloneMatches: false,
+  });
+const iosSafariInstalled = () =>
+  stubEnv({
+    userAgent: IOS_SAFARI_UA,
+    platform: 'iPhone',
+    maxTouchPoints: 5,
+    standalone: true,
+    standaloneMatches: true,
+  });
+const androidChrome = () =>
+  stubEnv({
+    userAgent: ANDROID_CHROME_UA,
+    platform: 'Linux armv8l',
+    maxTouchPoints: 5,
+    standalone: false,
+    standaloneMatches: false,
+  });
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  iosSafariNotInstalled(); // benign reset
+});
+
+const banner = wrapper => wrapper.find('.ios-install-banner');
+
+// shouldShow is flipped in onMounted, so the banner appears on the tick after
+// mount — await nextTick before asserting visibility.
+async function mountTip() {
+  const wrapper = mount(IosInstallTooltip, {
+    global: { stubs: { transition: false } },
+  });
+  await nextTick();
+  return wrapper;
+}
+
+describe('IosInstallTooltip — when it shows', () => {
+  it('shows for iOS Safari, not installed, never dismissed', async () => {
+    iosSafariNotInstalled();
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(true);
+    expect(wrapper.text()).toContain('Add to Home Screen');
+  });
+
+  it('shows again once an old dismissal has aged out (>30 days)', async () => {
+    iosSafariNotInstalled();
+    localStorage.setItem(STORAGE_KEY, String(Date.now() - 31 * DAY_MS));
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(true);
+  });
+
+  it('treats a corrupt dismissal timestamp as "not dismissed"', async () => {
+    iosSafariNotInstalled();
+    localStorage.setItem(STORAGE_KEY, 'not-a-number');
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(true);
+  });
+});
+
+describe('IosInstallTooltip — when it stays hidden', () => {
+  it('hidden when already installed (standalone)', async () => {
+    iosSafariInstalled();
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(false);
+  });
+
+  it('hidden on non-iOS-Safari (Android)', async () => {
+    androidChrome();
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(false);
+  });
+
+  it('hidden when dismissed within the last 30 days', async () => {
+    iosSafariNotInstalled();
+    localStorage.setItem(STORAGE_KEY, String(Date.now() - 5 * DAY_MS));
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(false);
+  });
+});
+
+describe('IosInstallTooltip — dismissal', () => {
+  it('hides and persists a timestamp when the close button is clicked', async () => {
+    iosSafariNotInstalled();
+    const wrapper = await mountTip();
+    expect(banner(wrapper).exists()).toBe(true);
+
+    await wrapper.find('.ios-install-close').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(banner(wrapper).exists()).toBe(false);
+    const stored = Number(localStorage.getItem(STORAGE_KEY));
+    expect(Number.isFinite(stored)).toBe(true);
+    expect(stored).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/utils/pwa.spec.js
+++ b/frontend/src/__tests__/utils/pwa.spec.js
@@ -1,0 +1,153 @@
+/**
+ * utils/pwa.js tests (SB-121).
+ *
+ * These helpers decide whether the iOS "Add to Home Screen" tooltip and the
+ * "install first" push gating appear. The decision matrix is UA- and
+ * display-mode-driven, so we stub navigator/matchMedia per case.
+ *
+ * Covers:
+ * - isIosSafari: true only for real iOS Safari (and iPadOS-on-desktop-UA),
+ *   false for iOS Chrome/Firefox/Edge (CriOS/FxiOS/EdgiOS) and non-iOS.
+ * - isStandalone: matchMedia(display-mode: standalone) OR navigator.standalone.
+ * - isIosNonStandalone: the AND of "iOS Safari" and "not standalone".
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { isIosSafari, isStandalone, isIosNonStandalone } from '@/utils/pwa';
+
+const IOS_SAFARI_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const IOS_CHROME_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1';
+const MAC_SAFARI_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+const ANDROID_CHROME_UA =
+  'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36';
+
+function stubNavigator({
+  userAgent,
+  platform = 'iPhone',
+  maxTouchPoints = 5,
+  standalone,
+}) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    value: maxTouchPoints,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'standalone', {
+    value: standalone,
+    configurable: true,
+  });
+}
+
+function stubMatchMedia(standaloneMatches) {
+  window.matchMedia = query => ({
+    matches: query === '(display-mode: standalone)' ? standaloneMatches : false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  });
+}
+
+afterEach(() => {
+  // Reset to a benign desktop-ish baseline so cases don't leak.
+  stubNavigator({
+    userAgent: MAC_SAFARI_UA,
+    platform: 'MacIntel',
+    maxTouchPoints: 0,
+    standalone: undefined,
+  });
+  stubMatchMedia(false);
+});
+
+describe('isIosSafari', () => {
+  it('true for iOS Safari', () => {
+    stubNavigator({ userAgent: IOS_SAFARI_UA });
+    expect(isIosSafari()).toBe(true);
+  });
+
+  it('false for iOS Chrome (CriOS)', () => {
+    stubNavigator({ userAgent: IOS_CHROME_UA });
+    expect(isIosSafari()).toBe(false);
+  });
+
+  it('true for iPadOS reporting a desktop UA (MacIntel + touch)', () => {
+    stubNavigator({
+      userAgent: MAC_SAFARI_UA,
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+    });
+    expect(isIosSafari()).toBe(true);
+  });
+
+  it('false for a real desktop Mac (MacIntel, no touch)', () => {
+    stubNavigator({
+      userAgent: MAC_SAFARI_UA,
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    });
+    expect(isIosSafari()).toBe(false);
+  });
+
+  it('false for Android Chrome', () => {
+    stubNavigator({
+      userAgent: ANDROID_CHROME_UA,
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5,
+    });
+    expect(isIosSafari()).toBe(false);
+  });
+});
+
+describe('isStandalone', () => {
+  it('true when display-mode matchMedia matches', () => {
+    stubNavigator({ userAgent: IOS_SAFARI_UA, standalone: undefined });
+    stubMatchMedia(true);
+    expect(isStandalone()).toBe(true);
+  });
+
+  it('true when navigator.standalone is set (iOS Safari)', () => {
+    stubNavigator({ userAgent: IOS_SAFARI_UA, standalone: true });
+    stubMatchMedia(false);
+    expect(isStandalone()).toBe(true);
+  });
+
+  it('false when neither signal is present', () => {
+    stubNavigator({ userAgent: IOS_SAFARI_UA, standalone: false });
+    stubMatchMedia(false);
+    expect(isStandalone()).toBe(false);
+  });
+});
+
+describe('isIosNonStandalone', () => {
+  it('true for iOS Safari not yet installed', () => {
+    stubNavigator({ userAgent: IOS_SAFARI_UA, standalone: false });
+    stubMatchMedia(false);
+    expect(isIosNonStandalone()).toBe(true);
+  });
+
+  it('false once installed (standalone)', () => {
+    stubNavigator({ userAgent: IOS_SAFARI_UA, standalone: true });
+    stubMatchMedia(true);
+    expect(isIosNonStandalone()).toBe(false);
+  });
+
+  it('false on non-iOS even when not standalone', () => {
+    stubNavigator({
+      userAgent: ANDROID_CHROME_UA,
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5,
+      standalone: false,
+    });
+    stubMatchMedia(false);
+    expect(isIosNonStandalone()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PWA slice 2 (iOS Add-to-Home-Screen tooltip) turned out to be **already implemented** — `IosInstallTooltip.vue` + `utils/pwa.js` shipped bundled into slice 1 (#403) and are wired into `App.vue`. What was missing was **test coverage**. This PR backfills it.

## Behavior under test (the existing, shipped component)

The tooltip nudges iOS Safari users through Share → "Add to Home Screen" (Apple gives PWAs no automatic install prompt). It appears **only** when iOS Safari + not already installed + not dismissed in the last 30 days.

## Tests added

- **`utils/pwa.spec.js`** (11 cases) — `isIosSafari` / `isStandalone` / `isIosNonStandalone` across iOS Safari, iOS Chrome (CriOS), iPadOS-on-desktop-UA, real desktop Mac, Android.
- **`IosInstallTooltip.spec.js`** (7 cases) — show/hide decision matrix + dismissal persistence + corrupt-timestamp tolerance + 30-day re-show.

## Test plan
- [x] `npx vitest run` on both specs — 18 passed
- [x] `npm run lint` — clean

Fixes SB-121

🤖 Generated with [Claude Code](https://claude.com/claude-code)