### PR TITLE
fix(theme): frame logo on a white chip in dark mode (SB-148)

### DIFF
--- a/frontend/src/components/AuthNav.vue
+++ b/frontend/src/components/AuthNav.vue
@@ -1,7 +1,7 @@
 <template>
   <nav class="auth-nav" data-testid="main-nav">
     <div class="nav-content container mx-auto px-4">
-      <div class="nav-brand">
+      <div class="nav-brand" :class="{ 'nav-brand--chip': isDark }">
         <img
           src="@/assets/logo.png"
           alt="Missing Table"
@@ -282,6 +282,15 @@ export default {
 .nav-brand {
   display: flex;
   align-items: center;
+}
+
+/* Interim dark-mode logo treatment (SB-148): the logo art has a white
+   background baked in, so on the dark nav we frame it as an intentional
+   white chip instead of a stray box. Removed once a proper asset lands. */
+.nav-brand--chip {
+  background-color: #ffffff;
+  padding: 4px 10px;
+  border-radius: 10px;
 }
 
 .nav-logo {


### PR DESCRIPTION
## Summary

The logo art ([logo.png](frontend/src/assets/logo.png)) has a white background baked into its pixels, so on the dark nav (shipped in SB-146/147) it showed as a stray white box.

Interim, code-only fix: in **dark mode only**, the logo wrapper gets a white rounded chip (`nav-brand--chip`, driven by `useTheme`'s `isDark`) so it reads as a deliberate badge. Light mode unchanged.

## Verification

Verified in local preview (dark) — logo now sits on a clean rounded white chip, top-left.

## Follow-up (tracked in SB-148)

Proper fix needs a designed asset: transparent-background / navy-recolored logo, ideally a theme-swapped dark variant. Not doable in code alone.

Part of theming sub-epic SB-144. Fixes SB-148 (interim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)