### PR TITLE
chore(landing): hide version and health badge from public footer (SB-134)

### DIFF
--- a/frontend/src/__tests__/components/VersionFooter.spec.js
+++ b/frontend/src/__tests__/components/VersionFooter.spec.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import VersionFooter from '@/components/VersionFooter.vue';
+import {
+  createMockAuthStore,
+  createAuthenticatedUserStore,
+  createUnauthenticatedStore,
+} from '../helpers/matchFactories';
+
+let mockAuthStore;
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => mockAuthStore,
+}));
+
+const mountFooter = async () => {
+  const wrapper = mount(VersionFooter, {
+    global: {
+      stubs: {
+        SupportEmailLink: true,
+        Teleport: true,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+describe('VersionFooter visibility gating', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ version: '1.6.9.1118', status: 'healthy' }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('hides version and health badge for anonymous visitors', async () => {
+    mockAuthStore = createUnauthenticatedStore();
+    const wrapper = await mountFooter();
+
+    expect(wrapper.find('[data-testid="whats-new-trigger"]').exists()).toBe(
+      false
+    );
+    expect(wrapper.find('.status-indicator').text()).toBe('');
+    expect(wrapper.text()).not.toContain('1.6.9.1118');
+    expect(wrapper.text()).not.toContain('Healthy');
+  });
+
+  it('shows version but not health badge for regular members', async () => {
+    mockAuthStore = createAuthenticatedUserStore();
+    const wrapper = await mountFooter();
+
+    expect(wrapper.find('[data-testid="whats-new-trigger"]').text()).toBe(
+      '1.6.9.1118'
+    );
+    expect(wrapper.text()).not.toContain('Healthy');
+  });
+
+  it('shows version and health badge for admins', async () => {
+    mockAuthStore = createMockAuthStore();
+    const wrapper = await mountFooter();
+
+    expect(wrapper.find('[data-testid="whats-new-trigger"]').text()).toBe(
+      '1.6.9.1118'
+    );
+    expect(wrapper.text()).toContain('Healthy');
+  });
+
+  it('keeps copyright and support link for everyone', async () => {
+    mockAuthStore = createUnauthenticatedStore();
+    const wrapper = await mountFooter();
+
+    expect(wrapper.text()).toContain('Missing Table');
+    expect(wrapper.text()).toContain('Need help?');
+  });
+
+  it('still emits open-whats-new from the version button for members', async () => {
+    mockAuthStore = createAuthenticatedUserStore();
+    const wrapper = await mountFooter();
+
+    await wrapper.find('[data-testid="whats-new-trigger"]').trigger('click');
+    expect(wrapper.emitted('open-whats-new')).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/VersionFooter.vue
+++ b/frontend/src/components/VersionFooter.vue
@@ -30,23 +30,25 @@
     </Teleport>
 
     <div class="version-container">
-      <!-- Version info (left side) -->
+      <!-- Version info (left side) — internal info, members only -->
       <div class="version-info">
-        <template v-if="version">
-          <button
-            type="button"
-            class="version-text version-button"
-            title="What's New"
-            data-testid="whats-new-trigger"
-            @click="$emit('open-whats-new')"
-          >
-            {{ version }}
-          </button>
-          <span v-if="environment !== 'production'" class="environment-badge">
-            {{ environment }}
-          </span>
+        <template v-if="authStore.isAuthenticated.value">
+          <template v-if="version">
+            <button
+              type="button"
+              class="version-text version-button"
+              title="What's New"
+              data-testid="whats-new-trigger"
+              @click="$emit('open-whats-new')"
+            >
+              {{ version }}
+            </button>
+            <span v-if="environment !== 'production'" class="environment-badge">
+              {{ environment }}
+            </span>
+          </template>
+          <span v-else class="version-loading">Loading version...</span>
         </template>
-        <span v-else class="version-loading">Loading version...</span>
       </div>
 
       <!-- Copyright/branding + support link (center) -->
@@ -64,9 +66,9 @@
         </div>
       </div>
 
-      <!-- Status indicator (right side) — only show when healthy -->
+      <!-- Status indicator (right side) — ops info, admins only -->
       <div class="status-indicator">
-        <template v-if="status === 'healthy'">
+        <template v-if="authStore.isAdmin.value && status === 'healthy'">
           <span class="status-dot status-healthy"></span>
           <span class="status-text">Healthy</span>
         </template>
@@ -168,6 +170,7 @@ export default {
     });
 
     return {
+      authStore,
       version,
       environment,
       status,


### PR DESCRIPTION
## Summary

Public footer exposed internal ops info to anonymous visitors.

- **Version button** (What's New entry point) + environment badge: now authenticated users only — keeps the What's New modal reachable for members
- **Healthy badge**: admins only — meaningless to visitors, and advertised when the site flipped unhealthy
- Copyright + contact-support link unchanged for everyone
- API-unreachable error banner still shows for all visitors

Part of UX Overhaul epic SB-130. Fixes SB-134.

## Testing

- New `VersionFooter.spec.js`: 5 tests covering anonymous/member/admin visibility and the `open-whats-new` emit
- `npm run lint` clean, `npm run test:run` 539/539 pass (was 534)
- Visually verified logged-out footer at 1280px — only copyright + support remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)