### PR TITLE
feat(landing): replace feature cards with live product preview table (SB-133)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -114,89 +114,8 @@
               </div>
             </div>
           </div>
-          <!-- Features Section -->
-          <div class="grid md:grid-cols-3 gap-4">
-            <div
-              class="bg-white rounded-xl shadow-sm ring-1 ring-slate-200/60 p-6 text-center"
-            >
-              <div
-                class="inline-flex items-center justify-center w-12 h-12 bg-brand-50 rounded-xl mb-4"
-              >
-                <svg
-                  class="w-6 h-6 text-brand-500"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke-width="1.5"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-semibold text-slate-800 mb-2">Live Standings</h3>
-              <p class="text-sm text-slate-500">
-                Real-time league tables with automatic point calculations and
-                rankings
-              </p>
-            </div>
-            <div
-              class="bg-white rounded-xl shadow-sm ring-1 ring-slate-200/60 p-6 text-center"
-            >
-              <div
-                class="inline-flex items-center justify-center w-12 h-12 bg-sky-50 rounded-xl mb-4"
-              >
-                <svg
-                  class="w-6 h-6 text-sky-600"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke-width="1.5"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-semibold text-slate-800 mb-2">Match Tracking</h3>
-              <p class="text-sm text-slate-500">
-                Track scores, schedules, and results for your team's games
-              </p>
-            </div>
-            <div
-              class="bg-white rounded-xl shadow-sm ring-1 ring-slate-200/60 p-6 text-center"
-            >
-              <div
-                class="inline-flex items-center justify-center w-12 h-12 bg-violet-50 rounded-xl mb-4"
-              >
-                <svg
-                  class="w-6 h-6 text-violet-600"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke-width="1.5"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-semibold text-slate-800 mb-2">Team Management</h3>
-              <p class="text-sm text-slate-500">
-                Manage rosters, match types, and team information all in one
-                place
-              </p>
-            </div>
-          </div>
+          <!-- Product Preview -->
+          <LandingPreview />
         </div>
 
         <!-- Invite Request Modal -->
@@ -500,6 +419,7 @@ import { recordPageView, recordInviteRequest } from './faro';
 // always-mounted chrome (nav, footer, indicators, login screen). These belong
 // in the initial bundle so first paint has no async waterfall.
 import LeagueTable from './components/LeagueTable.vue';
+import LandingPreview from './components/LandingPreview.vue';
 import AuthNav from './components/AuthNav.vue';
 import LoginForm from './components/LoginForm.vue';
 import VersionFooter from './components/VersionFooter.vue';
