### PR TITLE
feat(landing): scale hero headline down at mobile widths (SB-135)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -91,7 +91,7 @@
           >
             <div class="absolute inset-0 bg-brand-700/55 rounded-2xl"></div>
             <div class="relative z-10">
-              <h1 class="text-4xl font-bold mb-3 tracking-tight">
+              <h1 class="text-3xl sm:text-4xl font-bold mb-3 tracking-tight">
                 The table you've been missing.
               </h1>
               <p class="text-lg text-slate-300 max-w-xl mx-auto">


### PR DESCRIPTION
## Summary

Full mobile audit of the landing page at 380px. One fix shipped: hero headline now `text-3xl sm:text-4xl` (30px on phones, 36px from `sm` up) — gives the subtext and CTAs more breathing room and brings more of the preview table above the fold.

## Audit results (380px viewport)

| Check | Result |
|-------|--------|
| Horizontal overflow | None — `scrollWidth == clientWidth`, zero offending elements |
| Hero CTAs | Stack full-width, 300×48px+ — thumb-friendly |
| Preview table | Fits cleanly; GD/Form columns hidden below `md` |
| Footer | Stacks centered; anonymous sees only copyright + support |
| Headline | 36px → fixed to 30px below `sm` |

Closes out the landing-page children of UX Overhaul epic SB-130. Fixes SB-135.

## Testing

- `npm run lint` clean, `npm run test:run` 539/539 pass
- Verified 30px at 380px and 36px at 1280px via computed styles in local preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)