### PR TITLE
feat(theme): semantic color tokens + dark mode infrastructure (SB-146)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,8 +6,21 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚽</text></svg>">
     <title>Missing Table</title>
 
+    <!-- Apply theme before first paint to avoid a flash of the wrong mode (SB-146). -->
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('mt-theme');
+          var dark = t
+            ? t === 'dark'
+            : window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (dark) document.documentElement.classList.add('dark');
+        } catch (e) {}
+      })();
+    </script>
+
     <!-- PWA — manifest link auto-injected by vite-plugin-pwa from vite.config.js -->
-    <meta name="theme-color" content="#0257fe">
+    <meta name="theme-color" content="#1e40af">
     <link rel="apple-touch-icon" href="/pwa/apple-touch-icon-180.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-slate-50">
+  <div class="min-h-screen bg-surface">
     <!-- Deep-link match detail (from a push notification: ?matchId=). Overlays
          everything; works for any match status. -->
     <div

--- a/frontend/src/__tests__/composables/useTheme.spec.js
+++ b/frontend/src/__tests__/composables/useTheme.spec.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function mockMatchMedia(prefersDark) {
+  window.matchMedia = vi.fn().mockImplementation(query => ({
+    matches: prefersDark,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    // Composable holds module-level singleton state — reset between cases.
+    vi.resetModules();
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('defaults to OS dark when no stored preference', async () => {
+    mockMatchMedia(true);
+    const { useTheme } = await import('@/composables/useTheme');
+    const { isDark } = useTheme();
+    expect(isDark.value).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('defaults to OS light when no stored preference', async () => {
+    mockMatchMedia(false);
+    const { useTheme } = await import('@/composables/useTheme');
+    const { isDark } = useTheme();
+    expect(isDark.value).toBe(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('stored preference overrides OS setting', async () => {
+    localStorage.setItem('mt-theme', 'dark');
+    mockMatchMedia(false);
+    const { useTheme } = await import('@/composables/useTheme');
+    const { isDark } = useTheme();
+    expect(isDark.value).toBe(true);
+  });
+
+  it('toggle flips theme, persists, and updates the html class', async () => {
+    mockMatchMedia(false);
+    const { useTheme } = await import('@/composables/useTheme');
+    const { isDark, toggle } = useTheme();
+
+    expect(isDark.value).toBe(false);
+    toggle();
+    expect(isDark.value).toBe(true);
+    expect(localStorage.getItem('mt-theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    toggle();
+    expect(isDark.value).toBe(false);
+    expect(localStorage.getItem('mt-theme')).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('setTheme sets an explicit theme and persists it', async () => {
+    mockMatchMedia(true);
+    const { useTheme } = await import('@/composables/useTheme');
+    const { isDark, setTheme } = useTheme();
+    setTheme('light');
+    expect(isDark.value).toBe(false);
+    expect(localStorage.getItem('mt-theme')).toBe('light');
+  });
+});

--- a/frontend/src/components/AuthNav.vue
+++ b/frontend/src/components/AuthNav.vue
@@ -13,6 +13,46 @@
       <div class="nav-links">
         <!-- No navigation links here - they're handled by tabs in App.vue -->
 
+        <!-- Theme toggle (available to everyone, incl. logged-out) -->
+        <button
+          class="theme-toggle"
+          type="button"
+          data-testid="theme-toggle"
+          :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+          :aria-pressed="isDark"
+          @click="toggleTheme"
+        >
+          <svg
+            v-if="isDark"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="theme-toggle-icon"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path
+              d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+            />
+          </svg>
+          <svg
+            v-else
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="theme-toggle-icon"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        </button>
+
         <!-- Authenticated user menu -->
         <div
           v-if="authStore.isAuthenticated.value"
@@ -79,12 +119,14 @@
 <script>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useAuthStore } from '@/stores/auth';
+import { useTheme } from '@/composables/useTheme';
 
 export default {
   name: 'AuthNav',
   emits: ['show-login', 'logout'],
   setup(props, { emit }) {
     const authStore = useAuthStore();
+    const { isDark, toggle: toggleTheme } = useTheme();
     const showDropdown = ref(false);
 
     const roleClass = computed(() => {
@@ -180,6 +222,8 @@ export default {
 
     return {
       authStore,
+      isDark,
+      toggleTheme,
       showDropdown,
       roleClass,
       formatRole,
@@ -194,10 +238,37 @@ export default {
 
 <style scoped>
 .auth-nav {
-  background-color: #ffffff;
+  background-color: rgb(var(--color-card));
+  border-bottom: 1px solid rgb(var(--color-line));
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   position: relative;
   z-index: 1000;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgb(var(--color-line));
+  border-radius: 8px;
+  background: none;
+  color: rgb(var(--color-fg-muted));
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
+}
+
+.theme-toggle:hover {
+  background-color: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg));
+}
+
+.theme-toggle-icon {
+  width: 20px;
+  height: 20px;
 }
 
 .nav-content {
@@ -272,15 +343,15 @@ export default {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background-color: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background-color: rgb(var(--color-surface-alt));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .user-dropdown:hover {
-  background-color: #f1f5f9;
+  background-color: rgb(var(--color-line));
 }
 
 .user-info {
@@ -291,7 +362,7 @@ export default {
 
 .user-name {
   font-weight: 600;
-  color: #1e293b;
+  color: rgb(var(--color-fg));
   font-size: 0.9rem;
 }
 

--- a/frontend/src/composables/useTheme.js
+++ b/frontend/src/composables/useTheme.js
@@ -1,0 +1,55 @@
+import { ref } from 'vue';
+
+// Shared singleton (matches the auth-store pattern): one source of truth for
+// the active theme across every component that calls useTheme().
+const STORAGE_KEY = 'mt-theme';
+const THEME_COLOR = { light: '#1e40af', dark: '#0a0e1a' };
+
+const isDark = ref(false);
+let initialized = false;
+
+function systemPrefersDark() {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+}
+
+function apply(dark) {
+  isDark.value = dark;
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle('dark', dark);
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta)
+    meta.setAttribute('content', dark ? THEME_COLOR.dark : THEME_COLOR.light);
+}
+
+function init() {
+  if (initialized || typeof window === 'undefined') return;
+  initialized = true;
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+  apply(stored ? stored === 'dark' : systemPrefersDark());
+
+  // Follow OS changes only while the user hasn't set an explicit preference.
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', e => {
+      if (!localStorage.getItem(STORAGE_KEY)) apply(e.matches);
+    });
+}
+
+export function useTheme() {
+  init();
+
+  function setTheme(theme) {
+    localStorage.setItem(STORAGE_KEY, theme);
+    apply(theme === 'dark');
+  }
+
+  function toggle() {
+    setTheme(isDark.value ? 'light' : 'dark');
+  }
+
+  return { isDark, toggle, setTheme };
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2,6 +2,32 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Semantic color tokens (SB-146). Stored as space-separated RGB channels so
+   Tailwind's `rgb(var(--x) / <alpha-value>)` opacity modifiers work. Light
+   values on :root, dark values under .dark (toggled on <html> by useTheme). */
+@layer base {
+  :root {
+    --color-surface: 248 250 252;
+    --color-surface-alt: 241 245 249;
+    --color-card: 255 255 255;
+    --color-fg: 15 23 42;
+    --color-fg-muted: 100 116 139;
+    --color-line: 226 232 240;
+  }
+  .dark {
+    --color-surface: 10 14 26;
+    --color-surface-alt: 14 20 36;
+    --color-card: 19 26 46;
+    --color-fg: 232 238 247;
+    --color-fg-muted: 148 163 184;
+    --color-line: 35 48 71;
+  }
+  body {
+    background-color: rgb(var(--color-surface));
+    color: rgb(var(--color-fg));
+  }
+}
+
 /* PWA / standalone-mode safe areas — kicks in when the app is launched
    from a home-screen icon on iOS (or other devices that expose env() insets).
    Keeps the body content clear of the notch and the iOS home indicator.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {
       fontFamily: {
@@ -38,6 +39,17 @@ export default {
           800: '#6b2f0a',
           900: '#45200a',
         },
+        // Semantic tokens (SB-146) — flip with .dark via CSS vars in style.css.
+        surface: {
+          DEFAULT: 'rgb(var(--color-surface) / <alpha-value>)',
+          alt: 'rgb(var(--color-surface-alt) / <alpha-value>)',
+        },
+        card: 'rgb(var(--color-card) / <alpha-value>)',
+        fg: {
+          DEFAULT: 'rgb(var(--color-fg) / <alpha-value>)',
+          muted: 'rgb(var(--color-fg-muted) / <alpha-value>)',
+        },
+        line: 'rgb(var(--color-line) / <alpha-value>)',
       },
     },
   },


### PR DESCRIPTION
## Summary

The dark-mode engine for the Midnight Amber sub-epic ([SB-144](https://linear.app/silverbeer/issue/SB-144)). Tokenizes color into semantic CSS variables so dark mode is a value-swap, not a per-utility `dark:` sprinkle.

- `style.css`: semantic tokens (`surface`, `surface-alt`, `card`, `fg`, `fg-muted`, `line`) — light on `:root`, dark under `.dark`, stored as RGB channels for alpha support
- `tailwind.config.js`: `darkMode:'class'` + token-backed utilities (`bg-surface`, `bg-card`, `text-fg`, `text-fg-muted`, `border-line`)
- `useTheme` composable: shared singleton, `toggle`/`setTheme`, localStorage persist, OS default, follows OS only while no explicit preference
- `index.html`: pre-paint script sets `.dark` before first paint (no FOUC); `theme-color` meta navy → dark surface
- `AuthNav`: sun/moon toggle (visible to logged-out users too); nav bg/border/user chrome → tokens
- `App.vue` root `bg-slate-50` → `bg-surface`

## Rollout boundary

Shell (body, page bg, nav) flips cleanly in both modes. **Authed views and the landing sample-table card are intentionally NOT themed yet** — that's the per-view rollout, starting with the Table view (SB-147). Components still using `bg-white`/`text-gray-*` keep their light look on the dark shell until migrated.

## Testing

- New `useTheme.spec.js`: 5 tests (OS default light/dark, stored override, toggle persist + html class, setTheme). `npm run test:run` 544/544 pass, lint clean
- Verified toggle + persistence + shell flip via local preview at 1280px and 380px, both modes (computed `body` bg `rgb(10,14,26)` in dark)

## Follow-up

Logo wordmark is a light image asset — shows a white box on the dark nav. Reinforces the tracked logo-refresh follow-up.

Part of UX Overhaul SB-130 → theming sub-epic SB-144. Fixes SB-146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)