### PR TITLE
feat(theme): apply Midnight Amber brand palette (SB-145)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "serve", "--prefix", "frontend"],
+      "port": 8080
+    }
+  ]
+}

--- a/frontend/src/components/AuthNav.vue
+++ b/frontend/src/components/AuthNav.vue
@@ -390,7 +390,7 @@ export default {
 }
 
 .login-btn {
-  background-color: #0257fe;
+  background-color: #1e40af;
   color: white;
   border: none;
   padding: 0.5rem 1.5rem;
@@ -401,7 +401,7 @@ export default {
 }
 
 .login-btn:hover {
-  background-color: #0047d4;
+  background-color: #1a3793;
 }
 
 .loading-bar {
@@ -410,7 +410,7 @@ export default {
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, #0257fe, #99b8ff);
+  background: linear-gradient(90deg, #1e40af, #aac3ea);
   animation: loading 1.5s ease-in-out infinite;
 }
 

--- a/frontend/src/components/ForgotPasswordForm.vue
+++ b/frontend/src/components/ForgotPasswordForm.vue
@@ -217,8 +217,8 @@ export default {
 
 .form-group input:focus {
   outline: none;
-  border-color: #0257fe;
-  box-shadow: 0 0 0 2px rgba(2, 87, 254, 0.2);
+  border-color: #1e40af;
+  box-shadow: 0 0 0 2px rgba(30, 64, 175, 0.2);
 }
 
 .form-group input:disabled {
@@ -241,7 +241,7 @@ export default {
 
 .submit-btn {
   width: 100%;
-  background-color: #0257fe;
+  background-color: #1e40af;
   color: white;
   padding: 0.75rem;
   border: none;
@@ -253,7 +253,7 @@ export default {
 }
 
 .submit-btn:hover:not(:disabled) {
-  background-color: #0047d4;
+  background-color: #1a3793;
 }
 
 .submit-btn:disabled {
@@ -271,13 +271,13 @@ export default {
 .link-btn {
   background: none;
   border: none;
-  color: #0257fe;
+  color: #1e40af;
   cursor: pointer;
   text-decoration: underline;
   font-size: inherit;
 }
 
 .link-btn:hover {
-  color: #0047d4;
+  color: #1a3793;
 }
 </style>

--- a/frontend/src/components/IosInstallTooltip.vue
+++ b/frontend/src/components/IosInstallTooltip.vue
@@ -83,7 +83,7 @@ onMounted(() => {
   right: 12px;
   bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
   z-index: 1000;
-  background: #0257fe;
+  background: #1e40af;
   color: white;
   border-radius: 12px;
   padding: 12px 40px 12px 14px;

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -586,8 +586,8 @@ export default {
 .form-group input:focus,
 .form-group select:focus {
   outline: none;
-  border-color: #0257fe;
-  box-shadow: 0 0 0 3px rgba(2, 87, 254, 0.15);
+  border-color: #1e40af;
+  box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.15);
   background: white;
 }
 
@@ -625,7 +625,7 @@ export default {
 
 .submit-btn {
   width: 100%;
-  background-color: #0257fe;
+  background-color: #1e40af;
   color: white;
   padding: 0.75rem;
   border: none;
@@ -638,7 +638,7 @@ export default {
 }
 
 .submit-btn:hover:not(:disabled) {
-  background-color: #0047d4;
+  background-color: #1a3793;
 }
 
 .submit-btn:disabled {
@@ -662,7 +662,7 @@ export default {
 .link-btn {
   background: none;
   border: none;
-  color: #0257fe;
+  color: #1e40af;
   cursor: pointer;
   text-decoration: underline;
   font-size: inherit;
@@ -670,7 +670,7 @@ export default {
 }
 
 .link-btn:hover {
-  color: #0047d4;
+  color: #1a3793;
 }
 
 .role-selection {
@@ -703,13 +703,13 @@ export default {
 }
 
 .role-option:hover {
-  background-color: #e8f0ff;
-  border-color: #0257fe;
+  background-color: #eef3fb;
+  border-color: #1e40af;
 }
 
 .role-option input[type='radio'] {
   margin-right: 0.5rem;
-  accent-color: #0257fe;
+  accent-color: #1e40af;
 }
 
 .role-option span {

--- a/frontend/src/components/UpdateAvailablePrompt.vue
+++ b/frontend/src/components/UpdateAvailablePrompt.vue
@@ -69,7 +69,7 @@ function onReload() {
   right: 12px;
   bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
   z-index: 1050;
-  background: #0257fe;
+  background: #1e40af;
   color: white;
   border-radius: 12px;
   padding: 12px 40px 12px 14px;
@@ -111,7 +111,7 @@ function onReload() {
   padding: 8px 14px;
   border-radius: 8px;
   background: white;
-  color: #0257fe;
+  color: #1e40af;
   font-weight: 600;
   font-size: 13px;
   border: none;

--- a/frontend/src/components/VersionFooter.vue
+++ b/frontend/src/components/VersionFooter.vue
@@ -227,7 +227,7 @@ export default {
 }
 
 .version-button:hover {
-  color: #0257fe;
+  color: #1e40af;
 }
 
 .version-loading {

--- a/frontend/src/components/WhatsNewView.vue
+++ b/frontend/src/components/WhatsNewView.vue
@@ -121,7 +121,7 @@ onMounted(async () => {
   margin: 3px 0;
 }
 .changelog-body :deep(a) {
-  color: #0257fe;
+  color: #1e40af;
   text-decoration: underline;
 }
 .changelog-body :deep(code) {

--- a/frontend/src/components/notifications/FollowButton.vue
+++ b/frontend/src/components/notifications/FollowButton.vue
@@ -138,17 +138,17 @@ onMounted(() => {
 /* Light variant — sits on normal page background (SB-56 on MatchesView). */
 .follow-button--light {
   background: white;
-  color: #0257fe;
-  border: 1.5px solid #0257fe;
+  color: #1e40af;
+  border: 1.5px solid #1e40af;
 }
 
 .follow-button--light:hover:not(:disabled) {
-  background: rgba(2, 87, 254, 0.08);
+  background: rgba(30, 64, 175, 0.08);
   transform: translateY(-1px);
 }
 
 .follow-button--light:focus-visible {
-  outline: 2px solid #0257fe;
+  outline: 2px solid #1e40af;
   outline-offset: 2px;
 }
 

--- a/frontend/src/components/notifications/NotificationsCard.vue
+++ b/frontend/src/components/notifications/NotificationsCard.vue
@@ -428,7 +428,7 @@ onMounted(refresh);
 }
 
 .enable-button {
-  background: #0257fe;
+  background: #1e40af;
   color: white;
   border: none;
   border-radius: 8px;
@@ -441,7 +441,7 @@ onMounted(refresh);
 }
 
 .enable-button:hover:not(:disabled) {
-  background: #0047d4;
+  background: #1a3793;
 }
 
 .enable-button:disabled {
@@ -479,8 +479,8 @@ onMounted(refresh);
 
 .test-button {
   background: transparent;
-  color: #0257fe;
-  border: 1.5px solid #0257fe;
+  color: #1e40af;
+  border: 1.5px solid #1e40af;
   border-radius: 8px;
   padding: 10px 14px;
   font-size: 14px;
@@ -492,7 +492,7 @@ onMounted(refresh);
 }
 
 .test-button:hover:not(:disabled) {
-  background: rgba(2, 87, 254, 0.08);
+  background: rgba(30, 64, 175, 0.08);
 }
 
 .test-button:disabled {
@@ -561,7 +561,7 @@ onMounted(refresh);
   height: 20px;
   margin: 0;
   cursor: pointer;
-  accent-color: #0257fe;
+  accent-color: #1e40af;
   flex-shrink: 0;
 }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -13,17 +13,30 @@ export default {
         ],
       },
       colors: {
+        // Midnight Amber palette (SB-144): deep-navy brand chrome + warm amber accent.
         brand: {
-          50: '#e8f0ff',
-          100: '#c0d4ff',
-          200: '#99b8ff',
-          300: '#6694ff',
-          400: '#3370ff',
-          500: '#0257fe', // logo blue
-          600: '#0047d4',
-          700: '#0038aa',
-          800: '#002b82',
-          900: '#001e5a',
+          50: '#eef3fb',
+          100: '#d4e0f5',
+          200: '#aac3ea',
+          300: '#779edb',
+          400: '#4a72c9',
+          500: '#1e40af', // primary navy
+          600: '#1a3793', // header / hover
+          700: '#152c75',
+          800: '#112357',
+          900: '#0c1838',
+        },
+        accent: {
+          50: '#fef6e7',
+          100: '#fde8bf',
+          200: '#fbd187',
+          300: '#f9b84e',
+          400: '#f59e0b', // accent amber
+          500: '#d97f06',
+          600: '#b45309', // text-safe amber on light surfaces
+          700: '#8f3f0a',
+          800: '#6b2f0a',
+          900: '#45200a',
         },
       },
     },


### PR DESCRIPTION
## Summary

First step of the Midnight Amber theming sub-epic ([SB-144](https://linear.app/silverbeer/issue/SB-144)). Swaps the bright-blue brand for deep-navy chrome + a warm amber accent.

- `tailwind.config.js`: `brand` redefined as a navy scale (`500 #1e40af`, `600 #1a3793` for headers/hover); new `accent` amber scale (`400 #f59e0b`, text-safe `600 #b45309`)
- Swept hardcoded legacy-brand hexes (`#0257fe`, `#0047d4`, `rgba(2,87,254,…)`) across 9 components → new navy, so the recolor is global rather than half-applied. SB-146 replaces these literals with semantic CSS-variable tokens.

Light mode only — dark mode is the next child (SB-146).

## Testing

- `npm run lint` clean, `npm run test:run` 539/539 pass
- Verified header + Login button recolored to navy (`rgb(30,64,175)`) via computed styles in local preview

## Follow-up

App logo wordmark is still bright blue (`#0257fe`, image asset) — navy chrome may warrant a logo refresh. Flagged, not in scope here.

Part of UX Overhaul epic SB-130 → theming sub-epic SB-144. Fixes SB-145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)