### PR TITLE
chore: add Claude Code preview launch config (SB-143)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "serve", "--prefix", "frontend"],
+      "port": 8080
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Commits `.claude/launch.json` — Claude Code preview dev-server config (frontend, `npm run serve`, port 8080). Used for the visual verification loop (380px/1280px screenshots) throughout the SB-130 UX overhaul; committing makes it available on both machines without per-session setup.

Fixes SB-143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)