### PR TITLE
fix(auth): don't force re-login on transient refresh errors (SB-123)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from fastapi import BackgroundTasks, Depends, FastAPI, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials
+from gotrue.errors import AuthApiError
 from pydantic import BaseModel
 
 import r2_client
@@ -1783,10 +1784,22 @@ async def refresh_token(request: Request, refresh_data: RefreshTokenRequest):
             refresh_logger.warning("auth_refresh_failed", reason="no_session")
             raise HTTPException(status_code=401, detail="Failed to refresh token")
 
-    except Exception as e:
-        refresh_logger.error("auth_refresh_error", error=str(e))
-        logger.error(f"Token refresh error: {e}", exc_info=True)
+    except HTTPException:
+        raise
+    except AuthApiError as e:
+        # The auth API genuinely rejected the token (invalid / expired /
+        # already-used). This is a real auth failure — 401 tells the frontend
+        # to clear state and re-login.
+        refresh_logger.warning("auth_refresh_rejected", error=str(e), code=getattr(e, "code", None))
         raise HTTPException(status_code=401, detail="Invalid refresh token") from e
+    except Exception as e:
+        # Anything else (AuthRetryableError, network/timeout, upstream 5xx) is
+        # TRANSIENT — e.g. the network isn't ready on wake-from-sleep. Returning
+        # 401 here would force a needless re-login (SB-123). Return 503 so the
+        # frontend's transient path keeps the still-valid token and recovers on
+        # the next refresh attempt.
+        refresh_logger.warning("auth_refresh_transient", error=str(e))
+        raise HTTPException(status_code=503, detail="Token refresh temporarily unavailable") from e
 
 
 @app.get("/api/auth/me")

--- a/backend/tests/unit/test_refresh_token_error_mapping.py
+++ b/backend/tests/unit/test_refresh_token_error_mapping.py
@@ -1,0 +1,86 @@
+"""Unit tests for /api/auth/refresh error mapping (SB-123).
+
+The endpoint previously mapped *every* failure to HTTP 401. The frontend
+treats 401/403 from a refresh as a genuine auth failure and force-logs-out,
+so a transient upstream hiccup (network not ready on wake-from-sleep, a slow
+or 5xx Supabase response) became a needless re-login — the "logged out after
+idle" bug.
+
+Correct mapping:
+- genuine bad/expired/used token (AuthApiError) -> 401 (frontend logs out)
+- transient (AuthRetryableError, network, anything else) -> 503 (frontend
+  keeps the token and recovers on the next refresh)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from gotrue.errors import AuthApiError, AuthRetryableError
+
+import app as app_module
+
+REFRESH_URL = "/api/auth/refresh"
+BODY = {"refresh_token": "some-refresh-token"}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+def _session_response():
+    return SimpleNamespace(
+        session=SimpleNamespace(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            expires_at=1234567890,
+        )
+    )
+
+
+class TestRefreshErrorMapping:
+    def test_success_returns_new_session(self, client):
+        with patch.object(app_module.auth_ops_client.auth, "refresh_session", return_value=_session_response()):
+            resp = client.post(REFRESH_URL, json=BODY)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["session"]["access_token"] == "new-access"
+        assert body["session"]["refresh_token"] == "new-refresh"
+
+    def test_genuine_bad_token_returns_401(self, client):
+        err = AuthApiError("invalid refresh token", 400, "refresh_token_not_found")
+        with patch.object(app_module.auth_ops_client.auth, "refresh_session", side_effect=err):
+            resp = client.post(REFRESH_URL, json=BODY)
+        assert resp.status_code == 401
+
+    def test_retryable_error_returns_503(self, client):
+        # AuthRetryableError = upstream said "retry" (e.g. 5xx). Transient.
+        err = AuthRetryableError("service unavailable", 503)
+        with patch.object(app_module.auth_ops_client.auth, "refresh_session", side_effect=err):
+            resp = client.post(REFRESH_URL, json=BODY)
+        assert resp.status_code == 503
+
+    def test_network_error_returns_503(self, client):
+        # Raw connectivity failure (network not ready on wake). Transient.
+        with patch.object(
+            app_module.auth_ops_client.auth,
+            "refresh_session",
+            side_effect=ConnectionError("connection refused"),
+        ):
+            resp = client.post(REFRESH_URL, json=BODY)
+        assert resp.status_code == 503
+
+    def test_no_session_returns_401(self, client):
+        # Response with no session is a genuine failure, not transient.
+        with patch.object(
+            app_module.auth_ops_client.auth,
+            "refresh_session",
+            return_value=SimpleNamespace(session=None),
+        ):
+            resp = client.post(REFRESH_URL, json=BODY)
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

The real cause of the **"logged out after the PWA sits idle"** complaint — and it's our code, not a Supabase plan/setting (prod session timeouts are already `never`; the User Sessions config is Pro-gated but irrelevant here).

`/api/auth/refresh` mapped **every** failure to HTTP 401:

```python
except Exception as e:
    raise HTTPException(status_code=401, detail="Invalid refresh token") from e
```

The frontend (`stores/auth.js`) treats 401/403 from a refresh as a **genuine** auth failure → `clearAuthState()` → full re-login, and only treats network/5xx as *transient* (keeps the token, auto-recovers). So a transient upstream hiccup during refresh — network not ready on wake-from-sleep, a slow/5xx Supabase response — looked like an invalid token and logged the user out. On idle-reopen the first refresh routinely races a not-yet-ready network.

## Fix

Split the error mapping in `/api/auth/refresh`:

| Failure | Status | Frontend behavior |
|---|---|---|
| `AuthApiError` (token invalid / expired / already-used) | **401** | logs out (correct) |
| `AuthRetryableError`, network error, anything else | **503** | keeps token, recovers next refresh |

## Test plan
- [x] `pytest tests/unit/test_refresh_token_error_mapping.py` — 5 passed (success / 401-genuine / 503-retryable / 503-network / 401-no-session)
- [x] `ruff check` — clean

## Follow-ups (not in this PR)
- Raise prod `refresh_token_reuse_interval` (10s → ~30s) to absorb lost-response rotation races around sleep.
- `initialize()` could retry once on a transient refresh so the login screen never flashes on wake.

Fixes SB-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)