@@ -556,6 +476,7 @@ export default {
   components: {
     MatchForm,
     LeagueTable,
+    LandingPreview,
     MatchesView,
     MatchDetailView,
     GoalsLeaderboard,

--- a/frontend/src/components/LandingPreview.vue
+++ b/frontend/src/components/LandingPreview.vue
@@ -1,0 +1,203 @@
+<template>
+  <div>
+    <div
+      class="bg-white rounded-xl shadow-sm ring-1 ring-slate-200/60 overflow-hidden"
+    >
+      <div
+        class="flex items-center justify-between px-4 sm:px-6 py-3 border-b border-slate-100"
+      >
+        <span class="text-sm font-semibold text-slate-800"
+          >U14 · Northeast Division</span
+        >
+        <span
+          class="text-xs font-medium text-slate-500 bg-slate-100 rounded-full px-2.5 py-0.5"
+          >Sample</span
+        >
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200">
+          <thead class="bg-brand-500">
+            <tr>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              >
+                #
+              </th>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-semibold text-slate-300 uppercase tracking-wider"
+              >
+                Team
+              </th>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+                title="Games Played"
+              >
+                GP
+              </th>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+                title="Wins"
+              >
+                W
+              </th>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+                title="Draws"
+              >
+                D
+              </th>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+                title="Losses"
+              >
+                L
+              </th>
+              <th
+                class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+                title="Goal Difference"
+              >
+                GD
+              </th>
+              <th
+                class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-brand-200 uppercase tracking-wider"
+                title="Points"
+              >
+                Pts
+              </th>
+              <th
+                class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-semibold text-slate-300 uppercase tracking-wider"
+                title="Last 5 results"
+              >
+                Form
+              </th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-slate-100">
+            <tr
+              v-for="(team, index) in sampleStandings"
+              :key="team.name"
+              class="hover:bg-slate-50 transition-colors"
+            >
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-gray-500"
+              >
+                {{ index + 1 }}
+              </td>
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 text-xs sm:text-sm font-medium text-gray-900 whitespace-nowrap"
+              >
+                {{ team.name }}
+              </td>
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-center text-gray-500"
+              >
+                {{ team.wins + team.draws + team.losses }}
+              </td>
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-center text-gray-500"
+              >
+                {{ team.wins }}
+              </td>
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-center text-gray-500"
+              >
+                {{ team.draws }}
+              </td>
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-center text-gray-500"
+              >
+                {{ team.losses }}
+              </td>
+              <td
+                class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-center text-gray-500"
+              >
+                {{ team.gd > 0 ? `+${team.gd}` : team.gd }}
+              </td>
+              <td
+                class="px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-sm text-center font-bold text-brand-600"
+              >
+                {{ team.wins * 3 + team.draws }}
+              </td>
+              <td
+                class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 whitespace-nowrap text-center"
+              >
+                <div class="flex items-center justify-center gap-1">
+                  <span
+                    v-for="(result, rIdx) in team.form"
+                    :key="rIdx"
+                    class="inline-block w-5 h-5 rounded-full text-[10px] font-bold leading-5 text-white text-center"
+                    :class="{
+                      'bg-green-500': result === 'W',
+                      'bg-red-500': result === 'L',
+                      'bg-gray-400': result === 'D',
+                    }"
+                  >
+                    {{ result }}
+                  </span>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <p class="mt-4 text-center text-sm text-slate-500">
+      Live standings with automatic rankings · Scores &amp; schedules · Rosters
+      &amp; team management
+    </p>
+  </div>
+</template>
+
+<script setup>
+// Static sample data — landing page preview only, never fetched
+const sampleStandings = [
+  {
+    name: 'Harbor City FC',
+    wins: 8,
+    draws: 1,
+    losses: 1,
+    gd: 18,
+    form: ['W', 'W', 'D', 'W', 'W'],
+  },
+  {
+    name: 'Northside United',
+    wins: 7,
+    draws: 2,
+    losses: 1,
+    gd: 14,
+    form: ['W', 'D', 'W', 'W', 'L'],
+  },
+  {
+    name: 'Riverline SC',
+    wins: 6,
+    draws: 1,
+    losses: 3,
+    gd: 7,
+    form: ['L', 'W', 'W', 'D', 'W'],
+  },
+  {
+    name: 'Summit Athletic',
+    wins: 4,
+    draws: 3,
+    losses: 3,
+    gd: 2,
+    form: ['D', 'L', 'W', 'D', 'W'],
+  },
+  {
+    name: 'Bayview Rovers',
+    wins: 3,
+    draws: 2,
+    losses: 5,
+    gd: -6,
+    form: ['L', 'W', 'L', 'D', 'L'],
+  },
+  {
+    name: 'Ironbridge FC',
+    wins: 1,
+    draws: 1,
+    losses: 8,
+    gd: -21,
+    form: ['L', 'L', 'D', 'L', 'L'],
+  },
+];
+</script>


### PR DESCRIPTION
## Summary

Three generic icon cards told visitors what the product does — a real standings table shows them.

- New `LandingPreview` component: static sample league table styled identically to `LeagueTable` (same header/row/points/form-badge classes), with a **Sample** pill so it isn't mistaken for live data
- Replaces the three feature cards; feature bullets condensed to a one-line caption under the preview
- Sample data hardcoded — no fetch on the public landing page
- Mobile (<md) hides GD and Form columns, same responsive behavior as the real table

Part of UX Overhaul epic SB-130. Fixes SB-133.

## Testing

- `npm run lint` clean, `npm run test:run` 534/534 pass
- Visually verified via local preview at 380px (core columns fit, no overflow) and 1280px (full table incl. form badges, page still above fold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)