### PR TITLE
docs: fix manage_users.py paths after move to backend/scripts/ (SB-142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,8 +259,8 @@ npx supabase db diff -f add_new_feature
 
 ### User Management
 ```bash
-cd backend && APP_ENV=prod uv run python manage_users.py list
-cd backend && APP_ENV=prod uv run python manage_users.py create --email user@example.com --role admin
+cd backend && APP_ENV=prod uv run python scripts/manage_users.py list
+cd backend && APP_ENV=prod uv run python scripts/manage_users.py create --email user@example.com --role admin
 ```
 
 ---
@@ -322,4 +322,4 @@ Backend-centered auth resolves k8s networking issues. All Supabase credentials s
 
 ---
 
-**Last Updated**: 2026-02-04
+**Last Updated**: 2026-06-11

--- a/backend/README_MANAGE_USERS.md
+++ b/backend/README_MANAGE_USERS.md
@@ -15,37 +15,37 @@ A comprehensive power tool for managing users in the Missing Table application.
 
 ### List All Users
 ```bash
-uv run python manage_users.py list
+uv run python scripts/manage_users.py list
 ```
 
 ### Delete a User
 ```bash
 # Interactive (prompts for confirmation)
-uv run python manage_users.py delete --id <USER_ID>
+uv run python scripts/manage_users.py delete --id <USER_ID>
 
 # Skip confirmation
-uv run python manage_users.py delete --id <USER_ID> --confirm
+uv run python scripts/manage_users.py delete --id <USER_ID> --confirm
 ```
 
 ### Change Password
 ```bash
 # Prompt for password
-uv run python manage_users.py password --email <EMAIL>
+uv run python scripts/manage_users.py password --email <EMAIL>
 
 # Provide password directly
-uv run python manage_users.py password --email <EMAIL> --password <NEW_PASS>
+uv run python scripts/manage_users.py password --email <EMAIL> --password <NEW_PASS>
 
 # Generate secure password
-uv run python manage_users.py password --email <EMAIL> --generate
+uv run python scripts/manage_users.py password --email <EMAIL> --generate
 ```
 
 ### Create New User
 ```bash
 # Interactive
-uv run python manage_users.py create --email <EMAIL> --role <ROLE>
+uv run python scripts/manage_users.py create --email <EMAIL> --role <ROLE>
 
 # With all options
-uv run python manage_users.py create \
+uv run python scripts/manage_users.py create \
   --email user@example.com \
   --role team-fan \
   --display-name "John Doe" \
@@ -54,14 +54,14 @@ uv run python manage_users.py create \
 
 ### Update User Role
 ```bash
-uv run python manage_users.py role --email <EMAIL> --role <NEW_ROLE>
+uv run python scripts/manage_users.py role --email <EMAIL> --role <NEW_ROLE>
 ```
 
 Valid roles: `admin`, `team-manager`, `team-player`, `team-fan`
 
 ### View User Details
 ```bash
-uv run python manage_users.py info --email <EMAIL>
+uv run python scripts/manage_users.py info --email <EMAIL>
 ```
 
 ## Environment Support
@@ -70,11 +70,11 @@ The tool automatically loads the correct environment based on `APP_ENV`:
 
 ```bash
 # Default (dev)
-uv run python manage_users.py list
+uv run python scripts/manage_users.py list
 
 # Explicit environment
-APP_ENV=local uv run python manage_users.py list
-APP_ENV=prod uv run python manage_users.py list
+APP_ENV=local uv run python scripts/manage_users.py list
+APP_ENV=prod uv run python scripts/manage_users.py list
 ```
 
 ## Examples
@@ -83,22 +83,22 @@ APP_ENV=prod uv run python manage_users.py list
 
 **List all team managers:**
 ```bash
-uv run python manage_users.py list | grep "team-manager"
+uv run python scripts/manage_users.py list | grep "team-manager"
 ```
 
 **Delete old/duplicate user:**
 ```bash
-uv run python manage_users.py delete --id 8559d6a3-3298-47bc-a363-325795707fcc --confirm
+uv run python scripts/manage_users.py delete --id 8559d6a3-3298-47bc-a363-325795707fcc --confirm
 ```
 
 **Reset password for user:**
 ```bash
-uv run python manage_users.py password --email tom_ifa@missingtable.local --generate
+uv run python scripts/manage_users.py password --email tom_ifa@missingtable.local --generate
 ```
 
 **Create admin user:**
 ```bash
-uv run python manage_users.py create \
+uv run python scripts/manage_users.py create \
   --email admin@missingtable.com \
   --role admin \
   --display-name "Admin User" \
@@ -115,7 +115,7 @@ uv run python manage_users.py create \
 
 ## Tips
 
-- Use Tab completion: `uv run python manage_users.py --install-completion`
-- Get help: `uv run python manage_users.py COMMAND --help`
+- Use Tab completion: `uv run python scripts/manage_users.py --install-completion`
+- Get help: `uv run python scripts/manage_users.py COMMAND --help`
 - Skip confirmations in scripts: use `--confirm` or `-y` flag
 - Generate secure passwords: use `--generate` or `-g` flag


### PR DESCRIPTION
## Summary

`manage_users.py` moved from `backend/` to `backend/scripts/` in bae7098 (Dec 2025); CLAUDE.md and `backend/README_MANAGE_USERS.md` still pointed at the old path, so every documented command failed with file-not-found. Surfaced while investigating a prod login report.

- 2 commands fixed in CLAUDE.md, 19 in README_MANAGE_USERS.md
- Verified `cd backend && APP_ENV=prod uv run python scripts/manage_users.py list` works

Fixes SB-142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)