### PR TITLE
perf(pwa): lazy-load tab views, shrink initial bundle 71% (SB-122)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -532,31 +532,73 @@
 </template>
 
 <script>
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import {
+  ref,
+  computed,
+  onMounted,
+  onUnmounted,
+  watch,
+  defineAsyncComponent,
+} from 'vue';
 import { useAuthStore } from './stores/auth';
 import { useAdminAttentionCounts } from './composables/useAdminAttentionCounts';
 import { getApiBaseUrl } from './config/api';
 import { recordPageView, recordInviteRequest } from './faro';
-import MatchForm from './components/MatchForm.vue';
+
+// Eagerly loaded: initial-paint view (LeagueTable is the default tab) and the
+// always-mounted chrome (nav, footer, indicators, login screen). These belong
+// in the initial bundle so first paint has no async waterfall.
 import LeagueTable from './components/LeagueTable.vue';
-import MatchesView from './components/MatchesView.vue';
-import MatchDetailView from './components/MatchDetailView.vue';
-import GoalsLeaderboard from './components/GoalsLeaderboard.vue';
 import AuthNav from './components/AuthNav.vue';
 import LoginForm from './components/LoginForm.vue';
-import ForgotPasswordForm from './components/ForgotPasswordForm.vue';
-import ResetPasswordForm from './components/ResetPasswordForm.vue';
-import ProfileRouter from './components/ProfileRouter.vue';
-import TeamRosterRouter from './components/profiles/TeamRosterRouter.vue';
-import AdminPanel from './components/AdminPanel.vue';
-import TournamentMatchCenter from './components/TournamentMatchCenter.vue';
-import QoPStandings from './components/QoPStandings.vue';
 import VersionFooter from './components/VersionFooter.vue';
-import WhatsNewView from './components/WhatsNewView.vue';
-import { LiveMatchView } from './components/live';
 import IosInstallTooltip from './components/IosInstallTooltip.vue';
 import OfflineIndicator from './components/OfflineIndicator.vue';
 import UpdateAvailablePrompt from './components/UpdateAvailablePrompt.vue';
+
+// Lazily loaded (SB-122): every view that lives behind a tab `v-if` and isn't
+// shown on first paint. Each becomes its own chunk, fetched only when its tab
+// is opened — keeps the initial bundle (and TTI) small. TournamentMatchCenter
+// pulls the heavy bracket components, so this is the biggest single win.
+const MatchForm = defineAsyncComponent(
+  () => import('./components/MatchForm.vue')
+);
+const MatchesView = defineAsyncComponent(
+  () => import('./components/MatchesView.vue')
+);
+const MatchDetailView = defineAsyncComponent(
+  () => import('./components/MatchDetailView.vue')
+);
+const GoalsLeaderboard = defineAsyncComponent(
+  () => import('./components/GoalsLeaderboard.vue')
+);
+const ForgotPasswordForm = defineAsyncComponent(
+  () => import('./components/ForgotPasswordForm.vue')
+);
+const ResetPasswordForm = defineAsyncComponent(
+  () => import('./components/ResetPasswordForm.vue')
+);
+const ProfileRouter = defineAsyncComponent(
+  () => import('./components/ProfileRouter.vue')
+);
+const TeamRosterRouter = defineAsyncComponent(
+  () => import('./components/profiles/TeamRosterRouter.vue')
+);
+const AdminPanel = defineAsyncComponent(
+  () => import('./components/AdminPanel.vue')
+);
+const TournamentMatchCenter = defineAsyncComponent(
+  () => import('./components/TournamentMatchCenter.vue')
+);
+const QoPStandings = defineAsyncComponent(
+  () => import('./components/QoPStandings.vue')
+);
+const WhatsNewView = defineAsyncComponent(
+  () => import('./components/WhatsNewView.vue')
+);
+const LiveMatchView = defineAsyncComponent(() =>
+  import('./components/live').then(m => m.LiveMatchView)
+);
 
 export default {
   name: 'App',


### PR DESCRIPTION
## Summary

PWA slice 4 — performance. `App.vue` eagerly imported all 20 view components, so the initial bundle carried every tab (including the admin-only 264K AdminPanel and the heavy tournament brackets) even though only the default **Table** tab renders on first paint. This converts the tab-gated views to `defineAsyncComponent`, so each is its own chunk fetched on demand.

## Measured impact (`vite build`)

| | Before (main) | After |
|---|---|---|
| **Initial entry JS** | 1,344 KB | **387 KB** (−71%) |

On-demand chunks split out: MatchDetailView 299K · AdminPanel 264K · ProfileRouter 106K · MatchesView 75K · TournamentMatchCenter 43K (pulls the ~1900-line bracket components) · WhatsNewView 40K · MatchForm 14K · GoalsLeaderboard 12K · QoPStandings 9K.

## Kept eager (first paint + always-mounted chrome)
LeagueTable (default tab), AuthNav, LoginForm, VersionFooter, OfflineIndicator, UpdateAvailablePrompt, IosInstallTooltip.

## Test plan
- [x] `npm run build` — succeeds, chunks split as above
- [x] `npm run test:run` — 516 passed (39 files)
- [x] `npm run lint` — clean
- [ ] Lighthouse PWA ≥90 / TTI <3s on a mid-range device — **remaining manual step** (can't run Lighthouse in CI sandbox)

## Note
Acceptance criterion "Lighthouse ≥90 / TTI <3s" needs a real-device/CI Lighthouse run to close. This PR delivers the dominant lever (initial-bundle reduction); the measurement step remains.

Fixes SB-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)