### PR TITLE
feat(landing): add hero CTAs and make Request Invite primary (SB-131)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -116,6 +116,20 @@
                 Community-built standings, tracking the top youth soccer leagues
                 in the US
               </p>
+              <div class="mt-7 flex flex-col sm:flex-row gap-3 justify-center">
+                <button
+                  @click="showInviteRequestModal = true"
+                  class="bg-white text-brand-700 px-8 py-3 rounded-lg font-semibold hover:bg-slate-100 transition-colors text-base shadow-sm"
+                >
+                  Request Invite
+                </button>
+                <button
+                  @click="showLoginModal = true"
+                  class="bg-white/10 text-white px-8 py-3 rounded-lg font-semibold hover:bg-white/20 transition-colors text-base border border-white/40"
+                >
+                  Login
+                </button>
+              </div>
             </div>
           </div>
           <!-- Main Card -->
@@ -149,16 +163,16 @@
             </p>
             <div class="flex flex-col sm:flex-row gap-3 justify-center">
               <button
-                @click="showLoginModal = true"
+                @click="showInviteRequestModal = true"
                 class="bg-brand-500 text-white px-8 py-3 rounded-lg font-semibold hover:bg-brand-600 transition-colors text-base shadow-sm"
               >
-                Login
+                Request Invite
               </button>
               <button
-                @click="showInviteRequestModal = true"
+                @click="showLoginModal = true"
                 class="bg-white text-slate-700 px-8 py-3 rounded-lg font-semibold hover:bg-slate-50 transition-colors text-base border border-slate-300 shadow-sm"
               >
-                Request Invite
+                Login
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Landing page hero had no call to action, and the invite card emphasized **Login** over **Request Invite** — backwards for a logged-out visitor whose only meaningful action is requesting an invite (existing users are covered by the header Login button).

- Add **Request Invite** (primary, white on hero) + **Login** (secondary, ghost) buttons inside the hero
- Swap button order and emphasis in the invite card to match (Request Invite filled, Login ghost)

Part of UX Overhaul epic SB-130. Fixes SB-131.

## Testing

- `npm run lint` clean, `npm run test:run` 534/534 pass
- Visually verified via local preview at 380px (CTAs stack full-width, thumb-reachable) and 1280px (side-by-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)