### PR TITLE
feat(theme): dark mode for all remaining authed views (SB-151)

### DIFF
--- a/frontend/src/components/AdminPanel.vue
+++ b/frontend/src/components/AdminPanel.vue
@@ -8,8 +8,8 @@
     >
       <div class="max-w-md mx-auto">
         <div class="text-red-600 text-6xl mb-4">🚫</div>
-        <h2 class="text-2xl font-bold text-gray-900 mb-2">Access Denied</h2>
-        <p class="text-gray-600">
+        <h2 class="text-2xl font-bold text-fg mb-2">Access Denied</h2>
+        <p class="text-fg-muted">
           You need administrator privileges to access this page.
         </p>
       </div>
@@ -19,7 +19,7 @@
     <div v-else>
       <!-- Admin Description -->
       <div class="mb-6">
-        <p class="text-gray-600">Manage league data and configurations</p>
+        <p class="text-fg-muted">Manage league data and configurations</p>
       </div>
 
       <!-- Admin Navigation -->
@@ -30,7 +30,7 @@
           id="admin-section-select"
           v-model="currentSection"
           data-testid="admin-section-select"
-          class="sm:hidden block w-full px-3 py-2.5 text-base font-medium bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+          class="sm:hidden block w-full px-3 py-2.5 text-base font-medium bg-card border border-line rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
         >
           <optgroup
             v-for="category in adminCategories"
@@ -50,7 +50,7 @@
         <!-- Desktop: two-level tab bar (categories + sub-tabs) -->
         <div class="hidden sm:block space-y-2" aria-label="Admin sections">
           <nav
-            class="flex flex-wrap gap-1 bg-gray-100 p-1 rounded-lg"
+            class="flex flex-wrap gap-1 bg-surface-alt p-1 rounded-lg"
             aria-label="Admin categories"
           >
             <button
@@ -60,8 +60,8 @@
               :data-testid="`admin-category-${category.id}`"
               :class="[
                 currentCategory === category.id
-                  ? 'bg-white text-gray-900 shadow'
-                  : 'text-gray-600 hover:text-gray-900',
+                  ? 'bg-card text-fg shadow'
+                  : 'text-fg-muted hover:text-fg',
                 'px-4 py-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap',
               ]"
             >
@@ -80,8 +80,8 @@
               :data-testid="`admin-tab-${section.id}`"
               :class="[
                 currentSection === section.id
-                  ? 'text-brand-700 border-brand-500'
-                  : 'text-gray-500 hover:text-gray-800 border-transparent hover:border-gray-300',
+                  ? 'text-brand-700 border-brand-500 dark:text-brand-300 dark:border-brand-300'
+                  : 'text-fg-muted hover:text-fg border-transparent hover:border-line',
                 'px-3 py-1.5 text-sm font-medium border-b-2 transition-colors whitespace-nowrap',
               ]"
             >
@@ -93,7 +93,7 @@
 
       <!-- Section Content -->
       <div
-        class="bg-white rounded-lg shadow-sm border border-gray-200"
+        class="bg-card rounded-lg shadow-sm border border-line"
         data-testid="admin-content"
       >
         <!-- Invite Requests Management -->

--- a/frontend/src/components/ConfirmModal.vue
+++ b/frontend/src/components/ConfirmModal.vue
@@ -59,8 +59,8 @@
             </svg>
           </div>
           <div>
-            <h3 class="text-lg font-medium text-gray-900">{{ title }}</h3>
-            <p v-if="message" class="mt-1 text-sm text-gray-500">
+            <h3 class="text-lg font-medium text-fg">{{ title }}</h3>
+            <p v-if="message" class="mt-1 text-sm text-fg-muted">
               {{ message }}
             </p>
           </div>
@@ -76,7 +76,7 @@
           <button
             type="button"
             @click="$emit('cancel')"
-            class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+            class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
           >
             {{ cancelText }}
           </button>
@@ -170,7 +170,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 0.5rem;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
   max-width: 480px;

--- a/frontend/src/components/GoalsLeaderboard.vue
+++ b/frontend/src/components/GoalsLeaderboard.vue
@@ -34,7 +34,7 @@
     <div class="mb-6 space-y-4">
       <!-- Age Group Links -->
       <div data-testid="age-group-filter">
-        <h3 class="text-sm font-medium text-gray-700 mb-3">Age Groups</h3>
+        <h3 class="text-sm font-medium text-fg mb-3">Age Groups</h3>
         <div class="flex flex-wrap gap-2">
           <button
             v-for="ageGroup in ageGroups"
@@ -44,7 +44,7 @@
               'px-4 py-2 text-sm rounded-md font-medium transition-colors',
               selectedAgeGroupId === ageGroup.id
                 ? 'bg-brand-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                : 'bg-surface-alt text-fg hover:bg-line',
             ]"
             :data-testid="`age-group-${ageGroup.name}`"
           >
@@ -55,7 +55,7 @@
 
       <!-- League Selector -->
       <div>
-        <h3 class="text-sm font-medium text-gray-700 mb-3">League</h3>
+        <h3 class="text-sm font-medium text-fg mb-3">League</h3>
         <div class="flex flex-wrap gap-2">
           <button
             v-for="league in leagues"
@@ -65,7 +65,7 @@
               'px-4 py-2 text-sm rounded-md font-medium transition-colors',
               selectedLeagueId === league.id
                 ? 'bg-green-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                : 'bg-surface-alt text-fg hover:bg-line',
             ]"
           >
             {{ league.name }}
@@ -75,7 +75,7 @@
 
       <!-- Match Type Filter -->
       <div data-testid="match-type-filter">
-        <h3 class="text-sm font-medium text-gray-700 mb-3">Match Type</h3>
+        <h3 class="text-sm font-medium text-fg mb-3">Match Type</h3>
         <div class="flex flex-wrap gap-2">
           <button
             @click="selectedMatchTypeId = null"
@@ -83,7 +83,7 @@
               'px-4 py-2 text-sm rounded-md font-medium transition-colors',
               selectedMatchTypeId === null
                 ? 'bg-purple-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                : 'bg-surface-alt text-fg hover:bg-line',
             ]"
             data-testid="match-type-all"
           >
@@ -97,7 +97,7 @@
               'px-4 py-2 text-sm rounded-md font-medium transition-colors',
               selectedMatchTypeId === mt.id
                 ? 'bg-purple-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                : 'bg-surface-alt text-fg hover:bg-line',
             ]"
             :data-testid="`match-type-${mt.name}`"
           >
@@ -108,10 +108,10 @@
 
       <!-- Tournament Selector (only when Match Type = Tournament) -->
       <div v-if="isTournamentSelected" data-testid="tournament-filter">
-        <h3 class="text-sm font-medium text-gray-700 mb-3">Tournament</h3>
+        <h3 class="text-sm font-medium text-fg mb-3">Tournament</h3>
         <select
           v-model="selectedTournamentId"
-          class="block w-full sm:max-w-md px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+          class="block w-full sm:max-w-md px-3 py-2 bg-card text-fg border border-line rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
           data-testid="tournament-select"
         >
           <option :value="null">All Tournaments</option>
@@ -125,7 +125,7 @@
         </select>
         <p
           v-if="filteredTournaments.length === 0"
-          class="mt-2 text-xs text-gray-500"
+          class="mt-2 text-xs text-fg-muted"
         >
           No tournaments for the selected age group.
         </p>
@@ -137,10 +137,10 @@
       >
         <!-- Season Dropdown -->
         <div class="flex-1">
-          <h3 class="text-sm font-medium text-gray-700 mb-3">Season</h3>
+          <h3 class="text-sm font-medium text-fg mb-3">Season</h3>
           <select
             v-model="selectedSeasonId"
-            class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+            class="block w-full px-3 py-2 bg-card text-fg border border-line rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
             data-testid="season-filter"
           >
             <option
@@ -155,10 +155,10 @@
 
         <!-- Division Dropdown -->
         <div class="flex-1">
-          <h3 class="text-sm font-medium text-gray-700 mb-3">Division</h3>
+          <h3 class="text-sm font-medium text-fg mb-3">Division</h3>
           <select
             v-model="selectedDivisionId"
-            class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+            class="block w-full px-3 py-2 bg-card text-fg border border-line rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
             data-testid="division-filter"
           >
             <option :value="null">All Divisions</option>
@@ -196,7 +196,7 @@
       <!-- Empty State -->
       <div
         v-else-if="leaderboardData.length === 0"
-        class="text-center py-8 text-gray-500"
+        class="text-center py-8 text-fg-muted"
       >
         No goal scorers found for the selected filters.
       </div>
@@ -204,55 +204,55 @@
       <!-- Leaderboard Table -->
       <table
         v-else
-        class="min-w-full divide-y divide-gray-200"
+        class="min-w-full divide-y divide-line"
         data-testid="leaderboard-table"
       >
-        <thead class="bg-gray-50">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Rank
             </th>
             <th
-              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Player
             </th>
             <th
-              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider max-w-[100px] sm:max-w-[140px] md:max-w-none"
+              class="px-2 sm:px-4 md:px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider max-w-[100px] sm:max-w-[140px] md:max-w-none"
             >
               Team
             </th>
             <th
-              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Goals
             </th>
             <th
-              class="hidden sm:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="hidden sm:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Games
             </th>
             <th
-              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 text-center text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Goals/Game
             </th>
           </tr>
         </thead>
         <tbody
-          class="bg-white divide-y divide-gray-200"
+          class="bg-card divide-y divide-line"
           data-testid="leaderboard-body"
         >
           <tr
             v-for="player in leaderboardData"
             :key="player.player_id"
             data-testid="leaderboard-row"
-            class="hover:bg-gray-50"
+            class="hover:bg-surface-alt"
           >
             <td
-              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-gray-500"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-fg-muted"
             >
               <span
                 :class="[
@@ -263,14 +263,14 @@
                       ? 'bg-gray-200 text-gray-700'
                       : player.rank === 3
                         ? 'bg-orange-100 text-orange-800'
-                        : 'bg-transparent text-gray-500',
+                        : 'bg-transparent text-fg-muted',
                 ]"
               >
                 {{ player.rank }}
               </span>
             </td>
             <td
-              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm font-medium text-gray-900"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm font-medium text-fg"
             >
               <div class="flex items-center">
                 <span class="font-semibold text-base"
@@ -282,22 +282,22 @@
               </div>
             </td>
             <td
-              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 text-xs sm:text-sm text-gray-500 max-w-[100px] sm:max-w-[140px] md:max-w-none truncate"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 text-xs sm:text-sm text-fg-muted max-w-[100px] sm:max-w-[140px] md:max-w-none truncate"
             >
               {{ player.team_name || 'Unknown' }}
             </td>
             <td
-              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center font-semibold text-gray-900"
+              class="px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center font-semibold text-fg"
             >
               {{ player.goals }}
             </td>
             <td
-              class="hidden sm:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="hidden sm:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-fg-muted"
             >
               {{ player.games_played }}
             </td>
             <td
-              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-gray-500"
+              class="hidden md:table-cell px-2 sm:px-4 md:px-6 py-3 md:py-4 whitespace-nowrap text-sm text-center text-fg-muted"
             >
               {{ player.goals_per_game }}
             </td>

--- a/frontend/src/components/MatchDetailView.vue
+++ b/frontend/src/components/MatchDetailView.vue
@@ -4,7 +4,7 @@
     <button
       @click="$emit('back')"
       data-testid="back-button"
-      class="flex items-center gap-1.5 px-2 py-1 text-gray-600 hover:text-gray-900 font-medium text-xs mb-2 rounded hover:bg-gray-100 transition-colors"
+      class="flex items-center gap-1.5 px-2 py-1 text-fg-muted hover:text-fg font-medium text-xs mb-2 rounded hover:bg-surface-alt transition-colors"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -30,9 +30,9 @@
       data-testid="loading-state"
     >
       <div
-        class="w-8 h-8 border-3 border-gray-300 border-t-blue-500 rounded-full animate-spin mb-3"
+        class="w-8 h-8 border-3 border-line border-t-blue-500 rounded-full animate-spin mb-3"
       ></div>
-      <p class="text-gray-500 text-sm">Loading match details...</p>
+      <p class="text-fg-muted text-sm">Loading match details...</p>
     </div>
 
     <!-- Error state -->
@@ -46,7 +46,7 @@
       >
         !
       </div>
-      <p class="text-gray-500 mb-3 text-sm" data-testid="error-message">
+      <p class="text-fg-muted mb-3 text-sm" data-testid="error-message">
         {{ error }}
       </p>
       <button

--- a/frontend/src/components/MatchEditModal.vue
+++ b/frontend/src/components/MatchEditModal.vue
@@ -7,22 +7,22 @@
   >
     <div class="modal-content" @click.stop>
       <div class="p-6">
-        <h3 class="text-lg font-medium text-gray-900 mb-4">Edit Match</h3>
+        <h3 class="text-lg font-medium text-fg mb-4">Edit Match</h3>
 
         <!-- Audit Trail Info -->
         <div
           v-if="
             match && (match.match_id || match.created_at || match.updated_at)
           "
-          class="mb-4 p-3 bg-gray-50 border border-gray-200 rounded-md text-xs text-gray-600 space-y-1"
+          class="mb-4 p-3 bg-surface-alt border border-line rounded-md text-xs text-fg-muted space-y-1"
         >
           <div v-if="isAdmin && match.id" class="flex items-center space-x-2">
             <span class="font-medium">Match ID:</span>
-            <span class="font-mono text-gray-800">{{ match.id }}</span>
+            <span class="font-mono text-fg">{{ match.id }}</span>
           </div>
           <div v-if="match.match_id" class="flex items-center space-x-2">
             <span class="font-medium">External Match ID:</span>
-            <span class="font-mono text-gray-800">{{ match.match_id }}</span>
+            <span class="font-mono text-fg">{{ match.match_id }}</span>
           </div>
           <div v-if="match.source" class="flex items-center space-x-2">
             <span class="font-medium">Source:</span>
@@ -51,38 +51,36 @@
         <form @submit.prevent="updateMatch()">
           <div class="grid grid-cols-3 gap-4 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
-                >Date</label
-              >
+              <label class="block text-sm font-medium text-fg mb-2">Date</label>
               <input
                 v-model="formData.match_date"
                 type="date"
                 required
                 data-testid="date-input"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Kickoff Time
-                <span class="text-gray-400 text-xs">(optional)</span></label
+                <span class="text-fg-muted text-xs">(optional)</span></label
               >
               <input
                 v-model="formData.kickoff_time"
                 type="time"
                 data-testid="kickoff-time-input"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Match Type</label
               >
               <select
                 v-model="formData.match_type_id"
                 required
                 data-testid="match-type-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option
                   v-for="matchType in matchTypes"
@@ -97,14 +95,14 @@
 
           <div class="grid grid-cols-2 gap-4 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Home Team</label
               >
               <select
                 v-model="formData.home_team_id"
                 required
                 data-testid="home-team-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option
                   v-for="team in availableTeams"
@@ -116,14 +114,14 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Away Team</label
               >
               <select
                 v-model="formData.away_team_id"
                 required
                 data-testid="away-team-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option
                   v-for="team in availableTeams"
@@ -138,26 +136,26 @@
 
           <div class="grid grid-cols-2 gap-4 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Home Score</label
               >
               <input
                 v-model.number="formData.home_score"
                 type="number"
                 min="0"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Leave empty if not played"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Away Score</label
               >
               <input
                 v-model.number="formData.away_score"
                 type="number"
                 min="0"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Leave empty if not played"
               />
             </div>
@@ -165,13 +163,13 @@
 
           <div class="grid grid-cols-2 gap-4 mb-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Season</label
               >
               <select
                 v-model="formData.season_id"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option
                   v-for="season in seasons"
@@ -183,13 +181,13 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Age Group</label
               >
               <select
                 v-model="formData.age_group_id"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option
                   v-for="ageGroup in ageGroups"
@@ -203,14 +201,14 @@
           </div>
 
           <div class="mb-4">
-            <label class="block text-sm font-medium text-gray-700 mb-2"
+            <label class="block text-sm font-medium text-fg mb-2"
               >Match Status</label
             >
             <select
               v-model="formData.match_status"
               required
               data-testid="status-select"
-              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+              class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option value="scheduled">Scheduled</option>
               <option value="live">Live</option>
@@ -218,7 +216,7 @@
               <option value="postponed">Postponed</option>
               <option value="cancelled">Cancelled</option>
             </select>
-            <p class="mt-1 text-xs text-gray-500">
+            <p class="mt-1 text-xs text-fg-muted">
               Set to "Live" when the match is in progress
             </p>
           </div>
@@ -237,7 +235,7 @@
               type="button"
               @click="$emit('close')"
               data-testid="cancel-button"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+              class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
             >
               Cancel
             </button>
@@ -505,7 +503,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 0.5rem;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
   max-width: 600px;

--- a/frontend/src/components/MatchForm.vue
+++ b/frontend/src/components/MatchForm.vue
@@ -1,10 +1,8 @@
 <template>
-  <div class="bg-white rounded-lg shadow p-4" data-testid="match-form">
+  <div class="bg-card rounded-lg shadow p-4" data-testid="match-form">
     <!-- Form Type Selection -->
     <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-2"
-        >Action Type</label
-      >
+      <label class="block text-sm font-medium text-fg mb-2">Action Type</label>
       <div class="flex space-x-4">
         <label class="inline-flex items-center">
           <input
@@ -31,14 +29,12 @@
 
     <form @submit.prevent="submitMatch" class="space-y-3">
       <!-- Season/Age Group/Match Type Row -->
-      <div class="grid grid-cols-3 gap-3 p-3 bg-gray-50 rounded-md">
+      <div class="grid grid-cols-3 gap-3 p-3 bg-surface-alt rounded-md">
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
-            >Season</label
-          >
+          <label class="block text-xs font-medium text-fg mb-1">Season</label>
           <select
             v-model="selectedSeason"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="season-select"
           >
             <option
@@ -51,12 +47,12 @@
           </select>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Age Group</label
           >
           <select
             v-model="selectedAgeGroup"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="age-group-select"
           >
             <option
@@ -69,12 +65,12 @@
           </select>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Match Type</label
           >
           <select
             v-model="selectedMatchType"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="match-type-select"
           >
             <option
@@ -96,12 +92,12 @@
       >
         <div class="grid grid-cols-1 gap-3">
           <div>
-            <label class="block text-xs font-medium text-gray-700 mb-1"
+            <label class="block text-xs font-medium text-fg mb-1"
               >Division <span class="text-red-500">*</span></label
             >
             <select
               v-model="selectedDivision"
-              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+              class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
               required
               data-testid="division-select"
             >
@@ -114,7 +110,7 @@
                 {{ division.name }}
               </option>
             </select>
-            <p class="text-xs text-gray-600 mt-1">
+            <p class="text-xs text-fg-muted mt-1">
               Division is required for League matches to ensure proper standings
               calculation
             </p>
@@ -129,12 +125,12 @@
       >
         <div class="grid grid-cols-1 gap-3">
           <div>
-            <label class="block text-xs font-medium text-gray-700 mb-1"
+            <label class="block text-xs font-medium text-fg mb-1"
               >Game Status <span class="text-red-500">*</span></label
             >
             <select
               v-model="selectedStatus"
-              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+              class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
               required
               data-testid="status-select"
             >
@@ -143,7 +139,7 @@
               <option value="postponed">Postponed</option>
               <option value="cancelled">Cancelled</option>
             </select>
-            <p class="text-xs text-gray-600 mt-1">
+            <p class="text-xs text-fg-muted mt-1">
               Status determines whether the match counts toward standings. Only
               "Completed" matches affect team standings.
             </p>
@@ -154,42 +150,40 @@
       <!-- Date, Time, and Teams Row -->
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
-            >Date</label
-          >
+          <label class="block text-xs font-medium text-fg mb-1">Date</label>
           <input
             type="date"
             v-model="matchData.date"
             id="match_date"
             required
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="date-input"
           />
         </div>
 
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Kickoff Time
-            <span class="text-gray-400 text-[10px]">(optional)</span></label
+            <span class="text-fg-muted text-[10px]">(optional)</span></label
           >
           <input
             type="time"
             v-model="matchData.kickoffTime"
             id="kickoff_time"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="kickoff-time-input"
           />
         </div>
 
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Home Team</label
           >
           <select
             v-model="matchData.homeTeam"
             id="home_team"
             required
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="home-team-select"
           >
             <option value="">Select Team</option>
@@ -200,14 +194,14 @@
         </div>
 
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Away Team</label
           >
           <select
             v-model="matchData.awayTeam"
             id="away_team"
             required
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
+            class="block w-full rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-sm"
             data-testid="away-team-select"
           >
             <option value="">Select Team</option>
@@ -225,7 +219,7 @@
         data-testid="score-section"
       >
         <div class="text-center">
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Home Score</label
           >
           <input
@@ -234,15 +228,15 @@
             id="home_score"
             required
             min="0"
-            class="block w-20 rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-center text-lg font-bold"
+            class="block w-20 rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-center text-lg font-bold"
             data-testid="home-score-input"
           />
         </div>
 
-        <div class="text-xl font-bold text-gray-400">vs</div>
+        <div class="text-xl font-bold text-fg-muted">vs</div>
 
         <div class="text-center">
-          <label class="block text-xs font-medium text-gray-700 mb-1"
+          <label class="block text-xs font-medium text-fg mb-1"
             >Away Score</label
           >
           <input
@@ -251,7 +245,7 @@
             id="away_score"
             required
             min="0"
-            class="block w-20 rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 text-center text-lg font-bold"
+            class="block w-20 rounded-md border-line bg-card text-fg shadow-sm focus:border-brand-500 focus:ring-brand-500 text-center text-lg font-bold"
             data-testid="away-score-input"
           />
         </div>

--- a/frontend/src/components/PlayoffBracket.vue
+++ b/frontend/src/components/PlayoffBracket.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="playoff-bracket">
     <!-- Loading -->
-    <div v-if="loading" class="text-center py-8 text-gray-500">
+    <div v-if="loading" class="text-center py-8 text-fg-muted">
       Loading bracket...
     </div>
 
@@ -13,7 +13,7 @@
     <!-- No bracket -->
     <div
       v-else-if="bracket.length === 0"
-      class="text-center py-8 text-gray-400 text-sm"
+      class="text-center py-8 text-fg-muted text-sm"
     >
       No playoff bracket available.
     </div>
@@ -772,10 +772,10 @@ export default {
 .tier-header {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: rgb(var(--color-fg));
   margin-bottom: 0.75rem;
   padding-bottom: 0.25rem;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 /* Bracket layout — 5 columns: QF | connectors | SF | connectors | Final */
@@ -793,7 +793,7 @@ export default {
 .round-header {
   font-size: 0.75rem;
   font-weight: 600;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   text-transform: uppercase;
   letter-spacing: 0.05em;
   text-align: center;
@@ -802,10 +802,10 @@ export default {
 
 /* Matchup cards */
 .matchup-card {
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 0.5rem;
   overflow: hidden;
-  background: #fff;
+  background: rgb(var(--color-card));
   font-size: 0.8125rem;
 }
 
@@ -837,7 +837,7 @@ export default {
 }
 
 .team-row + .team-row {
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid rgb(var(--color-line));
 }
 
 .team-row.winner {
@@ -849,7 +849,7 @@ export default {
 .seed {
   width: 1rem;
   text-align: right;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   font-size: 0.6875rem;
   margin-right: 0.375rem;
   flex-shrink: 0;
@@ -924,7 +924,7 @@ export default {
   position: absolute;
   right: 0;
   width: 50%;
-  border-top: 2px solid #d1d5db;
+  border-top: 2px solid rgb(var(--color-line));
 }
 
 .connector-line.top {
@@ -940,14 +940,14 @@ export default {
   right: 0;
   top: 25%;
   height: 50%;
-  border-right: 2px solid #d1d5db;
+  border-right: 2px solid rgb(var(--color-line));
 }
 
 /* Match info and controls */
 .match-info {
   padding: 0.25rem 0.5rem;
-  background: #f9fafb;
-  border-top: 1px solid #f3f4f6;
+  background: rgb(var(--color-surface-alt));
+  border-top: 1px solid rgb(var(--color-line));
   font-size: 0.6875rem;
 }
 
@@ -958,7 +958,7 @@ export default {
 }
 
 .match-date {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .slot-controls {
@@ -971,15 +971,15 @@ export default {
 .advance-btn {
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
-  border: 1px solid #e5e7eb;
-  background: #fff;
+  border: 1px solid rgb(var(--color-line));
+  background: rgb(var(--color-card));
   cursor: pointer;
   font-size: 0.625rem;
   transition: background-color 0.15s;
 }
 
 .edit-btn:hover {
-  background: #f3f4f6;
+  background: rgb(var(--color-surface-alt));
 }
 
 .advance-btn {
@@ -1081,9 +1081,11 @@ export default {
 .date-input,
 .time-input {
   padding: 0.125rem 0.25rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 0.25rem;
   font-size: 0.625rem;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .date-input {

--- a/frontend/src/components/QoPStandings.vue
+++ b/frontend/src/components/QoPStandings.vue
@@ -2,10 +2,8 @@
   <div>
     <!-- Header -->
     <div class="mb-6">
-      <h2 class="text-lg font-semibold text-gray-800">
-        Quality of Play Rankings
-      </h2>
-      <p class="text-sm text-gray-500 mt-1">
+      <h2 class="text-lg font-semibold text-fg">Quality of Play Rankings</h2>
+      <p class="text-sm text-fg-muted mt-1">
         Homegrown · Updated weekly by MLS Next
       </p>
     </div>
@@ -14,7 +12,7 @@
     <div class="mb-6 space-y-3">
       <!-- Division -->
       <div>
-        <h3 class="text-sm font-medium text-gray-700 mb-2">Division</h3>
+        <h3 class="text-sm font-medium text-fg mb-2">Division</h3>
         <div class="flex flex-wrap gap-2">
           <button
             v-for="div in homegrownDivisions"
@@ -24,7 +22,7 @@
               'px-4 py-2 text-sm rounded-lg font-medium transition-colors',
               selectedDivisionId === div.id
                 ? 'bg-brand-500 text-white shadow-sm'
-                : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                : 'bg-surface-alt text-fg-muted hover:bg-line',
             ]"
           >
             {{ div.name }}
@@ -34,7 +32,7 @@
 
       <!-- Age Group -->
       <div>
-        <h3 class="text-sm font-medium text-gray-700 mb-2">Age Group</h3>
+        <h3 class="text-sm font-medium text-fg mb-2">Age Group</h3>
         <div class="flex flex-wrap gap-2">
           <button
             v-for="ag in qopAgeGroups"
@@ -44,7 +42,7 @@
               'px-4 py-2 text-sm rounded-lg font-medium transition-colors',
               selectedAgeGroupId === ag.id
                 ? 'bg-brand-500 text-white shadow-sm'
-                : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                : 'bg-surface-alt text-fg-muted hover:bg-line',
             ]"
           >
             {{ ag.name }}
@@ -54,7 +52,7 @@
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="text-center py-8 text-gray-500">
+    <div v-if="loading" class="text-center py-8 text-fg-muted">
       Loading QoP rankings...
     </div>
 
@@ -64,7 +62,7 @@
     </div>
 
     <!-- No data -->
-    <div v-else-if="!rankings.length" class="text-center py-8 text-gray-500">
+    <div v-else-if="!rankings.length" class="text-center py-8 text-fg-muted">
       No QoP rankings available yet for this age group.
     </div>
 
@@ -72,14 +70,14 @@
     <div v-else class="overflow-x-auto">
       <div
         v-if="weekOf"
-        class="flex items-center gap-2 text-xs text-gray-400 mb-2"
+        class="flex items-center gap-2 text-xs text-fg-muted mb-2"
       >
         <button
           v-if="prevSnapshotId != null"
           type="button"
           @click="goToSnapshot(prevSnapshotId)"
           :disabled="loading"
-          class="px-2 py-0.5 rounded hover:bg-slate-100 text-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="px-2 py-0.5 rounded hover:bg-surface-alt text-fg-muted disabled:opacity-50 disabled:cursor-not-allowed"
           :title="`Previous week${priorWeekOf ? ' (' + priorWeekOf + ')' : ''}`"
           aria-label="Previous snapshot"
         >
@@ -96,7 +94,7 @@
           type="button"
           @click="goToSnapshot(nextSnapshotId)"
           :disabled="loading"
-          class="px-2 py-0.5 rounded hover:bg-slate-100 text-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="px-2 py-0.5 rounded hover:bg-surface-alt text-fg-muted disabled:opacity-50 disabled:cursor-not-allowed"
           title="Next week"
           aria-label="Next snapshot"
         >
@@ -104,7 +102,7 @@
         </button>
       </div>
 
-      <table class="min-w-full divide-y divide-slate-200">
+      <table class="min-w-full divide-y divide-line">
         <thead class="bg-brand-500">
           <tr>
             <th
@@ -150,7 +148,7 @@
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white">
+        <tbody class="bg-card">
           <!-- Championship Qualification label before first row -->
           <tr v-if="rankings.length" class="border-0">
             <td colspan="7" class="px-0 py-0">
@@ -164,9 +162,9 @@
           </tr>
           <template v-for="entry in rankings" :key="entry.rank">
             <tr
-              class="hover:bg-slate-50 transition-colors border-b border-slate-100"
+              class="hover:bg-surface-alt transition-colors border-b border-line"
             >
-              <td class="px-3 py-3 text-sm text-gray-500">
+              <td class="px-3 py-3 text-sm text-fg-muted">
                 {{ entry.rank }}
               </td>
               <td class="px-3 py-3 text-xs text-center">
@@ -184,16 +182,16 @@
                 >
                   ▼{{ Math.abs(entry.rank_change) }}
                 </span>
-                <span v-else class="text-gray-400">—</span>
+                <span v-else class="text-fg-muted">—</span>
               </td>
-              <td class="px-4 py-3 text-sm font-medium text-gray-900">
+              <td class="px-4 py-3 text-sm font-medium text-fg">
                 {{ entry.team_name }}
               </td>
-              <td class="px-4 py-3 text-sm text-center text-gray-500">
+              <td class="px-4 py-3 text-sm text-center text-fg-muted">
                 {{ entry.matches_played ?? '—' }}
               </td>
               <td
-                class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
+                class="hidden sm:table-cell px-4 py-3 text-sm text-center text-fg-muted"
               >
                 {{ entry.att_score != null ? entry.att_score.toFixed(1) : '—' }}
                 <span
@@ -210,7 +208,7 @@
                 >
               </td>
               <td
-                class="hidden sm:table-cell px-4 py-3 text-sm text-center text-gray-500"
+                class="hidden sm:table-cell px-4 py-3 text-sm text-center text-fg-muted"
               >
                 {{ entry.def_score != null ? entry.def_score.toFixed(1) : '—' }}
                 <span
@@ -227,7 +225,7 @@
                 >
               </td>
               <td
-                class="px-4 py-3 text-sm text-center font-bold text-brand-600"
+                class="px-4 py-3 text-sm text-center font-bold text-brand-600 dark:text-brand-300"
               >
                 {{ entry.qop_score != null ? entry.qop_score.toFixed(1) : '—' }}
                 <span
@@ -251,7 +249,7 @@
                   class="flex items-center gap-2 border-t-2 border-brand-500 pt-1 pb-1 px-3"
                 >
                   <span
-                    class="text-xs font-semibold text-brand-600 uppercase tracking-wide whitespace-nowrap"
+                    class="text-xs font-semibold text-brand-600 dark:text-brand-300 uppercase tracking-wide whitespace-nowrap"
                     >Premier Qualification</span
                   >
                 </div>

--- a/frontend/src/components/TournamentBracket.vue
+++ b/frontend/src/components/TournamentBracket.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- No matches in this bracket -->
-    <div v-if="!hasAnyBracket" class="text-center py-10 text-gray-500">
+    <div v-if="!hasAnyBracket" class="text-center py-10 text-fg-muted">
       No matches in this bracket yet.
     </div>
 
@@ -325,7 +325,7 @@ const BracketCell = {
           'div',
           {
             class: [
-              'h-full rounded-md border border-dashed border-gray-200 bg-gray-50/50 flex items-center justify-center text-gray-300 text-xs',
+              'h-full rounded-md border border-dashed border-line bg-surface-alt/50 flex items-center justify-center text-fg-muted text-xs',
               p.isFinal ? 'px-3 py-2' : 'px-2 py-1.5',
             ],
           },
@@ -339,8 +339,8 @@ const BracketCell = {
           type: 'button',
           onClick: () => emit('click', p.match),
           class: [
-            'w-full text-left rounded-md border bg-white px-2 py-1.5 shadow-sm hover:border-brand-400 transition-colors',
-            live ? 'border-brand-400 animate-pulse' : 'border-gray-200',
+            'w-full text-left rounded-md border bg-card px-2 py-1.5 shadow-sm hover:border-brand-400 transition-colors',
+            live ? 'border-brand-400 animate-pulse' : 'border-line',
           ],
         },
         [
@@ -351,10 +351,10 @@ const BracketCell = {
               class: [
                 'flex items-center justify-between gap-2 text-xs',
                 homeWinner.value
-                  ? 'font-bold text-gray-900'
+                  ? 'font-bold text-fg'
                   : p.match.match_status === 'completed'
-                    ? 'text-gray-400'
-                    : 'text-gray-800',
+                    ? 'text-fg-muted'
+                    : 'text-fg',
               ],
             },
             [
@@ -377,10 +377,10 @@ const BracketCell = {
               class: [
                 'flex items-center justify-between gap-2 text-xs mt-0.5',
                 awayWinner.value
-                  ? 'font-bold text-gray-900'
+                  ? 'font-bold text-fg'
                   : p.match.match_status === 'completed'
-                    ? 'text-gray-400'
-                    : 'text-gray-800',
+                    ? 'text-fg-muted'
+                    : 'text-fg',
               ],
             },
             [
@@ -401,7 +401,7 @@ const BracketCell = {
             'div',
             {
               class:
-                'mt-1 flex items-center justify-between text-[10px] text-gray-400',
+                'mt-1 flex items-center justify-between text-[10px] text-fg-muted',
             },
             [
               h('span', null, formatMatchDate(p.match.match_date)),
@@ -501,7 +501,7 @@ function formatMatchDate(d) {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: rgb(107 114 128);
+  color: rgb(var(--color-fg-muted));
   text-align: center;
   padding-bottom: 0.5rem;
 }
@@ -660,7 +660,7 @@ function formatMatchDate(d) {
   top: 50%;
   width: 12px;
   height: 1px;
-  background: rgb(209 213 219);
+  background: rgb(var(--color-line));
 }
 .col-5.bracket-cell::after {
   display: none;
@@ -698,7 +698,7 @@ function formatMatchDate(d) {
   top: 50%;
   width: 1px;
   height: 100%;
-  background: rgb(209 213 219);
+  background: rgb(var(--color-line));
 }
 
 /* Mobile: keep the bracket usable; rely on the outer overflow-x scroll. */
@@ -738,7 +738,7 @@ function formatMatchDate(d) {
   top: 50%;
   width: 12px;
   height: 1px;
-  background: rgb(209 213 219);
+  background: rgb(var(--color-line));
 }
 /* Vertical bridge joining a sibling pair: 100% of the (top) cell's height
  * reaches from this cell's midpoint down to its sibling's midpoint. */
@@ -748,6 +748,6 @@ function formatMatchDate(d) {
   top: 50%;
   width: 1px;
   height: 100%;
-  background: rgb(209 213 219);
+  background: rgb(var(--color-line));
 }
 </style>

--- a/frontend/src/components/TournamentMatchCenter.vue
+++ b/frontend/src/components/TournamentMatchCenter.vue
@@ -7,13 +7,13 @@
   >
     <div class="min-h-full flex items-start justify-center p-3 sm:p-6">
       <div
-        class="relative w-full max-w-4xl bg-white rounded-lg shadow-2xl"
+        class="relative w-full max-w-4xl bg-card rounded-lg shadow-2xl"
         @click.stop
       >
         <button
           type="button"
           aria-label="Close match details"
-          class="absolute top-2 right-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+          class="absolute top-2 right-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-fg-muted hover:text-fg hover:bg-surface-alt transition-colors"
           @click="handleBackFromMatchDetail"
         >
           <svg
@@ -64,10 +64,10 @@
     <!-- No tournaments -->
     <div
       v-else-if="tournaments.length === 0"
-      class="text-center py-16 text-gray-500"
+      class="text-center py-16 text-fg-muted"
     >
       <div class="text-5xl mb-4">🏆</div>
-      <p class="text-lg font-medium text-gray-700">No active tournaments</p>
+      <p class="text-lg font-medium text-fg">No active tournaments</p>
       <p class="text-sm mt-1">Check back soon for upcoming events.</p>
     </div>
 
@@ -82,7 +82,7 @@
             'px-4 py-2 rounded-full text-sm font-medium transition-colors',
             selectedId === t.id
               ? 'bg-brand-600 text-white'
-              : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+              : 'bg-card border border-line text-fg hover:border-brand-400',
           ]"
         >
           {{ t.name }}
@@ -93,7 +93,7 @@
       <div v-if="selected">
         <!-- Header card -->
         <div
-          class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 sm:p-6 mb-6"
+          class="bg-card rounded-xl shadow-sm border border-line p-4 sm:p-6 mb-6"
         >
           <div
             class="flex flex-wrap items-start justify-between gap-3 sm:gap-4"
@@ -103,15 +103,15 @@
                 v-if="selected.logo_url"
                 :src="selected.logo_url"
                 :alt="`${selected.name} logo`"
-                class="w-14 h-14 sm:w-24 sm:h-24 md:w-32 md:h-32 rounded-md object-contain bg-white border border-gray-100 shrink-0"
+                class="w-14 h-14 sm:w-24 sm:h-24 md:w-32 md:h-32 rounded-md object-contain bg-card border border-line shrink-0"
                 data-testid="tournament-logo"
               />
               <div class="min-w-0 flex-1">
-                <h2 class="text-xl sm:text-2xl font-bold text-gray-900">
+                <h2 class="text-xl sm:text-2xl font-bold text-fg">
                   {{ selected.name }}
                 </h2>
                 <div
-                  class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500"
+                  class="flex flex-wrap items-center gap-3 mt-2 text-sm text-fg-muted"
                 >
                   <span v-if="selected.start_date">
                     📅 {{ formatDate(selected.start_date) }}
@@ -132,7 +132,7 @@
                 </div>
                 <p
                   v-if="selected.description"
-                  class="mt-3 text-sm text-gray-600"
+                  class="mt-3 text-sm text-fg-muted"
                 >
                   {{ selected.description }}
                 </p>
@@ -142,9 +142,9 @@
               class="flex flex-row sm:flex-col items-center sm:items-end justify-between gap-3 w-full sm:w-auto"
             >
               <div
-                class="flex items-baseline gap-1.5 sm:block sm:text-right text-sm text-gray-500"
+                class="flex items-baseline gap-1.5 sm:block sm:text-right text-sm text-fg-muted"
               >
-                <div class="text-xl sm:text-2xl font-bold text-gray-800">
+                <div class="text-xl sm:text-2xl font-bold text-fg">
                   {{ selected.matches?.length ?? 0 }}
                 </div>
                 <div>matches tracked</div>
@@ -152,7 +152,7 @@
               <!-- View toggle: List always shown; Bracket / Standings shown based on match round shape -->
               <div
                 v-if="hasBracketRounds || hasStandingsRounds"
-                class="inline-flex rounded-md border border-gray-300 bg-white p-0.5"
+                class="inline-flex rounded-md border border-line bg-card p-0.5"
               >
                 <button
                   type="button"
@@ -161,7 +161,7 @@
                     'px-3 py-1 text-xs font-medium rounded transition-colors',
                     viewMode === 'list'
                       ? 'bg-brand-600 text-white'
-                      : 'text-gray-600 hover:text-gray-900',
+                      : 'text-fg-muted hover:text-fg',
                   ]"
                 >
                   List
@@ -174,7 +174,7 @@
                     'px-3 py-1 text-xs font-medium rounded transition-colors',
                     viewMode === 'bracket'
                       ? 'bg-brand-600 text-white'
-                      : 'text-gray-600 hover:text-gray-900',
+                      : 'text-fg-muted hover:text-fg',
                   ]"
                 >
                   Bracket
@@ -187,7 +187,7 @@
                     'px-3 py-1 text-xs font-medium rounded transition-colors',
                     viewMode === 'standings'
                       ? 'bg-brand-600 text-white'
-                      : 'text-gray-600 hover:text-gray-900',
+                      : 'text-fg-muted hover:text-fg',
                   ]"
                 >
                   Standings
@@ -216,7 +216,7 @@
                 'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                 ageGroupFilter === null
                   ? 'bg-indigo-600 text-white'
-                  : 'bg-white border border-gray-300 text-gray-700 hover:border-indigo-400',
+                  : 'bg-card border border-line text-fg hover:border-indigo-400',
               ]"
             >
               All Ages
@@ -229,7 +229,7 @@
                 'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                 ageGroupFilter === ag.id
                   ? 'bg-indigo-600 text-white'
-                  : 'bg-white border border-gray-300 text-gray-700 hover:border-indigo-400',
+                  : 'bg-card border border-line text-fg hover:border-indigo-400',
               ]"
             >
               {{ ag.name }}
@@ -242,9 +242,9 @@
               v-model="teamFilter"
               type="text"
               placeholder="Filter by team…"
-              class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 w-full sm:w-48"
+              class="px-3 py-2 bg-card border border-line rounded-md text-sm text-fg focus:outline-none focus:ring-2 focus:ring-brand-500 w-full sm:w-48"
             />
-            <span class="text-sm text-gray-500"
+            <span class="text-sm text-fg-muted"
               >{{ filteredMatches.length }} match{{
                 filteredMatches.length !== 1 ? 'es' : ''
               }}</span
@@ -255,7 +255,7 @@
                 teamFilter = '';
                 ageGroupFilter = null;
               "
-              class="text-sm text-brand-600 hover:text-brand-800"
+              class="text-sm text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200"
             >
               clear all
             </button>
@@ -264,7 +264,7 @@
           <!-- No matches -->
           <div
             v-if="selected.matches.length === 0"
-            class="text-center py-10 text-gray-500"
+            class="text-center py-10 text-fg-muted"
           >
             No matches entered yet.
           </div>
@@ -272,7 +272,7 @@
           <!-- Group stage section -->
           <div v-if="groupStageMatches.length > 0" class="mb-6">
             <h3
-              class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3"
+              class="text-xs font-semibold text-fg-muted uppercase tracking-wider mb-3"
             >
               Group Stage
             </h3>
@@ -281,17 +281,17 @@
                 v-for="match in groupStageMatches"
                 :key="match.id"
                 @click="viewMatch(match)"
-                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
+                class="bg-card rounded-lg border border-line px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
               >
                 <!-- Mobile meta row -->
                 <div class="flex items-center justify-between mb-1.5 sm:hidden">
                   <div class="flex items-center gap-1.5 min-w-0 flex-wrap">
-                    <span class="text-xs text-gray-400">{{
+                    <span class="text-xs text-fg-muted">{{
                       formatMatchDate(match.match_date)
                     }}</span>
                     <span
                       v-if="match.scheduled_kickoff"
-                      class="text-xs text-gray-400"
+                      class="text-xs text-fg-muted"
                       >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
                     >
                     <span
@@ -301,7 +301,7 @@
                     >
                     <span
                       v-if="match.tournament_group"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-surface-alt text-fg-muted"
                       >{{ match.tournament_group }}</span
                     >
                   </div>
@@ -323,7 +323,7 @@
                     >
                     <span
                       v-else
-                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 hover:underline"
                       >Preview</span
                     >
                   </div>
@@ -331,10 +331,10 @@
                 <!-- Main row -->
                 <div class="flex items-center gap-2 sm:gap-3">
                   <div
-                    class="hidden sm:block w-24 shrink-0 text-xs text-gray-400"
+                    class="hidden sm:block w-24 shrink-0 text-xs text-fg-muted"
                   >
                     <div>{{ formatMatchDate(match.match_date) }}</div>
-                    <div v-if="match.scheduled_kickoff" class="text-gray-500">
+                    <div v-if="match.scheduled_kickoff" class="text-fg-muted">
                       {{ formatKickoffTime(match.scheduled_kickoff) }}
                     </div>
                   </div>
@@ -346,7 +346,7 @@
                     >
                     <span
                       v-if="match.tournament_group"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-surface-alt text-fg-muted"
                       >{{ match.tournament_group }}</span
                     >
                   </div>
@@ -359,7 +359,7 @@
                         class="w-5 h-5 object-contain shrink-0"
                       />
                       <span
-                        class="text-sm font-medium text-gray-900 text-right truncate flex-1 min-w-0"
+                        class="text-sm font-medium text-fg text-right truncate flex-1 min-w-0"
                         >{{ match.home_team?.name }}</span
                       >
                     </div>
@@ -368,7 +368,7 @@
                         'text-xs sm:text-sm font-mono px-1.5 sm:px-2 py-0.5 rounded shrink-0',
                         match.home_score != null
                           ? 'bg-gray-900 text-white font-bold'
-                          : 'text-gray-400',
+                          : 'text-fg-muted',
                       ]"
                     >
                       {{
@@ -381,7 +381,7 @@
                     </span>
                     <div class="flex-1 flex items-center gap-1.5 min-w-0">
                       <span
-                        class="text-sm font-medium text-gray-900 text-left truncate flex-1 min-w-0"
+                        class="text-sm font-medium text-fg text-left truncate flex-1 min-w-0"
                         >{{ match.away_team?.name }}</span
                       >
                       <img
@@ -410,7 +410,7 @@
                     >
                     <span
                       v-else
-                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 hover:underline"
                       >Preview</span
                     >
                   </div>
@@ -422,7 +422,7 @@
           <!-- Knockout section -->
           <div v-if="knockoutMatches.length > 0" class="mb-6">
             <h3
-              class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3"
+              class="text-xs font-semibold text-fg-muted uppercase tracking-wider mb-3"
             >
               Knockout Rounds
             </h3>
@@ -431,17 +431,17 @@
                 v-for="match in knockoutMatches"
                 :key="match.id"
                 @click="viewMatch(match)"
-                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
+                class="bg-card rounded-lg border border-line px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
               >
                 <!-- Mobile meta row -->
                 <div class="flex items-center justify-between mb-1.5 sm:hidden">
                   <div class="flex items-center gap-1.5 min-w-0 flex-wrap">
-                    <span class="text-xs text-gray-400">{{
+                    <span class="text-xs text-fg-muted">{{
                       formatMatchDate(match.match_date)
                     }}</span>
                     <span
                       v-if="match.scheduled_kickoff"
-                      class="text-xs text-gray-400"
+                      class="text-xs text-fg-muted"
                       >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
                     >
                     <span
@@ -473,7 +473,7 @@
                     >
                     <span
                       v-else
-                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 hover:underline"
                       >Preview</span
                     >
                   </div>
@@ -481,10 +481,10 @@
                 <!-- Main row -->
                 <div class="flex items-center gap-2 sm:gap-3">
                   <div
-                    class="hidden sm:block w-24 shrink-0 text-xs text-gray-400"
+                    class="hidden sm:block w-24 shrink-0 text-xs text-fg-muted"
                   >
                     <div>{{ formatMatchDate(match.match_date) }}</div>
-                    <div v-if="match.scheduled_kickoff" class="text-gray-500">
+                    <div v-if="match.scheduled_kickoff" class="text-fg-muted">
                       {{ formatKickoffTime(match.scheduled_kickoff) }}
                     </div>
                   </div>
@@ -501,7 +501,7 @@
                     >
                     <span
                       v-if="match.tournament_group"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-surface-alt text-fg-muted"
                       >{{ match.tournament_group }}</span
                     >
                   </div>
@@ -514,7 +514,7 @@
                         class="w-5 h-5 object-contain shrink-0"
                       />
                       <span
-                        class="text-sm font-medium text-gray-900 text-right truncate flex-1 min-w-0"
+                        class="text-sm font-medium text-fg text-right truncate flex-1 min-w-0"
                         >{{ match.home_team?.name }}</span
                       >
                     </div>
@@ -523,7 +523,7 @@
                         'text-xs sm:text-sm font-mono px-1.5 sm:px-2 py-0.5 rounded shrink-0',
                         match.home_score != null
                           ? 'bg-gray-900 text-white font-bold'
-                          : 'text-gray-400',
+                          : 'text-fg-muted',
                       ]"
                     >
                       {{
@@ -536,7 +536,7 @@
                     </span>
                     <div class="flex-1 flex items-center gap-1.5 min-w-0">
                       <span
-                        class="text-sm font-medium text-gray-900 text-left truncate flex-1 min-w-0"
+                        class="text-sm font-medium text-fg text-left truncate flex-1 min-w-0"
                         >{{ match.away_team?.name }}</span
                       >
                       <img
@@ -565,7 +565,7 @@
                     >
                     <span
                       v-else
-                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 hover:underline"
                       >Preview</span
                     >
                   </div>
@@ -577,7 +577,7 @@
           <!-- Untagged matches (no round set) -->
           <div v-if="untaggedMatches.length > 0" class="mb-6">
             <h3
-              class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3"
+              class="text-xs font-semibold text-fg-muted uppercase tracking-wider mb-3"
             >
               Matches
             </h3>
@@ -586,17 +586,17 @@
                 v-for="match in untaggedMatches"
                 :key="match.id"
                 @click="viewMatch(match)"
-                class="bg-white rounded-lg border border-gray-200 px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
+                class="bg-card rounded-lg border border-line px-3 sm:px-4 py-3 hover:border-brand-300 hover:shadow-sm transition-all cursor-pointer"
               >
                 <!-- Mobile meta row -->
                 <div class="flex items-center justify-between mb-1.5 sm:hidden">
                   <div class="flex items-center gap-1.5 min-w-0">
-                    <span class="text-xs text-gray-400">{{
+                    <span class="text-xs text-fg-muted">{{
                       formatMatchDate(match.match_date)
                     }}</span>
                     <span
                       v-if="match.scheduled_kickoff"
-                      class="text-xs text-gray-400"
+                      class="text-xs text-fg-muted"
                       >· {{ formatKickoffTime(match.scheduled_kickoff) }}</span
                     >
                     <span
@@ -623,7 +623,7 @@
                     >
                     <span
                       v-else
-                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 hover:underline"
                       >Preview</span
                     >
                   </div>
@@ -631,10 +631,10 @@
                 <!-- Main row -->
                 <div class="flex items-center gap-2 sm:gap-3">
                   <div
-                    class="hidden sm:block w-24 shrink-0 text-xs text-gray-400"
+                    class="hidden sm:block w-24 shrink-0 text-xs text-fg-muted"
                   >
                     <div>{{ formatMatchDate(match.match_date) }}</div>
-                    <div v-if="match.scheduled_kickoff" class="text-gray-500">
+                    <div v-if="match.scheduled_kickoff" class="text-fg-muted">
                       {{ formatKickoffTime(match.scheduled_kickoff) }}
                     </div>
                   </div>
@@ -654,7 +654,7 @@
                         class="w-5 h-5 object-contain shrink-0"
                       />
                       <span
-                        class="text-sm font-medium text-gray-900 text-right truncate flex-1 min-w-0"
+                        class="text-sm font-medium text-fg text-right truncate flex-1 min-w-0"
                         >{{ match.home_team?.name }}</span
                       >
                     </div>
@@ -663,7 +663,7 @@
                         'text-xs sm:text-sm font-mono px-1.5 sm:px-2 py-0.5 rounded shrink-0',
                         match.home_score != null
                           ? 'bg-gray-900 text-white font-bold'
-                          : 'text-gray-400',
+                          : 'text-fg-muted',
                       ]"
                     >
                       {{
@@ -676,7 +676,7 @@
                     </span>
                     <div class="flex-1 flex items-center gap-1.5 min-w-0">
                       <span
-                        class="text-sm font-medium text-gray-900 text-left truncate flex-1 min-w-0"
+                        class="text-sm font-medium text-fg text-left truncate flex-1 min-w-0"
                         >{{ match.away_team?.name }}</span
                       >
                       <img
@@ -705,7 +705,7 @@
                     >
                     <span
                       v-else
-                      class="text-xs font-medium text-brand-600 hover:text-brand-800 hover:underline"
+                      class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 hover:underline"
                       >Preview</span
                     >
                   </div>
@@ -726,7 +726,7 @@
               class="flex flex-wrap items-center gap-2"
             >
               <span
-                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                class="text-xs font-semibold text-fg-muted uppercase tracking-wider mr-1"
                 >Age</span
               >
               <button
@@ -737,7 +737,7 @@
                   'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                   bracketAgeGroupId === ag.id
                     ? 'bg-indigo-600 text-white'
-                    : 'bg-white border border-gray-300 text-gray-700 hover:border-indigo-400',
+                    : 'bg-card border border-line text-fg hover:border-indigo-400',
                 ]"
               >
                 {{ ag.name }}
@@ -748,7 +748,7 @@
               class="flex flex-wrap items-center gap-2"
             >
               <span
-                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                class="text-xs font-semibold text-fg-muted uppercase tracking-wider mr-1"
                 >Bracket</span
               >
               <button
@@ -759,7 +759,7 @@
                   'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                   bracketGroup === g
                     ? 'bg-brand-600 text-white'
-                    : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+                    : 'bg-card border border-line text-fg hover:border-brand-400',
                 ]"
               >
                 {{ g }}
@@ -777,7 +777,7 @@
                 'sm:ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                 isBracketFollowed
                   ? 'bg-green-600 text-white hover:bg-green-700'
-                  : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+                  : 'bg-card border border-line text-fg hover:border-brand-400',
               ]"
             >
               <span v-if="isBracketFollowed">✓ Following — Unfollow</span>
@@ -785,7 +785,7 @@
             </button>
             <span
               v-else-if="bracketNeedsPush"
-              class="sm:ml-auto text-xs text-gray-500"
+              class="sm:ml-auto text-xs text-fg-muted"
               data-testid="bracket-follow-push-hint"
             >
               🔔 Enable notifications in your profile to follow this bracket.
@@ -809,7 +809,7 @@
               class="flex flex-wrap items-center gap-2"
             >
               <span
-                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                class="text-xs font-semibold text-fg-muted uppercase tracking-wider mr-1"
                 >Age</span
               >
               <button
@@ -820,7 +820,7 @@
                   'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                   standingsAgeGroupId === ag.id
                     ? 'bg-indigo-600 text-white'
-                    : 'bg-white border border-gray-300 text-gray-700 hover:border-indigo-400',
+                    : 'bg-card border border-line text-fg hover:border-indigo-400',
                 ]"
               >
                 {{ ag.name }}
@@ -831,7 +831,7 @@
               class="flex flex-wrap items-center gap-2"
             >
               <span
-                class="text-xs font-semibold text-gray-500 uppercase tracking-wider mr-1"
+                class="text-xs font-semibold text-fg-muted uppercase tracking-wider mr-1"
                 >Bracket</span
               >
               <button
@@ -842,7 +842,7 @@
                   'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                   standingsGroup === g
                     ? 'bg-brand-600 text-white'
-                    : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+                    : 'bg-card border border-line text-fg hover:border-brand-400',
                 ]"
               >
                 {{ g }}
@@ -861,7 +861,7 @@
                 'sm:ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
                 isStandingsBracketFollowed
                   ? 'bg-green-600 text-white hover:bg-green-700'
-                  : 'bg-white border border-gray-300 text-gray-700 hover:border-brand-400',
+                  : 'bg-card border border-line text-fg hover:border-brand-400',
               ]"
             >
               <span v-if="isStandingsBracketFollowed"
@@ -871,7 +871,7 @@
             </button>
             <span
               v-else-if="standingsNeedsPush"
-              class="sm:ml-auto text-xs text-gray-500"
+              class="sm:ml-auto text-xs text-fg-muted"
               data-testid="standings-bracket-follow-push-hint"
             >
               🔔 Enable notifications in your profile to follow this bracket.

--- a/frontend/src/components/TournamentStandings.vue
+++ b/frontend/src/components/TournamentStandings.vue
@@ -3,18 +3,16 @@
     <!-- No matches -->
     <div
       v-if="bracketTeams.length === 0"
-      class="text-center py-10 text-gray-500"
+      class="text-center py-10 text-fg-muted"
     >
       No group-stage matches in this bracket yet.
     </div>
 
     <template v-else>
       <!-- Standings table -->
-      <div
-        class="overflow-x-auto bg-white rounded-lg border border-gray-200 mb-6"
-      >
+      <div class="overflow-x-auto bg-card rounded-lg border border-line mb-6">
         <table class="min-w-full text-xs sm:text-sm">
-          <thead class="bg-gray-50 text-gray-600">
+          <thead class="bg-surface-alt text-fg-muted">
             <tr>
               <th class="px-1.5 sm:px-2 py-2 w-7 text-center font-semibold">
                 #
@@ -37,19 +35,19 @@
               v-for="(row, idx) in standings"
               :key="row.team.id"
               :class="[
-                idx === 0 ? 'bg-brand-50/50' : 'hover:bg-gray-50',
-                'border-t border-gray-100',
+                idx === 0 ? 'bg-brand-50/50' : 'hover:bg-surface-alt',
+                'border-t border-line',
               ]"
             >
               <td
-                class="px-1.5 sm:px-2 py-2 text-center text-gray-500 tabular-nums"
+                class="px-1.5 sm:px-2 py-2 text-center text-fg-muted tabular-nums"
               >
                 {{ idx + 1 }}
               </td>
               <td
                 :class="[
                   'px-2 sm:px-3 py-2',
-                  idx === 0 ? 'font-semibold text-gray-900' : 'text-gray-800',
+                  idx === 0 ? 'font-semibold text-fg' : 'text-fg',
                 ]"
               >
                 <!-- Inner block truncates reliably; max-width on a <td> alone
@@ -67,9 +65,7 @@
                 :class="[
                   'px-1.5 sm:px-2 py-2 text-center tabular-nums',
                   col.mobileHidden ? 'hidden sm:table-cell' : '',
-                  col.key === 'pts'
-                    ? 'font-bold text-gray-900'
-                    : 'text-gray-700',
+                  col.key === 'pts' ? 'font-bold text-fg' : 'text-fg-muted',
                 ]"
               >
                 {{ formatStat(row, col.key) }}
@@ -83,18 +79,18 @@
       <div>
         <div class="flex items-baseline justify-between mb-2">
           <h3
-            class="text-xs font-semibold text-gray-400 uppercase tracking-wider"
+            class="text-xs font-semibold text-fg-muted uppercase tracking-wider"
           >
             Head-to-head
           </h3>
-          <span class="text-xs text-gray-400 sm:hidden">swipe →</span>
+          <span class="text-xs text-fg-muted sm:hidden">swipe →</span>
         </div>
-        <div class="overflow-x-auto bg-white rounded-lg border border-gray-200">
+        <div class="overflow-x-auto bg-card rounded-lg border border-line">
           <table class="min-w-full text-xs sm:text-sm">
-            <thead class="bg-gray-50 text-gray-600">
+            <thead class="bg-surface-alt text-fg-muted">
               <tr>
                 <th
-                  class="px-2 sm:px-3 py-2 text-left font-semibold sticky left-0 bg-gray-50 z-10 min-w-[104px] sm:min-w-[180px]"
+                  class="px-2 sm:px-3 py-2 text-left font-semibold sticky left-0 bg-surface-alt z-10 min-w-[104px] sm:min-w-[180px]"
                 ></th>
                 <th
                   v-for="team in bracketTeams"
@@ -113,10 +109,10 @@
               <tr
                 v-for="rowTeam in bracketTeams"
                 :key="`row-${rowTeam.id}`"
-                class="border-t border-gray-100"
+                class="border-t border-line"
               >
                 <td
-                  class="px-2 sm:px-3 py-2 font-medium text-gray-800 sticky left-0 bg-white z-10"
+                  class="px-2 sm:px-3 py-2 font-medium text-fg sticky left-0 bg-card z-10"
                 >
                   <div
                     class="truncate max-w-[88px] sm:max-w-[164px]"
@@ -131,8 +127,8 @@
                   :class="[
                     'px-2 sm:px-3 py-2 text-center tabular-nums',
                     rowTeam.id === colTeam.id
-                      ? 'bg-gray-100 text-gray-300'
-                      : 'text-gray-700',
+                      ? 'bg-surface-alt text-fg-muted'
+                      : 'text-fg-muted',
                   ]"
                 >
                   <span v-if="rowTeam.id === colTeam.id">—</span>

--- a/frontend/src/components/WhatsNewView.vue
+++ b/frontend/src/components/WhatsNewView.vue
@@ -6,22 +6,22 @@
   >
     <div class="min-h-full flex items-start justify-center p-3 sm:p-6">
       <div
-        class="relative w-full max-w-2xl bg-white rounded-lg shadow-2xl"
+        class="relative w-full max-w-2xl bg-card rounded-lg shadow-2xl"
         @click.stop
       >
         <button
           type="button"
           aria-label="Close what's new"
           data-testid="whats-new-close"
-          class="absolute top-3 right-3 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+          class="absolute top-3 right-3 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-fg-muted hover:text-fg hover:bg-surface-alt"
           @click="$emit('close')"
         >
           ✕
         </button>
 
         <div class="p-5 sm:p-7">
-          <h2 class="text-xl font-bold text-gray-900 mb-1">✨ What's New</h2>
-          <p class="text-sm text-gray-500 mb-5">
+          <h2 class="text-xl font-bold text-fg mb-1">✨ What's New</h2>
+          <p class="text-sm text-fg-muted mb-5">
             New features and improvements in Missing Table.
           </p>
 
@@ -30,7 +30,7 @@
           </p>
           <p
             v-else-if="loaded && !releases.length"
-            class="text-sm text-gray-500"
+            class="text-sm text-fg-muted"
           >
             No release notes yet — check back after the next update.
           </p>
@@ -42,10 +42,10 @@
             :data-testid="`changelog-release-${r.version}`"
           >
             <div class="flex items-baseline gap-2 flex-wrap">
-              <h3 class="text-base font-semibold text-gray-900">
+              <h3 class="text-base font-semibold text-fg">
                 {{ r.version }}
               </h3>
-              <span v-if="r.title" class="text-sm text-gray-600">{{
+              <span v-if="r.title" class="text-sm text-fg-muted">{{
                 r.title
               }}</span>
               <span
@@ -83,7 +83,7 @@ onMounted(async () => {
 <style scoped>
 .changelog-release {
   padding: 14px 0;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid rgb(var(--color-line));
 }
 .changelog-release:first-of-type {
   border-top: none;
@@ -102,7 +102,7 @@ onMounted(async () => {
 .changelog-body {
   margin-top: 6px;
   font-size: 14px;
-  color: #374151;
+  color: rgb(var(--color-fg));
   line-height: 1.5;
 }
 /* Lightweight markdown styling (no prose plugin dependency) */
@@ -110,7 +110,7 @@ onMounted(async () => {
   font-size: 14px;
   font-weight: 700;
   margin: 12px 0 4px;
-  color: #111827;
+  color: rgb(var(--color-fg));
 }
 .changelog-body :deep(ul) {
   list-style: disc;
@@ -124,14 +124,17 @@ onMounted(async () => {
   color: #1e40af;
   text-decoration: underline;
 }
+:global(.dark) .changelog-body :deep(a) {
+  color: #779edb;
+}
 .changelog-body :deep(code) {
-  background: #f3f4f6;
+  background: rgb(var(--color-surface-alt));
   padding: 1px 5px;
   border-radius: 4px;
   font-size: 12px;
 }
 .changelog-body :deep(strong) {
   font-weight: 600;
-  color: #111827;
+  color: rgb(var(--color-fg));
 }
 </style>

--- a/frontend/src/components/admin/AdminAgeGroups.vue
+++ b/frontend/src/components/admin/AdminAgeGroups.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Age Groups Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Age Groups Management</h3>
       <button
         @click="showAddModal = true"
         class="bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium"
@@ -30,42 +30,40 @@
       v-else
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Name
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Teams Count
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Created
             </th>
             <th
-              class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr v-for="ageGroup in ageGroups" :key="ageGroup.id">
-            <td
-              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ ageGroup.name }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ getTeamCount(ageGroup.id) }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatDate(ageGroup.created_at) }}
             </td>
             <td
@@ -73,7 +71,7 @@
             >
               <button
                 @click="editAgeGroup(ageGroup)"
-                class="text-brand-600 hover:text-brand-900 mr-3"
+                class="text-brand-600 dark:text-brand-300 hover:text-brand-900 dark:hover:text-brand-200 mr-3"
               >
                 Edit
               </button>
@@ -102,7 +100,7 @@
     >
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             {{ showEditModal ? 'Edit Age Group' : 'Add New Age Group' }}
           </h3>
 
@@ -112,14 +110,12 @@
             "
           >
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
-                >Name</label
-              >
+              <label class="block text-sm font-medium text-fg mb-2">Name</label>
               <input
                 v-model="formData.name"
                 type="text"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., U13, U14, U15..."
               />
             </div>
@@ -128,7 +124,7 @@
               <button
                 type="button"
                 @click="closeModals"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -334,7 +330,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 500px;
   width: 90%;

--- a/frontend/src/components/admin/AdminCache.vue
+++ b/frontend/src/components/admin/AdminCache.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="admin-cache">
     <div class="flex justify-between items-center mb-6">
-      <h2 class="text-xl font-semibold text-gray-900">Cache Management</h2>
+      <h2 class="text-xl font-semibold text-fg">Cache Management</h2>
       <button
         @click="fetchCacheStats"
         :disabled="loading"
-        class="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200 disabled:opacity-50"
+        class="px-3 py-1.5 text-sm bg-surface-alt text-fg-muted rounded hover:bg-line disabled:opacity-50"
       >
         {{ loading ? 'Loading...' : 'Refresh' }}
       </button>
@@ -22,7 +22,7 @@
     <!-- Cache Disabled -->
     <div
       v-if="!cacheStats.enabled && !loading"
-      class="text-center py-8 text-gray-500"
+      class="text-center py-8 text-fg-muted"
     >
       <div class="text-4xl mb-2">🚫</div>
       <p>{{ cacheStats.message || 'Cache is disabled' }}</p>
@@ -54,18 +54,16 @@
         <div
           v-for="(group, type) in cacheStats.groups"
           :key="type"
-          class="border border-gray-200 rounded-lg overflow-hidden"
+          class="border border-line rounded-lg overflow-hidden"
         >
           <div
-            class="flex items-center justify-between px-4 py-3 bg-gray-50 border-b border-gray-200"
+            class="flex items-center justify-between px-4 py-3 bg-surface-alt border-b border-line"
           >
             <div class="flex items-center space-x-3">
               <span class="text-lg">{{ getCacheIcon(type) }}</span>
-              <span class="font-medium text-gray-900 capitalize">{{
-                type
-              }}</span>
+              <span class="font-medium text-fg capitalize">{{ type }}</span>
               <span
-                class="px-2 py-0.5 text-xs bg-gray-200 text-gray-700 rounded-full"
+                class="px-2 py-0.5 text-xs bg-line text-fg-muted rounded-full"
               >
                 {{ group.count }} items
               </span>
@@ -80,18 +78,18 @@
           </div>
 
           <!-- Expandable Keys List -->
-          <div class="px-4 py-2 max-h-40 overflow-y-auto bg-white">
+          <div class="px-4 py-2 max-h-40 overflow-y-auto bg-card">
             <div
               v-for="key in group.keys.slice(0, 10)"
               :key="key"
-              class="text-xs text-gray-500 font-mono py-0.5 truncate"
+              class="text-xs text-fg-muted font-mono py-0.5 truncate"
               :title="key"
             >
               {{ key }}
             </div>
             <div
               v-if="group.keys.length > 10"
-              class="text-xs text-gray-400 py-1"
+              class="text-xs text-fg-muted py-1"
             >
               ... and {{ group.keys.length - 10 }} more
             </div>
@@ -102,7 +100,7 @@
       <!-- No Cache -->
       <div
         v-if="Object.keys(cacheStats.groups).length === 0"
-        class="text-center py-8 text-gray-500"
+        class="text-center py-8 text-fg-muted"
       >
         <div class="text-4xl mb-2">✨</div>
         <p>Cache is empty</p>
@@ -110,7 +108,7 @@
     </div>
 
     <!-- Loading -->
-    <div v-else-if="loading" class="text-center py-8 text-gray-500">
+    <div v-else-if="loading" class="text-center py-8 text-fg-muted">
       Loading cache stats...
     </div>
 

--- a/frontend/src/components/admin/AdminChannelRequests.vue
+++ b/frontend/src/components/admin/AdminChannelRequests.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h2 class="text-xl font-bold text-gray-900">Channel Access Requests</h2>
+      <h2 class="text-xl font-bold text-fg">Channel Access Requests</h2>
       <div class="flex items-center gap-4">
         <!-- Stats -->
-        <div v-if="stats" class="text-sm text-gray-600">
+        <div v-if="stats" class="text-sm text-fg-muted">
           <span class="font-medium">{{ stats.pending_total }}</span> pending
-          <span class="text-gray-400"
+          <span class="text-fg-muted"
             >({{ stats.pending_telegram }} Telegram /
             {{ stats.pending_discord }} Discord)</span
           >
@@ -17,7 +17,7 @@
         <select
           v-model="platformFilter"
           @change="fetchRequests"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Platforms</option>
           <option value="telegram">Telegram</option>
@@ -27,7 +27,7 @@
         <select
           v-model="statusFilter"
           @change="fetchRequests"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Statuses</option>
           <option value="pending">Pending</option>
@@ -42,7 +42,7 @@
       <div
         class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-brand-600"
       ></div>
-      <p class="mt-2 text-gray-600">Loading requests...</p>
+      <p class="mt-2 text-fg-muted">Loading requests...</p>
     </div>
 
     <!-- Error State -->
@@ -61,11 +61,11 @@
 
     <!-- Empty State -->
     <div v-else-if="requests.length === 0" class="text-center py-12">
-      <div class="text-gray-400 text-5xl mb-4">📡</div>
-      <h3 class="text-lg font-medium text-gray-900 mb-2">
+      <div class="text-fg-muted text-5xl mb-4">📡</div>
+      <h3 class="text-lg font-medium text-fg mb-2">
         No channel access requests
       </h3>
-      <p class="text-gray-600">
+      <p class="text-fg-muted">
         {{
           statusFilter || platformFilter
             ? 'No requests match the current filters.'
@@ -76,58 +76,58 @@
 
     <!-- Requests Table -->
     <div v-else class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Requester
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Team
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Telegram
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Discord
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Requested
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr
             v-for="request in requests"
             :key="request.id"
-            class="hover:bg-gray-50"
+            class="hover:bg-surface-alt"
           >
             <td class="px-4 py-4">
-              <div class="text-sm font-medium text-gray-900">
+              <div class="text-sm font-medium text-fg">
                 {{ request.user_display_name || '—' }}
               </div>
-              <div class="text-sm text-gray-500">
+              <div class="text-sm text-fg-muted">
                 {{ request.user_email || '—' }}
               </div>
             </td>
-            <td class="px-4 py-4 text-sm text-gray-500">
+            <td class="px-4 py-4 text-sm text-fg-muted">
               {{ request.team_name || '—' }}
             </td>
 
             <!-- Telegram column -->
             <td class="px-4 py-4">
               <div v-if="request.telegram_status !== 'none'">
-                <div class="text-sm text-gray-700 mb-1">
+                <div class="text-sm text-fg mb-1">
                   @{{ request.telegram_handle || '—' }}
                 </div>
                 <span
@@ -155,18 +155,18 @@
                 </div>
                 <div
                   v-else-if="request.telegram_reviewed_at"
-                  class="text-xs text-gray-400 mt-1"
+                  class="text-xs text-fg-muted mt-1"
                 >
                   {{ formatDate(request.telegram_reviewed_at) }}
                 </div>
               </div>
-              <span v-else class="text-xs text-gray-400">Not requested</span>
+              <span v-else class="text-xs text-fg-muted">Not requested</span>
             </td>
 
             <!-- Discord column -->
             <td class="px-4 py-4">
               <div v-if="request.discord_status !== 'none'">
-                <div class="text-sm text-gray-700 mb-1">
+                <div class="text-sm text-fg mb-1">
                   {{ request.discord_handle || '—' }}
                 </div>
                 <span
@@ -194,15 +194,15 @@
                 </div>
                 <div
                   v-else-if="request.discord_reviewed_at"
-                  class="text-xs text-gray-400 mt-1"
+                  class="text-xs text-fg-muted mt-1"
                 >
                   {{ formatDate(request.discord_reviewed_at) }}
                 </div>
               </div>
-              <span v-else class="text-xs text-gray-400">Not requested</span>
+              <span v-else class="text-xs text-fg-muted">Not requested</span>
             </td>
 
-            <td class="px-4 py-4 text-sm text-gray-500">
+            <td class="px-4 py-4 text-sm text-fg-muted">
               {{ formatDate(request.created_at) }}
             </td>
           </tr>
@@ -213,7 +213,7 @@
     <!-- Count -->
     <div
       v-if="requests.length > 0"
-      class="mt-4 text-sm text-gray-500 text-center"
+      class="mt-4 text-sm text-fg-muted text-center"
     >
       Showing {{ requests.length }} requests
     </div>

--- a/frontend/src/components/admin/AdminClubNotifications.vue
+++ b/frontend/src/components/admin/AdminClubNotifications.vue
@@ -1,15 +1,15 @@
 <template>
   <div data-testid="admin-club-notifications">
     <div class="flex justify-between items-center mb-6">
-      <h2 class="text-xl font-bold text-gray-900">Club Notifications</h2>
+      <h2 class="text-xl font-bold text-fg">Club Notifications</h2>
       <!-- Admins pick a club; club_managers are auto-scoped to their own -->
       <div v-if="isAdmin" class="flex items-center gap-3">
-        <label class="text-sm text-gray-600" for="club-picker">Club:</label>
+        <label class="text-sm text-fg-muted" for="club-picker">Club:</label>
         <select
           id="club-picker"
           v-model.number="selectedClubId"
           data-testid="admin-notifications-club-picker"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option :value="null" disabled>Select a club…</option>
           <option v-for="c in clubs" :key="c.id" :value="c.id">
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <div v-if="loadingClubs" class="text-sm text-gray-500">Loading clubs…</div>
+    <div v-if="loadingClubs" class="text-sm text-fg-muted">Loading clubs…</div>
 
     <div
       v-else-if="!isAdmin && !selectedClubId"
@@ -34,7 +34,7 @@
       <ClubNotificationChannels :club-id="selectedClubId" />
     </div>
 
-    <div v-else class="text-sm text-gray-500" data-testid="no-club-selected">
+    <div v-else class="text-sm text-fg-muted" data-testid="no-club-selected">
       Select a club to configure its notification channels.
     </div>
   </div>

--- a/frontend/src/components/admin/AdminClubs.vue
+++ b/frontend/src/components/admin/AdminClubs.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Clubs Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Clubs Management</h3>
       <button
         @click="showAddModal = true"
         class="bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium"
@@ -17,7 +17,7 @@
         type="search"
         placeholder="Search clubs by name…"
         data-testid="club-search"
-        class="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-brand-500 focus:border-brand-500"
+        class="w-full sm:w-80 bg-card text-fg border border-line rounded-md px-3 py-2 text-sm focus:ring-brand-500 focus:border-brand-500"
       />
     </div>
 
@@ -41,7 +41,7 @@
       <div
         v-for="club in filteredClubs"
         :key="club.id"
-        class="bg-white shadow-md rounded-lg overflow-hidden hover:shadow-lg transition-shadow"
+        class="bg-card shadow-md rounded-lg overflow-hidden hover:shadow-lg transition-shadow"
         :style="{
           border: `3px solid ${club.primary_color || '#3B82F6'}`,
         }"
@@ -79,7 +79,7 @@
 
           <div class="mb-4">
             <div
-              class="flex items-center justify-between text-sm text-gray-600 mb-2"
+              class="flex items-center justify-between text-sm text-fg-muted mb-2"
             >
               <span class="font-medium">Teams:</span>
               <div class="flex items-center gap-2">
@@ -90,7 +90,7 @@
                 </span>
                 <button
                   type="button"
-                  class="text-xs font-medium text-brand-600 hover:text-brand-800"
+                  class="text-xs font-medium text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200"
                   @click="toggleClubTeams(club.id)"
                 >
                   {{ expandedClubIds[club.id] ? 'Hide teams' : 'Show teams' }}
@@ -103,7 +103,7 @@
           <div v-if="expandedClubIds[club.id]" class="space-y-2">
             <div
               v-if="loadingTeams[club.id]"
-              class="text-sm text-gray-500 italic"
+              class="text-sm text-fg-muted italic"
             >
               Loading teams...
             </div>
@@ -116,11 +116,11 @@
               <div
                 v-for="team in teamsByClubId[club.id]"
                 :key="team.id"
-                class="text-sm text-gray-700 pl-2 py-2 hover:bg-gray-50 rounded border-b border-gray-100 last:border-0"
+                class="text-sm text-fg pl-2 py-2 hover:bg-surface-alt rounded border-b border-line last:border-0"
               >
                 <div class="flex items-center mb-1">
                   <svg
-                    class="w-3 h-3 mr-2 text-gray-400 flex-shrink-0"
+                    class="w-3 h-3 mr-2 text-fg-muted flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -156,17 +156,17 @@
                 </div>
               </div>
             </div>
-            <div v-else class="text-sm text-gray-500 italic">
+            <div v-else class="text-sm text-fg-muted italic">
               No teams in this club yet
             </div>
           </div>
         </div>
 
         <!-- Club Footer -->
-        <div class="bg-gray-50 px-6 py-3 flex justify-end space-x-2">
+        <div class="bg-surface-alt px-6 py-3 flex justify-end space-x-2">
           <button
             @click="viewClubDetails(club)"
-            class="text-brand-600 hover:text-brand-800 text-sm font-medium"
+            class="text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 text-sm font-medium"
           >
             View Details
           </button>
@@ -184,7 +184,7 @@
     <div
       v-if="!loading && clubs.length > 0 && filteredClubs.length === 0"
       data-testid="club-search-empty"
-      class="text-center py-8 text-sm text-gray-500"
+      class="text-center py-8 text-sm text-fg-muted"
     >
       No clubs match "{{ clubSearch }}".
     </div>
@@ -192,10 +192,10 @@
     <!-- Empty State -->
     <div
       v-if="!loading && clubs.length === 0"
-      class="text-center py-12 bg-gray-50 rounded-lg"
+      class="text-center py-12 bg-surface-alt rounded-lg"
     >
       <svg
-        class="mx-auto h-12 w-12 text-gray-400"
+        class="mx-auto h-12 w-12 text-fg-muted"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -207,8 +207,8 @@
           d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
         />
       </svg>
-      <h3 class="mt-2 text-sm font-medium text-gray-900">No clubs</h3>
-      <p class="mt-1 text-sm text-gray-500">
+      <h3 class="mt-2 text-sm font-medium text-fg">No clubs</h3>
+      <p class="mt-1 text-sm text-fg-muted">
         Get started by creating a new club.
       </p>
       <div class="mt-6">
@@ -226,9 +226,9 @@
       v-if="showAddModal"
       class="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50"
     >
-      <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
-        <div class="px-6 py-4 border-b border-gray-200">
-          <h3 class="text-lg font-medium text-gray-900">Add Club</h3>
+      <div class="bg-card rounded-lg shadow-xl max-w-md w-full mx-4">
+        <div class="px-6 py-4 border-b border-line">
+          <h3 class="text-lg font-medium text-fg">Add Club</h3>
         </div>
 
         <form @submit.prevent="createClub" class="px-6 py-4 space-y-4">
@@ -241,51 +241,47 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
+            <label class="block text-sm font-medium text-fg">
               Club Name *
             </label>
             <input
               v-model="newClub.name"
               type="text"
               required
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
               placeholder="e.g., IFA"
             />
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
-              City *
-            </label>
+            <label class="block text-sm font-medium text-fg"> City * </label>
             <input
               v-model="newClub.city"
               type="text"
               required
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
               placeholder="e.g., Weymouth, MA"
             />
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
-              Website
-            </label>
+            <label class="block text-sm font-medium text-fg"> Website </label>
             <input
               v-model="newClub.website"
               type="url"
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
               placeholder="e.g., https://ifasoccer.com"
             />
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
+            <label class="block text-sm font-medium text-fg">
               Description
             </label>
             <textarea
               v-model="newClub.description"
               rows="3"
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
               placeholder="Brief description of the club"
             ></textarea>
           </div>
@@ -296,11 +292,11 @@
               v-model="newClub.pro_academy"
               type="checkbox"
               id="new_pro_academy"
-              class="h-4 w-4 text-brand-600 focus:ring-brand-500 border-gray-300 rounded"
+              class="h-4 w-4 text-brand-600 focus:ring-brand-500 border-line rounded"
             />
             <label
               for="new_pro_academy"
-              class="ml-2 block text-sm font-medium text-gray-700"
+              class="ml-2 block text-sm font-medium text-fg"
             >
               Professional Academy
             </label>
@@ -317,7 +313,7 @@
             <button
               type="button"
               @click="cancelAdd"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              class="px-4 py-2 text-sm font-medium text-fg bg-card border border-line rounded-md hover:bg-surface-alt"
             >
               Cancel
             </button>
@@ -339,10 +335,10 @@
       class="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50"
     >
       <div
-        class="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto"
+        class="bg-card rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto"
       >
-        <div class="px-6 py-4 border-b border-gray-200">
-          <h3 class="text-lg font-medium text-gray-900">Edit Club</h3>
+        <div class="px-6 py-4 border-b border-line">
+          <h3 class="text-lg font-medium text-fg">Edit Club</h3>
         </div>
 
         <form @submit.prevent="updateClub" class="px-6 py-4 space-y-4">
@@ -355,48 +351,44 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
+            <label class="block text-sm font-medium text-fg">
               Club Name *
             </label>
             <input
               v-model="editClub.name"
               type="text"
               required
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
             />
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
-              City *
-            </label>
+            <label class="block text-sm font-medium text-fg"> City * </label>
             <input
               v-model="editClub.city"
               type="text"
               required
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
             />
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
-              Website
-            </label>
+            <label class="block text-sm font-medium text-fg"> Website </label>
             <input
               v-model="editClub.website"
               type="url"
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
             />
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700">
+            <label class="block text-sm font-medium text-fg">
               Description
             </label>
             <textarea
               v-model="editClub.description"
               rows="3"
-              class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              class="mt-1 block w-full bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
             ></textarea>
           </div>
 
@@ -406,11 +398,11 @@
               v-model="editClub.pro_academy"
               type="checkbox"
               id="pro_academy"
-              class="h-4 w-4 text-brand-600 focus:ring-brand-500 border-gray-300 rounded"
+              class="h-4 w-4 text-brand-600 focus:ring-brand-500 border-line rounded"
             />
             <label
               for="pro_academy"
-              class="ml-2 block text-sm font-medium text-gray-700"
+              class="ml-2 block text-sm font-medium text-fg"
             >
               Professional Academy
             </label>
@@ -418,7 +410,7 @@
 
           <!-- Logo Upload Section -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2">
+            <label class="block text-sm font-medium text-fg mb-2">
               Club Logo
             </label>
             <div class="flex items-center gap-4">
@@ -428,14 +420,14 @@
                   v-if="editClub.logo_url || logoPreview"
                   :src="logoPreview || editClub.logo_url"
                   alt="Club logo preview"
-                  class="w-16 h-16 rounded-full object-cover border-2 border-gray-200"
+                  class="w-16 h-16 rounded-full object-cover border-2 border-line"
                 />
                 <div
                   v-else
-                  class="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center"
+                  class="w-16 h-16 rounded-full bg-surface-alt flex items-center justify-center"
                 >
                   <svg
-                    class="w-8 h-8 text-gray-400"
+                    class="w-8 h-8 text-fg-muted"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -462,11 +454,11 @@
                   type="button"
                   @click="$refs.logoInput.click()"
                   :disabled="uploadingLogo"
-                  class="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+                  class="px-3 py-2 text-sm font-medium text-fg bg-card border border-line rounded-md hover:bg-surface-alt disabled:opacity-50"
                 >
                   {{ uploadingLogo ? 'Uploading...' : 'Choose Image' }}
                 </button>
-                <p class="mt-1 text-xs text-gray-500">PNG or JPG, max 2MB</p>
+                <p class="mt-1 text-xs text-fg-muted">PNG or JPG, max 2MB</p>
               </div>
             </div>
           </div>
@@ -474,37 +466,37 @@
           <!-- Color Pickers Section -->
           <div class="grid grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2">
+              <label class="block text-sm font-medium text-fg mb-2">
                 Primary Color
               </label>
               <div class="flex items-center gap-2">
                 <input
                   v-model="editClub.primary_color"
                   type="color"
-                  class="w-10 h-10 rounded cursor-pointer border border-gray-300"
+                  class="w-10 h-10 rounded cursor-pointer border border-line"
                 />
                 <input
                   v-model="editClub.primary_color"
                   type="text"
-                  class="flex-1 border border-gray-300 rounded-md shadow-sm py-2 px-3 text-sm font-mono"
+                  class="flex-1 bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 text-sm font-mono"
                   placeholder="#6B7280"
                 />
               </div>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2">
+              <label class="block text-sm font-medium text-fg mb-2">
                 Secondary Color
               </label>
               <div class="flex items-center gap-2">
                 <input
                   v-model="editClub.secondary_color"
                   type="color"
-                  class="w-10 h-10 rounded cursor-pointer border border-gray-300"
+                  class="w-10 h-10 rounded cursor-pointer border border-line"
                 />
                 <input
                   v-model="editClub.secondary_color"
                   type="text"
-                  class="flex-1 border border-gray-300 rounded-md shadow-sm py-2 px-3 text-sm font-mono"
+                  class="flex-1 bg-card text-fg border border-line rounded-md shadow-sm py-2 px-3 text-sm font-mono"
                   placeholder="#374151"
                 />
               </div>
@@ -513,7 +505,7 @@
 
           <!-- Color Preview -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2">
+            <label class="block text-sm font-medium text-fg mb-2">
               Color Preview
             </label>
             <div
@@ -528,7 +520,7 @@
             <button
               type="button"
               @click="cancelEdit"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              class="px-4 py-2 text-sm font-medium text-fg bg-card border border-line rounded-md hover:bg-surface-alt"
             >
               Cancel
             </button>

--- a/frontend/src/components/admin/AdminDivisions.vue
+++ b/frontend/src/components/admin/AdminDivisions.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Divisions Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Divisions Management</h3>
       <button
         @click="showAddModal = true"
         class="bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium"
@@ -30,58 +30,56 @@
       v-else
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Name
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               League
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Description
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Teams Count
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Created
             </th>
             <th
-              class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr v-for="division in divisions" :key="division.id">
-            <td
-              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ division.name }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ division.leagues?.name || getLeagueName(division.league_id) }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ division.description }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ getTeamCount(division.id) }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatDate(division.created_at) }}
             </td>
             <td
@@ -89,7 +87,7 @@
             >
               <button
                 @click="editDivision(division)"
-                class="text-brand-600 hover:text-brand-900 mr-3"
+                class="text-brand-600 dark:text-brand-300 hover:text-brand-900 mr-3"
               >
                 Edit
               </button>
@@ -118,7 +116,7 @@
     >
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             {{ showEditModal ? 'Edit Division' : 'Add New Division' }}
           </h3>
 
@@ -128,26 +126,26 @@
             "
           >
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Division Name</label
               >
               <input
                 v-model="formData.name"
                 type="text"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., Northeast, Southeast, Central..."
               />
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >League</label
               >
               <select
                 v-model="formData.league_id"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option :value="null" disabled>Select a league...</option>
                 <option
@@ -161,13 +159,13 @@
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Description</label
               >
               <textarea
                 v-model="formData.description"
                 rows="3"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Description of the division..."
               ></textarea>
             </div>
@@ -176,7 +174,7 @@
               <button
                 type="button"
                 @click="closeModals"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -424,7 +422,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 500px;
   width: 90%;

--- a/frontend/src/components/admin/AdminGoals.vue
+++ b/frontend/src/components/admin/AdminGoals.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Goals Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Goals Management</h3>
       <div class="flex space-x-3">
         <select
           v-model="filterSeason"
           @change="fetchGoals"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 border border-line rounded-md text-sm bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Seasons</option>
           <option v-for="season in seasons" :key="season.id" :value="season.id">
@@ -17,7 +17,7 @@
         <select
           v-model="filterAgeGroup"
           @change="fetchGoals"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 border border-line rounded-md text-sm bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Age Groups</option>
           <option
@@ -32,7 +32,7 @@
         <select
           v-model="filterMatchType"
           @change="fetchGoals"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 border border-line rounded-md text-sm bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Match Types</option>
           <option
@@ -66,70 +66,68 @@
       v-else
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Match
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               Date
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Scorer
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-20"
             >
               Minute
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               Season
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               Age Group
             </th>
             <th
-              class="px-4 py-3 text-right text-xs font-medium text-gray-500 bg-gray-50 uppercase tracking-wider w-44 sticky right-0"
+              class="px-4 py-3 text-right text-xs font-medium text-fg-muted bg-surface-alt uppercase tracking-wider w-44 sticky right-0"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr v-for="goal in goals" :key="goal.id">
-            <td
-              class="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-4 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ getHomeTeamName(goal) }} vs {{ getAwayTeamName(goal) }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatDate(goal.match?.match_date) }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg">
               {{ goal.player_name || 'Unknown' }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatMinute(goal.match_minute, goal.extra_time) }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ goal.match?.season?.name || '-' }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ goal.match?.age_group?.name || '-' }}
             </td>
             <td
-              class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium bg-gray-50 w-44 sticky right-0"
+              class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium bg-surface-alt w-44 sticky right-0"
             >
               <div class="flex gap-2 justify-end items-center">
                 <button
@@ -153,7 +151,7 @@
 
       <!-- Empty state -->
       <div v-if="!loading && goals.length === 0" class="text-center py-12">
-        <div class="text-gray-500">No goals found</div>
+        <div class="text-fg-muted">No goals found</div>
       </div>
     </div>
 
@@ -161,9 +159,9 @@
     <div v-if="showEditModal" class="modal-overlay" @click="closeEditModal">
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">Edit Goal</h3>
+          <h3 class="text-lg font-medium text-fg mb-4">Edit Goal</h3>
 
-          <div class="mb-4 text-sm text-gray-600">
+          <div class="mb-4 text-sm text-fg-muted">
             <span class="font-medium">Match:</span>
             {{ getHomeTeamName(editingGoal) }} vs
             {{ getAwayTeamName(editingGoal) }} ({{
@@ -174,7 +172,7 @@
           <form @submit.prevent="updateGoal()">
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Match Minute</label
                 >
                 <input
@@ -182,12 +180,12 @@
                   type="number"
                   min="0"
                   max="120"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="e.g. 45"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Extra Time</label
                 >
                 <input
@@ -195,21 +193,21 @@
                   type="number"
                   min="0"
                   max="30"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="e.g. 3"
                 />
               </div>
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Player Name</label
               >
               <input
                 v-model="editFormData.player_name"
                 type="text"
                 maxlength="200"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 border border-line rounded-md bg-card text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Goal scorer name"
               />
             </div>
@@ -218,7 +216,7 @@
               <button
                 type="button"
                 @click="closeEditModal"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -485,7 +483,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 600px;
   width: 90%;

--- a/frontend/src/components/admin/AdminInviteRequests.vue
+++ b/frontend/src/components/admin/AdminInviteRequests.vue
@@ -1,17 +1,17 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h2 class="text-xl font-bold text-gray-900">Invite Requests</h2>
+      <h2 class="text-xl font-bold text-fg">Invite Requests</h2>
       <div class="flex items-center gap-4">
         <!-- Stats -->
-        <div v-if="stats" class="text-sm text-gray-600">
+        <div v-if="stats" class="text-sm text-fg-muted">
           <span class="font-medium">{{ stats.pending }}</span> pending /
           <span class="font-medium">{{ stats.total }}</span> total
         </div>
         <!-- Test email -->
         <button
           type="button"
-          class="px-3 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+          class="px-3 py-2 text-sm rounded-md border border-line text-fg hover:bg-surface-alt"
           :disabled="sendingTestEmail"
           @click="sendTestApprovalEmail"
         >
@@ -21,7 +21,7 @@
         <select
           v-model="statusFilter"
           @change="fetchRequests"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card border border-line rounded-md text-sm text-fg focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Requests</option>
           <option value="pending">Pending</option>
@@ -36,7 +36,7 @@
       <div
         class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-brand-600"
       ></div>
-      <p class="mt-2 text-gray-600">Loading requests...</p>
+      <p class="mt-2 text-fg-muted">Loading requests...</p>
     </div>
 
     <!-- Error State -->
@@ -55,9 +55,9 @@
 
     <!-- Empty State -->
     <div v-else-if="requests.length === 0" class="text-center py-12">
-      <div class="text-gray-400 text-5xl mb-4">📬</div>
-      <h3 class="text-lg font-medium text-gray-900 mb-2">No invite requests</h3>
-      <p class="text-gray-600">
+      <div class="text-fg-muted text-5xl mb-4">📬</div>
+      <h3 class="text-lg font-medium text-fg mb-2">No invite requests</h3>
+      <p class="text-fg-muted">
         {{
           statusFilter
             ? `No ${statusFilter} requests found.`
@@ -68,58 +68,58 @@
 
     <!-- Requests Table -->
     <div v-else class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Requester
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Team
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Reason
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Status
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Date
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr
             v-for="request in requests"
             :key="request.id"
-            class="hover:bg-gray-50"
+            class="hover:bg-surface-alt"
           >
             <td class="px-4 py-4">
-              <div class="text-sm font-medium text-gray-900">
+              <div class="text-sm font-medium text-fg">
                 {{ request.name }}
               </div>
-              <div class="text-sm text-gray-500">{{ request.email }}</div>
+              <div class="text-sm text-fg-muted">{{ request.email }}</div>
             </td>
-            <td class="px-4 py-4 text-sm text-gray-500">
+            <td class="px-4 py-4 text-sm text-fg-muted">
               {{ request.team || '-' }}
             </td>
             <td
-              class="px-4 py-4 text-sm text-gray-500 max-w-xs truncate"
+              class="px-4 py-4 text-sm text-fg-muted max-w-xs truncate"
               :title="request.reason"
             >
               {{ request.reason || '-' }}
@@ -136,7 +136,7 @@
                 {{ request.status }}
               </span>
             </td>
-            <td class="px-4 py-4 text-sm text-gray-500">
+            <td class="px-4 py-4 text-sm text-fg-muted">
               {{ formatDate(request.created_at) }}
             </td>
             <td class="px-4 py-4 text-sm">
@@ -155,14 +155,14 @@
                 </button>
               </div>
               <div v-else class="flex flex-col gap-1 text-xs">
-                <span v-if="request.reviewed_at" class="text-gray-400">
+                <span v-if="request.reviewed_at" class="text-fg-muted">
                   {{ formatDate(request.reviewed_at) }}
                 </span>
                 <div class="flex gap-3">
                   <button
                     v-if="request.status === 'approved'"
                     :disabled="resendingIds.has(request.id)"
-                    class="text-blue-600 hover:text-blue-800 font-medium disabled:text-gray-400"
+                    class="text-blue-600 hover:text-blue-800 font-medium disabled:text-fg-muted"
                     @click="resendApprovalEmail(request)"
                   >
                     {{
@@ -170,7 +170,7 @@
                     }}
                   </button>
                   <button
-                    class="text-gray-600 hover:text-gray-800 font-medium"
+                    class="text-fg-muted hover:text-fg font-medium"
                     @click="resetToPending(request.id)"
                   >
                     Reset
@@ -186,7 +186,7 @@
     <!-- Pagination placeholder -->
     <div
       v-if="requests.length > 0"
-      class="mt-4 text-sm text-gray-500 text-center"
+      class="mt-4 text-sm text-fg-muted text-center"
     >
       Showing {{ requests.length }} requests
     </div>

--- a/frontend/src/components/admin/AdminInvites.vue
+++ b/frontend/src/components/admin/AdminInvites.vue
@@ -6,7 +6,7 @@
 
     <!-- Create Invite Section -->
     <div
-      class="bg-white rounded-lg shadow p-4 sm:p-6 mb-4 sm:mb-6"
+      class="bg-card rounded-lg shadow p-4 sm:p-6 mb-4 sm:mb-6"
       data-testid="create-invite-section"
     >
       <h3 class="text-base sm:text-lg font-semibold mb-3 sm:mb-4">
@@ -20,14 +20,14 @@
       >
         <!-- Invite Type Selection -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2"
+          <label class="block text-sm font-medium text-fg mb-2"
             >Invite Type</label
           >
           <select
             v-model="newInvite.inviteType"
             required
             data-testid="invite-type-select"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">Select type...</option>
             <option v-if="isAdmin" value="club_manager">Club Manager</option>
@@ -44,14 +44,12 @@
             newInvite.inviteType === 'club_fan'
           "
         >
-          <label class="block text-sm font-medium text-gray-700 mb-2"
-            >Club</label
-          >
+          <label class="block text-sm font-medium text-fg mb-2">Club</label>
           <select
             v-model="newInvite.clubId"
             required
             data-testid="invite-club-select"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">Select club...</option>
             <option v-for="club in clubs" :key="club.id" :value="club.id">
@@ -68,14 +66,12 @@
             newInvite.inviteType !== 'club_fan'
           "
         >
-          <label class="block text-sm font-medium text-gray-700 mb-2"
-            >Team</label
-          >
+          <label class="block text-sm font-medium text-fg mb-2">Team</label>
           <select
             v-model="newInvite.teamId"
             required
             data-testid="invite-team-select"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">Select team...</option>
             <option v-for="team in teams" :key="team.id" :value="team.id">
@@ -92,14 +88,14 @@
             newInvite.inviteType !== 'club_fan'
           "
         >
-          <label class="block text-sm font-medium text-gray-700 mb-2"
+          <label class="block text-sm font-medium text-fg mb-2"
             >Age Group</label
           >
           <select
             v-model="newInvite.ageGroupId"
             required
             data-testid="invite-age-group-select"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">Select age group...</option>
             <option
@@ -114,7 +110,7 @@
 
         <!-- Jersey Number (for team_player invites) -->
         <div v-if="newInvite.inviteType === 'team_player'">
-          <label class="block text-sm font-medium text-gray-700 mb-2"
+          <label class="block text-sm font-medium text-fg mb-2"
             >Jersey Number (Optional)</label
           >
           <input
@@ -124,9 +120,9 @@
             max="99"
             placeholder="e.g., 10"
             data-testid="invite-jersey-number-input"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
-          <p class="mt-1 text-xs text-gray-500">
+          <p class="mt-1 text-xs text-fg-muted">
             If provided, a roster entry will be created when the invite is
             accepted.
           </p>
@@ -134,7 +130,7 @@
 
         <!-- Email (Optional) -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2"
+          <label class="block text-sm font-medium text-fg mb-2"
             >Email (Optional)</label
           >
           <input
@@ -142,9 +138,9 @@
             type="email"
             placeholder="Pre-fill email for recipient"
             data-testid="invite-email-input"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
-          <p class="text-xs text-gray-500 mt-1">
+          <p class="text-xs text-fg-muted mt-1">
             If provided, the invite link will be auto-emailed to this address
             once the invite is created.
           </p>
@@ -152,7 +148,7 @@
 
         <!-- Note (Optional) -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2"
+          <label class="block text-sm font-medium text-fg mb-2"
             >Note (Optional)</label
           >
           <input
@@ -161,9 +157,9 @@
             maxlength="500"
             placeholder="Who is this invite for? e.g., John Smith - U13 coach"
             data-testid="invite-note-input"
-            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
-          <p class="mt-1 text-xs text-gray-500">
+          <p class="mt-1 text-xs text-fg-muted">
             Personal reminder — visible only to you, not sent to the recipient.
           </p>
         </div>
@@ -222,9 +218,9 @@
         </div>
 
         <!-- Copy-Ready Invite Message -->
-        <div class="bg-white border border-gray-300 rounded-md p-4 mb-3">
+        <div class="bg-card border border-line rounded-md p-4 mb-3">
           <div class="flex justify-between items-center mb-2">
-            <span class="text-sm font-medium text-gray-700"
+            <span class="text-sm font-medium text-fg"
               >Invite Message (copy and send):</span
             >
             <button
@@ -250,7 +246,7 @@
             </button>
           </div>
           <pre
-            class="text-sm text-gray-800 whitespace-pre-wrap font-sans bg-gray-50 p-3 rounded border border-gray-200"
+            class="text-sm text-fg whitespace-pre-wrap font-sans bg-surface-alt p-3 rounded border border-line"
             >{{ generatedInviteMessage }}</pre
           >
         </div>
@@ -259,7 +255,7 @@
         <button
           @click="copyInviteLink(createdInvite.invite_code)"
           data-testid="copy-invite-link-button"
-          class="text-sm bg-gray-200 hover:bg-gray-300 px-3 py-1 rounded"
+          class="text-sm bg-surface-alt text-fg hover:bg-line px-3 py-1 rounded"
         >
           Copy Link Only
         </button>
@@ -268,7 +264,7 @@
 
     <!-- Existing Invites -->
     <div
-      class="bg-white rounded-lg shadow p-4 sm:p-6"
+      class="bg-card rounded-lg shadow p-4 sm:p-6"
       data-testid="existing-invites-section"
     >
       <h3 class="text-base sm:text-lg font-semibold mb-3 sm:mb-4">
@@ -281,7 +277,7 @@
           v-model="statusFilter"
           @change="fetchInvites"
           data-testid="invite-status-filter"
-          class="w-full sm:w-auto px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="w-full sm:w-auto px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Invites</option>
           <option value="pending">Pending</option>
@@ -295,7 +291,7 @@
         <div
           v-for="invite in invites"
           :key="invite.id"
-          class="border rounded-lg p-3 bg-gray-50"
+          class="border border-line rounded-lg p-3 bg-surface-alt"
         >
           <div class="flex justify-between items-start mb-2">
             <span class="font-mono text-sm font-medium">{{
@@ -314,11 +310,11 @@
           </div>
           <div class="text-sm space-y-1">
             <p>
-              <span class="text-gray-500">Type:</span>
+              <span class="text-fg-muted">Type:</span>
               {{ formatInviteType(invite.invite_type) }}
             </p>
             <p>
-              <span class="text-gray-500">For:</span>
+              <span class="text-fg-muted">For:</span>
               <template v-if="invite.club_id">
                 {{ invite.clubs?.name || 'Club ' + invite.club_id }}
               </template>
@@ -327,19 +323,22 @@
               </template>
             </p>
             <p v-if="invite.used_by_user">
-              <span class="text-gray-500">Used by:</span>
+              <span class="text-fg-muted">Used by:</span>
               {{
                 invite.used_by_user.display_name || invite.used_by_user.username
               }}
             </p>
-            <p v-if="invite.note" class="text-gray-700 text-xs italic">
+            <p v-if="invite.note" class="text-fg text-xs italic">
               {{ invite.note }}
             </p>
-            <p class="text-gray-500 text-xs">
+            <p class="text-fg-muted text-xs">
               {{ formatDate(invite.created_at) }}
             </p>
           </div>
-          <div class="mt-2 pt-2 border-t" v-if="invite.status === 'pending'">
+          <div
+            class="mt-2 pt-2 border-t border-line"
+            v-if="invite.status === 'pending'"
+          >
             <button
               @click="cancelInvite(invite.id)"
               class="text-red-600 hover:text-red-900 text-sm font-medium"
@@ -348,7 +347,7 @@
             </button>
           </div>
         </div>
-        <p v-if="invites.length === 0" class="text-gray-500 text-center py-4">
+        <p v-if="invites.length === 0" class="text-fg-muted text-center py-4">
           No invites found
         </p>
       </div>
@@ -359,60 +358,60 @@
         data-testid="invites-table-container"
       >
         <table
-          class="min-w-full divide-y divide-gray-200"
+          class="min-w-full divide-y divide-line"
           data-testid="invites-table"
         >
-          <thead class="bg-gray-50">
+          <thead class="bg-surface-alt">
             <tr>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Code
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Type
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Club/Team
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Email Sent To
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Status
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Used By
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Note
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Created
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Actions
               </th>
             </tr>
           </thead>
           <tbody
-            class="bg-white divide-y divide-gray-200"
+            class="bg-card divide-y divide-line"
             data-testid="invites-tbody"
           >
             <tr
@@ -445,7 +444,7 @@
                 <span
                   v-if="invite.email"
                   :title="`Invite email auto-sent to ${invite.email}`"
-                  class="inline-flex items-center gap-1 text-gray-700"
+                  class="inline-flex items-center gap-1 text-fg"
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -463,7 +462,7 @@
                   </svg>
                   {{ invite.email }}
                 </span>
-                <span v-else class="text-gray-300">—</span>
+                <span v-else class="text-fg-muted">—</span>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <span
@@ -478,25 +477,25 @@
                   {{ invite.status }}
                 </span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-fg">
                 <template v-if="invite.used_by_user">
                   {{
                     invite.used_by_user.display_name ||
                     invite.used_by_user.username
                   }}
                 </template>
-                <span v-else class="text-gray-300">-</span>
+                <span v-else class="text-fg-muted">-</span>
               </td>
-              <td class="px-6 py-4 text-sm text-gray-500 max-w-xs">
+              <td class="px-6 py-4 text-sm text-fg-muted max-w-xs">
                 <span
                   v-if="invite.note"
                   :title="invite.note"
                   class="truncate block"
                   >{{ invite.note }}</span
                 >
-                <span v-else class="text-gray-300">-</span>
+                <span v-else class="text-fg-muted">-</span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
                 {{ formatDate(invite.created_at) }}
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm">
@@ -535,13 +534,13 @@
     >
       <div class="min-h-full flex items-start justify-center p-4 sm:p-8">
         <div
-          class="relative w-full max-w-2xl bg-white rounded-lg shadow-2xl"
+          class="relative w-full max-w-2xl bg-card rounded-lg shadow-2xl"
           @click.stop
         >
           <button
             type="button"
             aria-label="Close invite details"
-            class="absolute top-3 right-3 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+            class="absolute top-3 right-3 inline-flex items-center justify-center w-8 h-8 rounded-full text-fg-muted hover:text-fg hover:bg-surface-alt"
             @click="closeInviteDetail"
           >
             <svg
@@ -560,13 +559,11 @@
             </svg>
           </button>
 
-          <div class="px-6 py-5 border-b">
-            <h3 class="text-lg font-semibold text-gray-900">
-              Invitation details
-            </h3>
-            <p class="text-xs text-gray-500 mt-1">
+          <div class="px-6 py-5 border-b border-line">
+            <h3 class="text-lg font-semibold text-fg">Invitation details</h3>
+            <p class="text-xs text-fg-muted mt-1">
               Code:
-              <span class="font-mono text-gray-700">
+              <span class="font-mono text-fg">
                 {{ selectedInvite.invite_code }}
               </span>
             </p>
@@ -577,18 +574,18 @@
           >
             <div>
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Type
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 {{ formatInviteType(selectedInvite.invite_type) }}
               </dd>
             </div>
 
             <div>
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Status
               </dt>
@@ -611,11 +608,11 @@
 
             <div>
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Club / Team
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 <template v-if="selectedInvite.club_id">
                   {{
                     selectedInvite.clubs?.name ||
@@ -626,104 +623,104 @@
                   {{ selectedInvite.teams?.name }} —
                   {{ selectedInvite.age_groups?.name }}
                 </template>
-                <span v-else class="text-gray-400">—</span>
+                <span v-else class="text-fg-muted">—</span>
               </dd>
             </div>
 
             <div>
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Email Sent To
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 <span v-if="selectedInvite.email">
                   {{ selectedInvite.email }}
                 </span>
-                <span v-else class="text-gray-400">— (none provided)</span>
+                <span v-else class="text-fg-muted">— (none provided)</span>
               </dd>
             </div>
 
             <div>
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Used By
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 <template v-if="selectedInvite.used_by_user">
                   {{
                     selectedInvite.used_by_user.display_name ||
                     selectedInvite.used_by_user.username
                   }}
                 </template>
-                <span v-else class="text-gray-400">— (not redeemed)</span>
+                <span v-else class="text-fg-muted">— (not redeemed)</span>
               </dd>
             </div>
 
             <div>
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Created
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 {{ formatDate(selectedInvite.created_at) }}
               </dd>
             </div>
 
             <div v-if="selectedInvite.expires_at">
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Expires
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 {{ formatDate(selectedInvite.expires_at) }}
               </dd>
             </div>
 
             <div v-if="selectedInvite.jersey_number" class="sm:col-span-1">
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Jersey #
               </dt>
-              <dd class="mt-1 text-gray-900">
+              <dd class="mt-1 text-fg">
                 {{ selectedInvite.jersey_number }}
               </dd>
             </div>
 
             <div class="sm:col-span-2">
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Note
               </dt>
               <dd
-                class="mt-1 text-gray-900 whitespace-pre-wrap break-words"
+                class="mt-1 text-fg whitespace-pre-wrap break-words"
                 data-testid="invite-detail-note"
               >
                 <template v-if="selectedInvite.note">
                   {{ selectedInvite.note }}
                 </template>
-                <span v-else class="text-gray-400">— (no note)</span>
+                <span v-else class="text-fg-muted">— (no note)</span>
               </dd>
             </div>
 
-            <div class="sm:col-span-2 pt-2 border-t">
+            <div class="sm:col-span-2 pt-2 border-t border-line">
               <dt
-                class="text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Redemption link
               </dt>
-              <dd class="mt-1 text-gray-700 break-all font-mono text-xs">
+              <dd class="mt-1 text-fg break-all font-mono text-xs">
                 {{ currentOrigin }}/?code={{ selectedInvite.invite_code }}
               </dd>
             </div>
           </dl>
 
-          <div class="px-6 py-4 border-t flex justify-end gap-2">
+          <div class="px-6 py-4 border-t border-line flex justify-end gap-2">
             <button
               v-if="selectedInvite.status === 'pending'"
               type="button"

--- a/frontend/src/components/admin/AdminLeagues.vue
+++ b/frontend/src/components/admin/AdminLeagues.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Leagues Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Leagues Management</h3>
       <button
         @click="showAddModal = true"
         class="bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium"
@@ -30,57 +30,55 @@
       v-else
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Name
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Description
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Sport
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Divisions Count
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Active
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Created
             </th>
             <th
-              class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr v-for="league in leagues" :key="league.id">
-            <td
-              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ league.name }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ league.description || 'N/A' }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 :class="[
                   'inline-flex px-2 py-1 text-xs font-semibold rounded-full',
@@ -92,10 +90,10 @@
                 {{ league.sport_type === 'futsal' ? 'Futsal' : 'Soccer' }}
               </span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ getDivisionCount(league.id) }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 :class="[
                   'inline-flex px-2 py-1 text-xs font-semibold rounded-full',
@@ -107,7 +105,7 @@
                 {{ league.is_active ? 'Active' : 'Inactive' }}
               </span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatDate(league.created_at) }}
             </td>
             <td
@@ -115,7 +113,7 @@
             >
               <button
                 @click="editLeague(league)"
-                class="text-brand-600 hover:text-brand-900 mr-3"
+                class="text-brand-600 dark:text-brand-300 hover:text-brand-900 dark:hover:text-brand-200 mr-3"
               >
                 Edit
               </button>
@@ -149,7 +147,7 @@
     >
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             {{ showEditModal ? 'Edit League' : 'Add New League' }}
           </h3>
 
@@ -157,37 +155,37 @@
             @submit.prevent="showEditModal ? updateLeague() : createLeague()"
           >
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >League Name</label
               >
               <input
                 v-model="formData.name"
                 type="text"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., Homegrown, ECNL, MLS Next..."
               />
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Description</label
               >
               <textarea
                 v-model="formData.description"
                 rows="3"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Description of the league..."
               ></textarea>
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Sport Type</label
               >
               <select
                 v-model="formData.sport_type"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option value="soccer">Soccer (11v11)</option>
                 <option value="futsal">Futsal (5v5)</option>
@@ -199,11 +197,11 @@
                 <input
                   v-model="formData.is_active"
                   type="checkbox"
-                  class="h-4 w-4 text-brand-600 focus:ring-brand-500 border-gray-300 rounded"
+                  class="h-4 w-4 text-brand-600 focus:ring-brand-500 border-line rounded"
                 />
-                <span class="ml-2 text-sm text-gray-700">Active League</span>
+                <span class="ml-2 text-sm text-fg">Active League</span>
               </label>
-              <p class="mt-1 text-xs text-gray-500">
+              <p class="mt-1 text-xs text-fg-muted">
                 Inactive leagues won't be available for selection
               </p>
             </div>
@@ -212,7 +210,7 @@
               <button
                 type="button"
                 @click="closeModals"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -435,7 +433,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 500px;
   width: 90%;

--- a/frontend/src/components/admin/AdminMatches.vue
+++ b/frontend/src/components/admin/AdminMatches.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Matches Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Matches Management</h3>
       <div class="flex space-x-3">
         <!-- Filters -->
         <select
           v-model="filterSeason"
           @change="fetchMatches"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Seasons</option>
           <option v-for="season in seasons" :key="season.id" :value="season.id">
@@ -18,7 +18,7 @@
         <select
           v-model="filterMatchType"
           @change="fetchMatches"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Match Types</option>
           <option
@@ -33,7 +33,7 @@
         <select
           v-model="filterLeague"
           @change="fetchMatches"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Leagues</option>
           <option v-for="league in leagues" :key="league.id" :value="league.id">
@@ -44,7 +44,7 @@
         <select
           v-model="filterAgeGroup"
           @change="fetchMatches"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">All Age Groups</option>
           <option
@@ -78,101 +78,97 @@
       v-else
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               Date
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-20"
             >
               Time
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Home Team
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Away Team
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-20"
             >
               Score
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-20"
             >
               Type
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               League
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               Season
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-20"
             >
               Age Group
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-24"
             >
               Status
             </th>
             <th
-              class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32"
+              class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-32"
             >
               Match ID
             </th>
             <th
-              class="px-4 py-3 text-right text-xs font-medium text-gray-500 bg-gray-50 uppercase tracking-wider w-44 sticky right-0"
+              class="px-4 py-3 text-right text-xs font-medium text-fg-muted bg-surface-alt uppercase tracking-wider w-44 sticky right-0"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr v-for="match in matches" :key="match.id">
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg">
               {{ formatDate(match.match_date) }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span v-if="formatLocalTime(match.scheduled_kickoff)">
                 {{ formatLocalTime(match.scheduled_kickoff) }}
               </span>
-              <span v-else class="text-gray-400 italic">-</span>
+              <span v-else class="text-fg-muted italic">-</span>
             </td>
-            <td
-              class="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-4 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ match.home_team_name }}
             </td>
-            <td
-              class="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-4 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ match.away_team_name }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 v-if="match.home_score !== null && match.away_score !== null"
               >
                 {{ match.home_score }} - {{ match.away_score }}
               </span>
-              <span v-else class="text-gray-400 italic">Not played</span>
+              <span v-else class="text-fg-muted italic">Not played</span>
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
                 :class="getMatchTypeClass(match.match_type_name)"
@@ -180,7 +176,7 @@
                 {{ match.match_type_name }}
               </span>
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
                 :class="getLeagueClass(match.league_name)"
@@ -188,13 +184,13 @@
                 {{ match.league_name }}
               </span>
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ match.season_name }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ match.age_group_name }}
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
                 :class="getStatusClass(match.status)"
@@ -202,7 +198,7 @@
                 {{ getStatusDisplay(match.status) }}
               </span>
             </td>
-            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-4 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 v-if="match.match_id"
                 class="font-mono text-xs"
@@ -210,10 +206,10 @@
               >
                 {{ match.match_id }}
               </span>
-              <span v-else class="text-gray-400 italic text-xs">-</span>
+              <span v-else class="text-fg-muted italic text-xs">-</span>
             </td>
             <td
-              class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium bg-gray-50 w-44 sticky right-0"
+              class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium bg-surface-alt w-44 sticky right-0"
             >
               <div class="flex gap-2 justify-end items-center">
                 <button
@@ -237,7 +233,7 @@
 
       <!-- Empty state -->
       <div v-if="!loading && matches.length === 0" class="text-center py-12">
-        <div class="text-gray-500">No matches found</div>
+        <div class="text-fg-muted">No matches found</div>
       </div>
     </div>
 
@@ -245,40 +241,40 @@
     <div v-if="showEditModal" class="modal-overlay" @click="closeEditModal">
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">Edit Match</h3>
+          <h3 class="text-lg font-medium text-fg mb-4">Edit Match</h3>
 
           <form @submit.prevent="updateMatch()">
             <div class="grid grid-cols-3 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Date</label
                 >
                 <input
                   v-model="editFormData.match_date"
                   type="date"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Kickoff Time
-                  <span class="text-gray-400 text-xs">(optional)</span></label
+                  <span class="text-fg-muted text-xs">(optional)</span></label
                 >
                 <input
                   v-model="editFormData.kickoff_time"
                   type="time"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Match Type</label
                 >
                 <select
                   v-model="editFormData.match_type_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option
                     v-for="matchType in matchTypes"
@@ -293,13 +289,13 @@
 
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Home Team</label
                 >
                 <select
                   v-model="editFormData.home_team_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option v-for="team in teams" :key="team.id" :value="team.id">
                     {{ team.name }}
@@ -307,13 +303,13 @@
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Away Team</label
                 >
                 <select
                   v-model="editFormData.away_team_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option v-for="team in teams" :key="team.id" :value="team.id">
                     {{ team.name }}
@@ -324,26 +320,26 @@
 
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Home Score</label
                 >
                 <input
                   v-model.number="editFormData.home_score"
                   type="number"
                   min="0"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="Leave empty if not played"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Away Score</label
                 >
                 <input
                   v-model.number="editFormData.away_score"
                   type="number"
                   min="0"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="Leave empty if not played"
                 />
               </div>
@@ -351,13 +347,13 @@
 
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Season</label
                 >
                 <select
                   v-model="editFormData.season_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option
                     v-for="season in seasons"
@@ -369,13 +365,13 @@
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Age Group</label
                 >
                 <select
                   v-model="editFormData.age_group_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option
                     v-for="ageGroup in ageGroups"
@@ -389,16 +385,16 @@
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Match ID
-                <span class="text-gray-400 text-xs"
+                <span class="text-fg-muted text-xs"
                   >(optional - for externally scraped matches)</span
                 ></label
               >
               <input
                 v-model="editFormData.match_id"
                 type="text"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 font-mono text-sm"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 font-mono text-sm"
                 placeholder="e.g., external-match-12345"
               />
             </div>
@@ -407,7 +403,7 @@
               <button
                 type="button"
                 @click="closeEditModal"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -789,7 +785,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 800px;
   width: 90%;

--- a/frontend/src/components/admin/AdminPlayers.vue
+++ b/frontend/src/components/admin/AdminPlayers.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Players Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Players Management</h3>
     </div>
 
     <!-- Search and Filters -->
@@ -11,14 +11,14 @@
           v-model="searchQuery"
           type="text"
           placeholder="Search by name or email..."
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           @input="debouncedSearch"
         />
       </div>
       <div class="w-48">
         <select
           v-model="selectedClubId"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           @change="fetchPlayers"
         >
           <option :value="null">All Clubs</option>
@@ -30,7 +30,7 @@
       <div class="w-48">
         <select
           v-model="selectedTeamId"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
           @change="fetchPlayers"
         >
           <option :value="null">All Teams</option>
@@ -61,42 +61,42 @@
       v-else-if="!loading"
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Player
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Email
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Jersey #
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Current Teams
             </th>
             <th
-              class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr v-for="player in players" :key="player.id">
             <td class="px-6 py-4 whitespace-nowrap">
               <div class="flex items-center">
                 <div
-                  class="h-10 w-10 flex-shrink-0 rounded-full bg-gray-200 flex items-center justify-center"
+                  class="h-10 w-10 flex-shrink-0 rounded-full bg-surface-alt flex items-center justify-center"
                 >
                   <img
                     v-if="player.photo_1_url"
@@ -104,24 +104,24 @@
                     class="h-10 w-10 rounded-full object-cover"
                     alt=""
                   />
-                  <span v-else class="text-gray-500 text-sm">{{
+                  <span v-else class="text-fg-muted text-sm">{{
                     getInitials(player.display_name)
                   }}</span>
                 </div>
                 <div class="ml-4">
-                  <div class="text-sm font-medium text-gray-900">
+                  <div class="text-sm font-medium text-fg">
                     {{ player.display_name || 'Unknown' }}
                   </div>
                 </div>
               </div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ player.email || '-' }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ player.player_number || '-' }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               <div class="flex flex-wrap gap-1">
                 <span
                   v-for="assignment in player.current_teams"
@@ -134,7 +134,7 @@
                   v-if="
                     !player.current_teams || player.current_teams.length === 0
                   "
-                  class="text-gray-400 italic"
+                  class="text-fg-muted italic"
                 >
                   No team assigned
                 </span>
@@ -145,7 +145,7 @@
             >
               <button
                 @click="openEditModal(player)"
-                class="text-brand-600 hover:text-brand-900 mr-3"
+                class="text-brand-600 dark:text-brand-300 hover:text-brand-900 dark:hover:text-brand-200 mr-3"
               >
                 Edit
               </button>
@@ -158,7 +158,7 @@
             </td>
           </tr>
           <tr v-if="players.length === 0">
-            <td colspan="5" class="px-6 py-8 text-center text-gray-500">
+            <td colspan="5" class="px-6 py-8 text-center text-fg-muted">
               No players found
             </td>
           </tr>
@@ -168,20 +168,20 @@
       <!-- Pagination -->
       <div
         v-if="totalCount > 0"
-        class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6"
+        class="bg-card px-4 py-3 flex items-center justify-between border-t border-line sm:px-6"
       >
         <div class="flex-1 flex justify-between sm:hidden">
           <button
             @click="previousPage"
             :disabled="offset === 0"
-            class="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+            class="relative inline-flex items-center px-4 py-2 border border-line text-sm font-medium rounded-md text-fg bg-card hover:bg-surface-alt disabled:opacity-50"
           >
             Previous
           </button>
           <button
             @click="nextPage"
             :disabled="offset + limit >= totalCount"
-            class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+            class="ml-3 relative inline-flex items-center px-4 py-2 border border-line text-sm font-medium rounded-md text-fg bg-card hover:bg-surface-alt disabled:opacity-50"
           >
             Next
           </button>
@@ -190,7 +190,7 @@
           class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between"
         >
           <div>
-            <p class="text-sm text-gray-700">
+            <p class="text-sm text-fg">
               Showing
               <span class="font-medium">{{ offset + 1 }}</span>
               to
@@ -210,14 +210,14 @@
               <button
                 @click="previousPage"
                 :disabled="offset === 0"
-                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-line bg-card text-sm font-medium text-fg-muted hover:bg-surface-alt disabled:opacity-50"
               >
                 Previous
               </button>
               <button
                 @click="nextPage"
                 :disabled="offset + limit >= totalCount"
-                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-line bg-card text-sm font-medium text-fg-muted hover:bg-surface-alt disabled:opacity-50"
               >
                 Next
               </button>
@@ -234,24 +234,24 @@
       @click="closeModals"
     >
       <div
-        class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white"
+        class="relative top-20 mx-auto p-5 border border-line w-96 shadow-lg rounded-md bg-card"
         @click.stop
       >
         <div class="mt-3">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">Edit Player</h3>
+          <h3 class="text-lg font-medium text-fg mb-4">Edit Player</h3>
           <form @submit.prevent="updatePlayer">
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Display Name</label
               >
               <input
                 v-model="editForm.display_name"
                 type="text"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Jersey Number</label
               >
               <input
@@ -259,11 +259,11 @@
                 type="number"
                 min="1"
                 max="99"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Positions</label
               >
               <div class="flex flex-wrap gap-2">
@@ -276,9 +276,9 @@
                     type="checkbox"
                     :value="pos"
                     v-model="editForm.positions"
-                    class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                    class="rounded border-line text-brand-600 focus:ring-brand-500"
                   />
-                  <span class="ml-2 text-sm text-gray-700">{{ pos }}</span>
+                  <span class="ml-2 text-sm text-fg">{{ pos }}</span>
                 </label>
               </div>
             </div>
@@ -286,7 +286,7 @@
               <button
                 type="button"
                 @click="closeModals"
-                class="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+                class="px-4 py-2 bg-surface-alt text-fg rounded-md hover:bg-line"
               >
                 Cancel
               </button>
@@ -310,17 +310,17 @@
       @click="closeModals"
     >
       <div
-        class="relative top-20 mx-auto p-5 border w-[500px] shadow-lg rounded-md bg-white"
+        class="relative top-20 mx-auto p-5 border border-line w-[500px] shadow-lg rounded-md bg-card"
         @click.stop
       >
         <div class="mt-3">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             Manage Teams for {{ selectedPlayer?.display_name }}
           </h3>
 
           <!-- Current Team Assignments -->
           <div class="mb-6">
-            <h4 class="text-sm font-medium text-gray-700 mb-2">
+            <h4 class="text-sm font-medium text-fg mb-2">
               Current Team Assignments
             </h4>
             <div
@@ -330,13 +330,13 @@
               <div
                 v-for="assignment in selectedPlayer.current_teams"
                 :key="assignment.id"
-                class="flex items-center justify-between p-2 bg-gray-50 rounded"
+                class="flex items-center justify-between p-2 bg-surface-alt rounded"
               >
                 <div>
                   <span class="font-medium">{{
                     assignment.team?.name || 'Unknown'
                   }}</span>
-                  <span class="text-gray-500 text-sm ml-2">
+                  <span class="text-fg-muted text-sm ml-2">
                     ({{ assignment.season?.name || 'Unknown Season' }})
                   </span>
                 </div>
@@ -348,24 +348,24 @@
                 </button>
               </div>
             </div>
-            <div v-else class="text-gray-500 text-sm">
+            <div v-else class="text-fg-muted text-sm">
               No current assignments
             </div>
           </div>
 
           <!-- Add New Assignment -->
-          <div class="border-t pt-4">
-            <h4 class="text-sm font-medium text-gray-700 mb-2">
+          <div class="border-t border-line pt-4">
+            <h4 class="text-sm font-medium text-fg mb-2">
               Add Team Assignment
             </h4>
             <form @submit.prevent="addTeamAssignment">
               <div class="grid grid-cols-2 gap-4 mb-4">
                 <div>
-                  <label class="block text-sm text-gray-600 mb-1">Season</label>
+                  <label class="block text-sm text-fg-muted mb-1">Season</label>
                   <select
                     v-model="assignmentForm.season_id"
                     required
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   >
                     <option :value="null" disabled>Select season</option>
                     <option
@@ -378,11 +378,11 @@
                   </select>
                 </div>
                 <div>
-                  <label class="block text-sm text-gray-600 mb-1">Team</label>
+                  <label class="block text-sm text-fg-muted mb-1">Team</label>
                   <select
                     v-model="assignmentForm.team_id"
                     required
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   >
                     <option :value="null" disabled>Select team</option>
                     <option
@@ -397,7 +397,7 @@
               </div>
               <div class="grid grid-cols-2 gap-4 mb-4">
                 <div>
-                  <label class="block text-sm text-gray-600 mb-1"
+                  <label class="block text-sm text-fg-muted mb-1"
                     >Jersey Number</label
                   >
                   <input
@@ -405,7 +405,7 @@
                     type="number"
                     min="1"
                     max="99"
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div class="flex items-end">
@@ -413,9 +413,9 @@
                     <input
                       type="checkbox"
                       v-model="assignmentForm.is_current"
-                      class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                      class="rounded border-line text-brand-600 focus:ring-brand-500"
                     />
-                    <span class="ml-2 text-sm text-gray-700">Current team</span>
+                    <span class="ml-2 text-sm text-fg">Current team</span>
                   </label>
                 </div>
               </div>
@@ -423,7 +423,7 @@
                 <button
                   type="button"
                   @click="closeModals"
-                  class="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+                  class="px-4 py-2 bg-surface-alt text-fg rounded-md hover:bg-line"
                 >
                   Close
                 </button>

--- a/frontend/src/components/admin/AdminPlayoffs.vue
+++ b/frontend/src/components/admin/AdminPlayoffs.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Playoffs Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Playoffs Management</h3>
       <div class="flex space-x-3">
         <!-- League selector -->
         <select
           v-model="selectedLeague"
           @change="onLeagueChange"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">Select League</option>
           <option v-for="league in leagues" :key="league.id" :value="league.id">
@@ -19,7 +19,7 @@
         <select
           v-model="selectedSeason"
           @change="fetchBracket"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">Select Season</option>
           <option v-for="season in seasons" :key="season.id" :value="season.id">
@@ -31,7 +31,7 @@
         <select
           v-model="selectedAgeGroup"
           @change="fetchBracket"
-          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">Select Age Group</option>
           <option v-for="ag in ageGroups" :key="ag.id" :value="ag.id">
@@ -69,7 +69,7 @@
       v-if="
         !loading && (!selectedLeague || !selectedSeason || !selectedAgeGroup)
       "
-      class="text-center py-12 text-gray-500"
+      class="text-center py-12 text-fg-muted"
     >
       Select a league, season, and age group to manage playoffs.
     </div>
@@ -80,27 +80,27 @@
     >
       <!-- No bracket exists - show configuration form -->
       <div v-if="bracket.length === 0" class="py-8">
-        <p class="text-gray-500 mb-6 text-center">
+        <p class="text-fg-muted mb-6 text-center">
           No playoff bracket exists for this selection.
         </p>
 
         <div v-if="divisions.length >= 2" class="max-w-lg mx-auto space-y-5">
-          <h4 class="text-sm font-semibold text-gray-700 mb-3">
+          <h4 class="text-sm font-semibold text-fg mb-3">
             Bracket Configuration
           </h4>
 
           <!-- Bracket Type Selection -->
           <div>
-            <label class="block text-sm text-gray-600 mb-1">Bracket Type</label>
+            <label class="block text-sm text-fg-muted mb-1">Bracket Type</label>
             <select
               v-model="configBracketType"
-              class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <option v-for="bt in bracketTypes" :key="bt.key" :value="bt.key">
                 {{ bt.name }}
               </option>
             </select>
-            <p class="mt-1 text-xs text-gray-500">
+            <p class="mt-1 text-xs text-fg-muted">
               {{ selectedBracketType?.description }}
             </p>
           </div>
@@ -108,10 +108,10 @@
           <!-- Division Selection -->
           <div class="grid grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm text-gray-600 mb-1">Division A</label>
+              <label class="block text-sm text-fg-muted mb-1">Division A</label>
               <select
                 v-model="configDivisionA"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option value="">Select...</option>
                 <option
@@ -125,10 +125,10 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm text-gray-600 mb-1">Division B</label>
+              <label class="block text-sm text-fg-muted mb-1">Division B</label>
               <select
                 v-model="configDivisionB"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option value="">Select...</option>
                 <option
@@ -145,38 +145,38 @@
 
           <!-- Start Date -->
           <div>
-            <label class="block text-sm text-gray-600 mb-1"
+            <label class="block text-sm text-fg-muted mb-1"
               >First Round Date (Quarterfinals)</label
             >
             <input
               type="date"
               v-model="configStartDate"
-              class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
             />
           </div>
 
           <!-- Tier Names -->
           <div class="grid grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm text-gray-600 mb-1"
+              <label class="block text-sm text-fg-muted mb-1"
                 >Upper Bracket Name (Positions 1-4)</label
               >
               <input
                 type="text"
                 v-model="configTier1Name"
                 placeholder="Gold Cup"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
             <div>
-              <label class="block text-sm text-gray-600 mb-1"
+              <label class="block text-sm text-fg-muted mb-1"
                 >Lower Bracket Name (Positions 5-8)</label
               >
               <input
                 type="text"
                 v-model="configTier2Name"
                 placeholder="Silver Cup"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
               />
             </div>
           </div>
@@ -212,14 +212,16 @@
 
         <!-- Bracket tiers -->
         <div v-for="tier in bracketTiers" :key="tier.key" class="mb-8">
-          <h4 class="text-md font-semibold text-gray-700 mb-3 border-b pb-1">
+          <h4
+            class="text-md font-semibold text-fg mb-3 border-b border-line pb-1"
+          >
             {{ tier.label }}
           </h4>
           <div class="bracket-grid">
             <!-- Quarterfinals -->
             <div class="bracket-round">
               <h4
-                class="text-sm font-semibold text-gray-500 uppercase mb-3 text-center"
+                class="text-sm font-semibold text-fg-muted uppercase mb-3 text-center"
               >
                 Quarterfinals
               </h4>
@@ -238,7 +240,7 @@
             <!-- Semifinals -->
             <div class="bracket-round">
               <h4
-                class="text-sm font-semibold text-gray-500 uppercase mb-3 text-center"
+                class="text-sm font-semibold text-fg-muted uppercase mb-3 text-center"
               >
                 Semifinals
               </h4>
@@ -257,7 +259,7 @@
             <!-- Final -->
             <div class="bracket-round">
               <h4
-                class="text-sm font-semibold text-gray-500 uppercase mb-3 text-center"
+                class="text-sm font-semibold text-fg-muted uppercase mb-3 text-center"
               >
                 Final
               </h4>
@@ -301,26 +303,26 @@
       </div>
 
       <!-- Configuration Details -->
-      <div class="bg-gray-50 rounded-md p-4 text-sm space-y-2">
+      <div class="bg-surface-alt rounded-md p-4 text-sm space-y-2">
         <div class="grid grid-cols-2 gap-x-4">
-          <div class="text-gray-500">Division A:</div>
+          <div class="text-fg-muted">Division A:</div>
           <div class="font-medium">{{ getDivisionName(configDivisionA) }}</div>
         </div>
         <div class="grid grid-cols-2 gap-x-4">
-          <div class="text-gray-500">Division B:</div>
+          <div class="text-fg-muted">Division B:</div>
           <div class="font-medium">{{ getDivisionName(configDivisionB) }}</div>
         </div>
         <div class="grid grid-cols-2 gap-x-4">
-          <div class="text-gray-500">First Round Date:</div>
+          <div class="text-fg-muted">First Round Date:</div>
           <div class="font-medium">{{ configStartDate }}</div>
         </div>
-        <div class="border-t border-gray-200 my-2"></div>
+        <div class="border-t border-line my-2"></div>
         <div class="grid grid-cols-2 gap-x-4">
-          <div class="text-gray-500">Upper Bracket (1-4):</div>
+          <div class="text-fg-muted">Upper Bracket (1-4):</div>
           <div class="font-medium">{{ configTier1Name || 'Gold Cup' }}</div>
         </div>
         <div class="grid grid-cols-2 gap-x-4">
-          <div class="text-gray-500">Lower Bracket (5-8):</div>
+          <div class="text-fg-muted">Lower Bracket (5-8):</div>
           <div class="font-medium">{{ configTier2Name || 'Silver Cup' }}</div>
         </div>
       </div>

--- a/frontend/src/components/admin/AdminSeasons.vue
+++ b/frontend/src/components/admin/AdminSeasons.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Seasons Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Seasons Management</h3>
       <button
         @click="showAddModal = true"
         class="bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium"
@@ -30,46 +30,44 @@
       v-else
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
     >
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Name
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Start Date
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               End Date
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               data-testid="matches-count-header"
             >
               Matches Count
             </th>
             <th
-              class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-card divide-y divide-line">
           <tr
             v-for="season in seasons"
             :key="season.id"
             :class="{ 'bg-brand-50': isCurrentSeason(season) }"
           >
-            <td
-              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-            >
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-fg">
               {{ season.name }}
               <span
                 v-if="isCurrentSeason(season)"
@@ -78,14 +76,14 @@
                 Current
               </span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatDate(season.start_date) }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               {{ formatDate(season.end_date) }}
             </td>
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"
+              class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted"
               :data-testid="`matches-count-${season.id}`"
             >
               {{ getMatchesCount(season.id) }}
@@ -95,7 +93,7 @@
             >
               <button
                 @click="editSeason(season)"
-                class="text-brand-600 hover:text-brand-900 mr-3"
+                class="text-brand-600 dark:text-brand-300 hover:text-brand-900 dark:hover:text-brand-200 mr-3"
               >
                 Edit
               </button>
@@ -124,7 +122,7 @@
     >
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             {{ showEditModal ? 'Edit Season' : 'Add New Season' }}
           </h3>
 
@@ -132,39 +130,39 @@
             @submit.prevent="showEditModal ? updateSeason() : createSeason()"
           >
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Season Name</label
               >
               <input
                 v-model="formData.name"
                 type="text"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., 2024-2025, 2025-2026..."
               />
             </div>
 
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Start Date</label
                 >
                 <input
                   v-model="formData.start_date"
                   type="date"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >End Date</label
                 >
                 <input
                   v-model="formData.end_date"
                   type="date"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
             </div>
@@ -173,7 +171,7 @@
               <button
                 type="button"
                 @click="closeModals"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -395,7 +393,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 500px;
   width: 90%;

--- a/frontend/src/components/admin/AdminTeamMatchTypes.vue
+++ b/frontend/src/components/admin/AdminTeamMatchTypes.vue
@@ -1,43 +1,41 @@
 <template>
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <h2 class="text-2xl font-bold mb-6">
       Manage Team Match Type Participation
     </h2>
 
     <!-- Add Team Section -->
-    <div class="mb-8 p-4 border border-gray-200 rounded-lg">
+    <div class="mb-8 p-4 border border-line rounded-lg">
       <h3 class="text-lg font-semibold mb-4">Add New Team</h3>
       <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-fg mb-1"
             >Team Name</label
           >
           <input
             v-model="newTeam.name"
             type="text"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500"
+            class="block w-full rounded-md bg-card text-fg border-line shadow-sm focus:border-brand-500 focus:ring-brand-500"
             placeholder="e.g., Visiting Club ABC"
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
-            >City</label
-          >
+          <label class="block text-sm font-medium text-fg mb-1">City</label>
           <input
             v-model="newTeam.city"
             type="text"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500"
+            class="block w-full rounded-md bg-card text-fg border-line shadow-sm focus:border-brand-500 focus:ring-brand-500"
             placeholder="e.g., Toronto"
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-fg mb-1"
             >Team Type</label
           >
           <select
             v-model="newTeam.teamType"
             @change="onTeamTypeChange"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500"
+            class="block w-full rounded-md bg-card text-fg border-line shadow-sm focus:border-brand-500 focus:ring-brand-500"
           >
             <option value="">Select Team Type</option>
             <option value="league">League Team</option>
@@ -46,12 +44,12 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-fg mb-1"
             >Age Group</label
           >
           <select
             v-model="newTeam.ageGroupId"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500"
+            class="block w-full rounded-md bg-card text-fg border-line shadow-sm focus:border-brand-500 focus:ring-brand-500"
           >
             <option value="">Select Age Group</option>
             <option
@@ -64,9 +62,9 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">
+          <label class="block text-sm font-medium text-fg mb-1">
             Match Types
-            <span class="text-xs text-gray-500"
+            <span class="text-xs text-fg-muted"
               >(auto-selected based on team type)</span
             >
           </label>
@@ -80,7 +78,7 @@
                 type="checkbox"
                 :value="matchType.id"
                 v-model="newTeam.matchTypeIds"
-                class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                class="rounded border-line text-brand-600 focus:ring-brand-500"
               />
               <span class="ml-2">{{ matchType.name }}</span>
             </label>
@@ -95,7 +93,7 @@
           !newTeam.teamType ||
           newTeam.matchTypeIds.length === 0
         "
-        class="mt-4 bg-brand-500 text-white px-4 py-2 rounded-md hover:bg-brand-600 disabled:bg-gray-300"
+        class="mt-4 bg-brand-500 text-white px-4 py-2 rounded-md hover:bg-brand-600 disabled:bg-line"
       >
         Add
         {{
@@ -115,12 +113,12 @@
       <!-- Filters -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-fg mb-1"
             >Filter by Age Group</label
           >
           <select
             v-model="filterAgeGroup"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500"
+            class="block w-full rounded-md bg-card text-fg border-line shadow-sm focus:border-brand-500 focus:ring-brand-500"
           >
             <option value="">All Age Groups</option>
             <option
@@ -133,12 +131,12 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-fg mb-1"
             >Filter by Match Type</label
           >
           <select
             v-model="filterMatchType"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500"
+            class="block w-full rounded-md bg-card text-fg border-line shadow-sm focus:border-brand-500 focus:ring-brand-500"
           >
             <option value="">All Match Types</option>
             <option
@@ -162,47 +160,47 @@
 
       <!-- Teams Table -->
       <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
+        <table class="min-w-full divide-y divide-line">
+          <thead class="bg-surface-alt">
             <tr>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Team
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 City
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Age Groups
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Match Types
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
+          <tbody class="bg-card divide-y divide-line">
             <tr v-for="team in filteredTeams" :key="team.id">
               <td
-                class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
+                class="px-6 py-4 whitespace-nowrap text-sm font-medium text-fg"
               >
                 {{ team.name }}
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
                 {{ team.city }}
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
                 <span
                   v-for="ageGroup in team.age_groups"
                   :key="ageGroup.id"
@@ -211,7 +209,7 @@
                   {{ ageGroup.name }}
                 </span>
               </td>
-              <td class="px-6 py-4 text-sm text-gray-500">
+              <td class="px-6 py-4 text-sm text-fg-muted">
                 <div class="space-y-1">
                   <div v-for="ageGroup in team.age_groups" :key="ageGroup.id">
                     <span class="font-medium">{{ ageGroup.name }}:</span>
@@ -222,7 +220,7 @@
                       :class="
                         teamCanParticipate(team.id, matchType.id, ageGroup.id)
                           ? 'bg-green-100 text-green-800'
-                          : 'bg-gray-100 text-gray-500'
+                          : 'bg-surface-alt text-fg-muted'
                       "
                     >
                       {{ matchType.name }}
@@ -233,7 +231,7 @@
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                 <button
                   @click="editTeam(team)"
-                  class="text-brand-600 hover:text-brand-900 mr-3"
+                  class="text-brand-600 dark:text-brand-300 hover:text-brand-900 dark:hover:text-brand-200 mr-3"
                 >
                   Edit Participation
                 </button>

--- a/frontend/src/components/admin/AdminTeams.vue
+++ b/frontend/src/components/admin/AdminTeams.vue
@@ -1,7 +1,7 @@
 <template>
   <div data-testid="admin-teams">
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Teams Management</h3>
+      <h3 class="text-lg font-semibold text-fg">Teams Management</h3>
       <button
         @click="showAddModal = true"
         data-testid="add-team-button"
@@ -18,7 +18,7 @@
         type="search"
         placeholder="Search teams by name or club…"
         data-testid="team-search"
-        class="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-brand-500 focus:border-brand-500"
+        class="w-full sm:w-80 bg-card text-fg border border-line rounded-md px-3 py-2 text-sm focus:ring-brand-500 focus:border-brand-500"
       />
     </div>
 
@@ -48,48 +48,42 @@
       class="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg"
       data-testid="teams-table-container"
     >
-      <table
-        class="min-w-full divide-y divide-gray-300"
-        data-testid="teams-table"
-      >
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-line" data-testid="teams-table">
+        <thead class="bg-surface-alt">
           <tr>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Name
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Parent Club
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               League
             </th>
             <th
-              class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Age Groups
             </th>
             <th
-              class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+              class="px-6 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider"
             >
               Actions
             </th>
           </tr>
         </thead>
-        <tbody
-          class="bg-white divide-y divide-gray-200"
-          data-testid="teams-tbody"
-        >
+        <tbody class="bg-card divide-y divide-line" data-testid="teams-tbody">
           <tr
             v-if="teams.length > 0 && filteredTeams.length === 0"
             data-testid="team-search-empty"
           >
-            <td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">
+            <td colspan="5" class="px-6 py-8 text-center text-sm text-fg-muted">
               No teams match "{{ teamSearch }}".
             </td>
           </tr>
@@ -100,21 +94,21 @@
             data-team-row
           >
             <td
-              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
+              class="px-6 py-4 whitespace-nowrap text-sm font-medium text-fg"
               data-testid="team-name"
             >
               {{ team.name }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 v-if="team.parent_club"
                 class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800"
               >
                 {{ team.parent_club.name }}
               </span>
-              <span v-else class="text-gray-400 italic">Independent</span>
+              <span v-else class="text-fg-muted italic">Independent</span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               <span
                 v-if="team.league_name === 'Academy'"
                 class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800"
@@ -134,7 +128,7 @@
                 {{ team.league_name || 'Unknown' }}
               </span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-fg-muted">
               <div class="flex flex-wrap gap-1">
                 <span
                   v-for="ageGroup in (team.age_groups || []).filter(ag => ag)"
@@ -150,7 +144,7 @@
             >
               <button
                 @click="editTeam(team)"
-                class="text-brand-600 hover:text-brand-900 mr-3"
+                class="text-brand-600 dark:text-brand-300 hover:text-brand-900 mr-3"
                 data-testid="edit-team-button"
               >
                 Edit
@@ -192,7 +186,7 @@
       <div class="modal-content" @click.stop data-testid="team-modal">
         <div class="p-6">
           <h3
-            class="text-lg font-medium text-gray-900 mb-4"
+            class="text-lg font-medium text-fg mb-4"
             data-testid="team-modal-title"
           >
             {{ showEditModal ? 'Edit Team' : 'Add New Team' }}
@@ -203,7 +197,7 @@
             data-testid="team-form"
           >
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Team Name</label
               >
               <input
@@ -211,33 +205,31 @@
                 type="text"
                 required
                 data-testid="team-name-input"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., New York City FC, Boston United..."
               />
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
-                >City</label
-              >
+              <label class="block text-sm font-medium text-fg mb-2">City</label>
               <input
                 v-model="formData.city"
                 type="text"
                 data-testid="team-city-input"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g., New York, Boston..."
               />
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Parent Club</label
               >
               <select
                 v-model="formData.parentClubId"
                 :disabled="isClubManager()"
                 data-testid="team-club-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-surface-alt disabled:cursor-not-allowed"
               >
                 <option v-if="!isClubManager()" :value="null">
                   Independent Team (No Parent Club)
@@ -246,7 +238,7 @@
                   {{ club.name }}
                 </option>
               </select>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-xs text-fg-muted mt-1">
                 <span v-if="isClubManager()">
                   Teams you create will be assigned to your club
                 </span>
@@ -257,7 +249,7 @@
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Team Type<span v-if="!showEditModal" class="text-red-500"
                   >*</span
                 ></label
@@ -267,14 +259,14 @@
                 @change="onTeamTypeChange"
                 :required="!showEditModal"
                 data-testid="team-type-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option value="">Select Team Type</option>
                 <option value="league">League Team</option>
                 <option value="guest">Guest Team</option>
                 <option value="tournament">Tournament Team</option>
               </select>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-xs text-fg-muted mt-1">
                 League teams can play in all game types. Guest teams are for
                 friendlies only. Tournament teams can play in tournaments and
                 friendlies.
@@ -286,7 +278,7 @@
               v-if="!showEditModal && formData.teamType === 'league'"
               class="mb-4"
             >
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >League <span class="text-red-500">*</span></label
               >
               <select
@@ -294,7 +286,7 @@
                 @change="formData.divisionId = null"
                 required
                 data-testid="team-league-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option :value="null">Select League</option>
                 <option
@@ -305,7 +297,7 @@
                   {{ league.name }}
                 </option>
               </select>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-xs text-fg-muted mt-1">
                 Select which league this team will participate in
               </p>
             </div>
@@ -318,14 +310,14 @@
               "
               class="mb-4"
             >
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Division <span class="text-red-500">*</span></label
               >
               <select
                 v-model="formData.divisionId"
                 required
                 data-testid="team-division-select"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <option :value="null">Select Division</option>
                 <option
@@ -336,14 +328,14 @@
                   {{ division.name }}
                 </option>
               </select>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-xs text-fg-muted mt-1">
                 Select the division within the league (e.g., Northeast, Bracket
                 A)
               </p>
             </div>
 
             <div v-if="showEditModal" class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Current Age Groups</label
               >
               <div class="flex flex-wrap gap-1 mb-2">
@@ -356,22 +348,22 @@
                 </span>
                 <span
                   v-if="!editingTeam?.age_groups?.length"
-                  class="text-sm text-gray-500 italic"
+                  class="text-sm text-fg-muted italic"
                 >
                   No age groups assigned
                 </span>
               </div>
-              <p class="text-xs text-gray-500">
+              <p class="text-xs text-fg-muted">
                 Use the "Leagues" button to manage age group assignments
               </p>
             </div>
 
             <div v-if="!showEditModal" class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2"
+              <label class="block text-sm font-medium text-fg mb-2"
                 >Age Groups</label
               >
               <div
-                class="space-y-2 max-h-40 overflow-y-auto border border-gray-300 rounded-md p-3"
+                class="space-y-2 max-h-40 overflow-y-auto border border-line rounded-md p-3"
               >
                 <label
                   v-for="ageGroup in ageGroups"
@@ -382,20 +374,20 @@
                     type="checkbox"
                     :value="ageGroup.id"
                     v-model="formData.ageGroupIds"
-                    class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                    class="rounded border-line text-brand-600 focus:ring-brand-500"
                   />
                   <span class="ml-2">{{ ageGroup.name }}</span>
                 </label>
               </div>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-xs text-fg-muted mt-1">
                 Select one or more age groups this team will participate in
               </p>
             </div>
 
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-2">
+              <label class="block text-sm font-medium text-fg mb-2">
                 Game Types Participation
-                <span v-if="!showEditModal" class="text-xs text-gray-500"
+                <span v-if="!showEditModal" class="text-xs text-fg-muted"
                   >(auto-selected based on team type)</span
                 >
               </label>
@@ -409,29 +401,27 @@
                     type="checkbox"
                     :value="gameType.id"
                     v-model="formData.gameTypeIds"
-                    class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                    class="rounded border-line text-brand-600 focus:ring-brand-500"
                   />
                   <span class="ml-2">{{ gameType.name }}</span>
                 </label>
               </div>
-              <p v-if="showEditModal" class="text-xs text-gray-500 mt-1">
+              <p v-if="showEditModal" class="text-xs text-fg-muted mt-1">
                 Note: This will update game type participation for all age
                 groups this team is assigned to
               </p>
             </div>
 
             <div class="mb-4">
-              <label
-                class="flex items-center text-sm font-medium text-gray-700"
-              >
+              <label class="flex items-center text-sm font-medium text-fg">
                 <input
                   type="checkbox"
                   v-model="formData.academyTeam"
-                  class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 mr-2"
+                  class="rounded border-line text-brand-600 focus:ring-brand-500 mr-2"
                 />
                 Pro Academy Team
               </label>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-xs text-fg-muted mt-1">
                 Check this if this is a pro academy team
               </p>
             </div>
@@ -441,7 +431,7 @@
                 type="button"
                 @click="closeModals"
                 data-testid="team-modal-cancel"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -473,34 +463,34 @@
     >
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             Manage League Assignments - {{ selectedTeam?.name }}
           </h3>
 
           <div class="mb-4">
-            <p class="text-sm text-gray-600 mb-4">
+            <p class="text-sm text-fg-muted mb-4">
               Assign this team to age groups and divisions. Each assignment
               creates a league participation.
             </p>
 
             <!-- Current Mappings -->
             <div class="mb-6">
-              <h4 class="text-sm font-medium text-gray-700 mb-2">
+              <h4 class="text-sm font-medium text-fg mb-2">
                 Current Assignments
               </h4>
               <div class="space-y-2">
                 <div
                   v-for="mapping in selectedTeam?.team_mappings"
                   :key="`${mapping.age_groups.id}-${mapping.divisions.id}`"
-                  class="flex items-center justify-between p-3 border border-gray-200 rounded-md"
+                  class="flex items-center justify-between p-3 border border-line rounded-md"
                 >
                   <span class="text-sm">
                     <span class="font-medium">{{
                       mapping.divisions?.leagues?.name || 'Unknown League'
                     }}</span>
-                    <span class="text-gray-400 mx-1">/</span>
+                    <span class="text-fg-muted mx-1">/</span>
                     {{ mapping.divisions.name }}
-                    <span class="text-gray-400 mx-1">/</span>
+                    <span class="text-fg-muted mx-1">/</span>
                     {{ mapping.age_groups.name }}
                   </span>
                   <button
@@ -512,7 +502,7 @@
                 </div>
                 <div
                   v-if="!selectedTeam?.team_mappings?.length"
-                  class="text-sm text-gray-500 italic"
+                  class="text-sm text-fg-muted italic"
                 >
                   No league assignments yet
                 </div>
@@ -520,20 +510,20 @@
             </div>
 
             <!-- Add New Mapping -->
-            <div class="border-t pt-4">
-              <h4 class="text-sm font-medium text-gray-700 mb-3">
+            <div class="border-t border-line pt-4">
+              <h4 class="text-sm font-medium text-fg mb-3">
                 Add New Assignment
               </h4>
               <form @submit.prevent="addTeamMapping()" class="space-y-3">
                 <div class="grid grid-cols-3 gap-3">
                   <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1"
+                    <label class="block text-sm font-medium text-fg mb-1"
                       >League</label
                     >
                     <select
                       v-model="mappingForm.league_id"
                       required
-                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                     >
                       <option value="">Select League</option>
                       <option
@@ -546,14 +536,14 @@
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1"
+                    <label class="block text-sm font-medium text-fg mb-1"
                       >Division</label
                     >
                     <select
                       v-model="mappingForm.division_id"
                       required
                       :disabled="!mappingForm.league_id"
-                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+                      class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-surface-alt disabled:cursor-not-allowed"
                     >
                       <option value="">
                         {{
@@ -572,13 +562,13 @@
                     </select>
                   </div>
                   <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1"
+                    <label class="block text-sm font-medium text-fg mb-1"
                       >Age Group</label
                     >
                     <select
                       v-model="mappingForm.age_group_id"
                       required
-                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                     >
                       <option value="">Select Age Group</option>
                       <option
@@ -605,7 +595,7 @@
           <div class="flex justify-end">
             <button
               @click="closeMappingsModal"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+              class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
             >
               Close
             </button>
@@ -1217,7 +1207,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 600px;
   width: 90%;

--- a/frontend/src/components/admin/AdminTournaments.vue
+++ b/frontend/src/components/admin/AdminTournaments.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Header -->
     <div class="flex justify-between items-center mb-6">
-      <h3 class="text-lg font-semibold text-gray-900">Tournaments</h3>
+      <h3 class="text-lg font-semibold text-fg">Tournaments</h3>
       <button
         @click="openCreateTournament"
         class="bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium"
@@ -31,19 +31,17 @@
       <div
         v-for="tournament in tournaments"
         :key="tournament.id"
-        class="border border-gray-200 rounded-lg overflow-hidden"
+        class="border border-line rounded-lg overflow-hidden"
       >
         <!-- Tournament row -->
         <div
-          class="flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 cursor-pointer"
+          class="flex items-center justify-between p-4 bg-surface-alt hover:bg-line cursor-pointer"
           @click="toggleTournament(tournament)"
         >
           <div class="flex items-center gap-4">
             <div>
               <div class="flex items-center gap-2">
-                <span class="font-medium text-gray-900">{{
-                  tournament.name
-                }}</span>
+                <span class="font-medium text-fg">{{ tournament.name }}</span>
                 <span
                   class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono bg-yellow-50 text-yellow-700 border border-yellow-200 select-all"
                   :title="tournament.id"
@@ -52,7 +50,7 @@
                 </span>
                 <span
                   v-if="!tournament.is_active"
-                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600"
+                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-alt text-fg-muted"
                 >
                   Inactive
                 </span>
@@ -64,7 +62,7 @@
                   {{ ag.name }}
                 </span>
               </div>
-              <div class="text-sm text-gray-500 mt-0.5">
+              <div class="text-sm text-fg-muted mt-0.5">
                 {{ formatDate(tournament.start_date) }}
                 <span v-if="tournament.end_date">
                   – {{ formatDate(tournament.end_date) }}</span
@@ -76,14 +74,14 @@
             </div>
           </div>
           <div class="flex items-center gap-3">
-            <span class="text-sm text-gray-500">
+            <span class="text-sm text-fg-muted">
               {{ tournament.match_count ?? 0 }} match{{
                 (tournament.match_count ?? 0) !== 1 ? 'es' : ''
               }}
             </span>
             <button
               @click.stop="openEditTournament(tournament)"
-              class="text-brand-600 hover:text-brand-900 text-sm"
+              class="text-brand-600 dark:text-brand-300 hover:text-brand-900 text-sm"
             >
               Edit
             </button>
@@ -93,7 +91,7 @@
             >
               Delete
             </button>
-            <span class="text-gray-400 text-sm">
+            <span class="text-fg-muted text-sm">
               {{ selectedTournamentId === tournament.id ? '▲' : '▼' }}
             </span>
           </div>
@@ -113,69 +111,69 @@
             <div v-if="selectedMatches.length > 0" class="overflow-x-auto mb-4">
               <table class="min-w-full text-sm">
                 <thead>
-                  <tr class="border-b border-gray-200">
+                  <tr class="border-b border-line">
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Date
                     </th>
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Round
                     </th>
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Group
                     </th>
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Home
                     </th>
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Score
                     </th>
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Away
                     </th>
                     <th
-                      class="text-left py-2 pr-4 font-medium text-gray-500 text-xs uppercase"
+                      class="text-left py-2 pr-4 font-medium text-fg-muted text-xs uppercase"
                     >
                       Status
                     </th>
                     <th
-                      class="text-right py-2 font-medium text-gray-500 text-xs uppercase"
+                      class="text-right py-2 font-medium text-fg-muted text-xs uppercase"
                     >
                       Actions
                     </th>
                   </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-100">
+                <tbody class="divide-y divide-line">
                   <tr v-for="match in selectedMatches" :key="match.id">
-                    <td class="py-2 pr-4 text-gray-700">
+                    <td class="py-2 pr-4 text-fg">
                       {{ formatDate(match.match_date) }}
                     </td>
-                    <td class="py-2 pr-4 text-gray-500">
+                    <td class="py-2 pr-4 text-fg-muted">
                       {{ formatRound(match.tournament_round) }}
                     </td>
-                    <td class="py-2 pr-4 text-gray-500">
+                    <td class="py-2 pr-4 text-fg-muted">
                       {{ match.tournament_group || '—' }}
                     </td>
-                    <td class="py-2 pr-4 font-medium text-gray-900">
+                    <td class="py-2 pr-4 font-medium text-fg">
                       {{ match.home_team?.name }}
                     </td>
-                    <td class="py-2 pr-4 text-gray-700 font-mono">
+                    <td class="py-2 pr-4 text-fg font-mono">
                       <span v-if="match.home_score != null">
                         {{ match.home_score }} – {{ match.away_score }}
                         <span
                           v-if="match.home_penalty_score != null"
-                          class="text-xs text-gray-500 ml-1"
+                          class="text-xs text-fg-muted ml-1"
                         >
                           ({{ match.home_penalty_score }}–{{
                             match.away_penalty_score
@@ -183,9 +181,9 @@
                           pens)
                         </span>
                       </span>
-                      <span v-else class="text-gray-400">vs</span>
+                      <span v-else class="text-fg-muted">vs</span>
                     </td>
-                    <td class="py-2 pr-4 font-medium text-gray-900">
+                    <td class="py-2 pr-4 font-medium text-fg">
                       {{ match.away_team?.name }}
                     </td>
                     <td class="py-2 pr-4">
@@ -196,7 +194,7 @@
                     <td class="py-2 text-right">
                       <button
                         @click="openEditMatch(match)"
-                        class="text-brand-600 hover:text-brand-900 mr-3"
+                        class="text-brand-600 dark:text-brand-300 hover:text-brand-900 mr-3"
                       >
                         Edit
                       </button>
@@ -212,7 +210,7 @@
               </table>
             </div>
 
-            <p v-else class="text-gray-500 text-sm mb-4">No matches yet.</p>
+            <p v-else class="text-fg-muted text-sm mb-4">No matches yet.</p>
 
             <button
               @click="openAddMatch(tournament)"
@@ -226,7 +224,7 @@
 
       <p
         v-if="!loading && tournaments.length === 0"
-        class="text-gray-500 text-center py-8"
+        class="text-fg-muted text-center py-8"
       >
         No tournaments yet. Click "Add Tournament" to create one.
       </p>
@@ -240,20 +238,20 @@
     >
       <div class="modal-content" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             {{ editingTournament ? 'Edit Tournament' : 'New Tournament' }}
           </h3>
           <form @submit.prevent="saveTournament">
             <!-- Name -->
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-1"
+              <label class="block text-sm font-medium text-fg mb-1"
                 >Name *</label
               >
               <input
                 v-model="tForm.name"
                 type="text"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g. 2026 Generation adidas Cup"
               />
             </div>
@@ -261,44 +259,44 @@
             <!-- Dates -->
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Start Date *</label
                 >
                 <input
                   v-model="tForm.start_date"
                   type="date"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >End Date</label
                 >
                 <input
                   v-model="tForm.end_date"
                   type="date"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
             </div>
 
             <!-- Location -->
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-1"
+              <label class="block text-sm font-medium text-fg mb-1"
                 >Location</label
               >
               <input
                 v-model="tForm.location"
                 type="text"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="e.g. IMG Academy, Bradenton FL"
               />
             </div>
 
             <!-- Age Groups (multi-select) -->
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-1"
+              <label class="block text-sm font-medium text-fg mb-1"
                 >Age Groups</label
               >
               <div class="flex flex-wrap gap-3">
@@ -311,46 +309,44 @@
                     type="checkbox"
                     :value="ag.id"
                     v-model="tForm.age_group_ids"
-                    class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                    class="rounded border-line text-brand-600 focus:ring-brand-500"
                   />
-                  <span class="text-sm text-gray-700">{{ ag.name }}</span>
+                  <span class="text-sm text-fg">{{ ag.name }}</span>
                 </label>
               </div>
             </div>
 
             <!-- Description -->
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-1"
+              <label class="block text-sm font-medium text-fg mb-1"
                 >Description</label
               >
               <textarea
                 v-model="tForm.description"
                 rows="2"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 placeholder="Optional notes about format, teams, etc."
               ></textarea>
             </div>
 
             <!-- Logo -->
             <div class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-1"
-                >Logo</label
-              >
+              <label class="block text-sm font-medium text-fg mb-1">Logo</label>
               <div class="flex items-center gap-4">
                 <!-- Preview -->
                 <img
                   v-if="tLogoPreview || editingTournament?.logo_url"
                   :src="tLogoPreview || editingTournament.logo_url"
                   alt="Tournament logo preview"
-                  class="w-16 h-16 rounded-md object-contain border border-gray-200 bg-white p-1"
+                  class="w-16 h-16 rounded-md object-contain border border-line bg-white p-1"
                   data-testid="tournament-logo-preview"
                 />
                 <div
                   v-else
-                  class="w-16 h-16 rounded-md bg-gray-100 flex items-center justify-center"
+                  class="w-16 h-16 rounded-md bg-surface-alt flex items-center justify-center"
                 >
                   <svg
-                    class="w-8 h-8 text-gray-400"
+                    class="w-8 h-8 text-fg-muted"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -376,11 +372,11 @@
                     type="button"
                     @click="$refs.tLogoInput.click()"
                     :disabled="tUploadingLogo"
-                    class="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+                    class="px-3 py-2 text-sm font-medium text-fg bg-card border border-line rounded-md hover:bg-surface-alt disabled:opacity-50"
                   >
                     {{ tUploadingLogo ? 'Uploading...' : 'Choose Image' }}
                   </button>
-                  <p class="mt-1 text-xs text-gray-500">
+                  <p class="mt-1 text-xs text-fg-muted">
                     PNG or JPG, max 2MB. Square with transparent background
                     looks best on share cards.
                   </p>
@@ -394,9 +390,9 @@
                 v-model="tForm.is_active"
                 id="is_active"
                 type="checkbox"
-                class="h-4 w-4 text-brand-600 border-gray-300 rounded"
+                class="h-4 w-4 text-brand-600 border-line rounded"
               />
-              <label for="is_active" class="text-sm text-gray-700"
+              <label for="is_active" class="text-sm text-fg"
                 >Visible to fans (active)</label
               >
             </div>
@@ -405,7 +401,7 @@
               <button
                 type="button"
                 @click="closeTournamentModal"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -432,7 +428,7 @@
     <div v-if="showMatchModal" class="modal-overlay" @click="closeMatchModal">
       <div class="modal-content modal-content-wide" @click.stop>
         <div class="p-6">
-          <h3 class="text-lg font-medium text-gray-900 mb-4">
+          <h3 class="text-lg font-medium text-fg mb-4">
             {{ editingMatch ? 'Edit Match' : 'Add Match' }}
           </h3>
           <form @submit.prevent="saveMatch">
@@ -440,20 +436,19 @@
             <!-- Edit mode: show teams as read-only text with swap option -->
             <div
               v-if="editingMatch"
-              class="mb-4 p-3 bg-gray-50 rounded-md border border-gray-200 flex items-center gap-2"
+              class="mb-4 p-3 bg-surface-alt rounded-md border border-line flex items-center gap-2"
             >
-              <span
-                class="text-sm font-medium text-gray-900 flex-1 text-right"
-                >{{ editingMatch.home_team?.name }}</span
-              >
-              <span class="text-xs text-gray-400 font-mono">vs</span>
-              <span class="text-sm font-medium text-gray-900 flex-1">{{
+              <span class="text-sm font-medium text-fg flex-1 text-right">{{
+                editingMatch.home_team?.name
+              }}</span>
+              <span class="text-xs text-fg-muted font-mono">vs</span>
+              <span class="text-sm font-medium text-fg flex-1">{{
                 editingMatch.away_team?.name
               }}</span>
               <button
                 type="button"
                 @click="swapHomeAway"
-                class="ml-2 text-xs text-brand-600 hover:text-brand-800 border border-brand-300 rounded px-2 py-0.5"
+                class="ml-2 text-xs text-brand-600 dark:text-brand-300 hover:text-brand-800 dark:hover:text-brand-200 border border-brand-300 rounded px-2 py-0.5"
                 title="Swap home and away teams"
               >
                 ⇄ Swap
@@ -462,13 +457,13 @@
             <!-- Add mode: team selector + opponent input -->
             <div v-else class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Our Team *</label
                 >
                 <select
                   v-model="mForm.our_team_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option :value="null" disabled>— select —</option>
                   <option v-for="t in leagueTeams" :key="t.id" :value="t.id">
@@ -477,17 +472,17 @@
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Opponent *</label
                 >
                 <input
                   v-model="mForm.opponent_name"
                   type="text"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="Opponent team name"
                 />
-                <p class="text-xs text-gray-400 mt-1">
+                <p class="text-xs text-fg-muted mt-1">
                   Created automatically if not in system
                 </p>
               </div>
@@ -495,7 +490,7 @@
 
             <!-- Home/Away toggle -->
             <div v-if="!editingMatch" class="mb-4">
-              <label class="block text-sm font-medium text-gray-700 mb-1"
+              <label class="block text-sm font-medium text-fg mb-1"
                 >Our Team Is</label
               >
               <div class="flex gap-4">
@@ -523,24 +518,24 @@
             <!-- Date + kickoff time -->
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Match Date *</label
                 >
                 <input
                   v-model="mForm.match_date"
                   type="date"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Kickoff Time</label
                 >
                 <input
                   v-model="mForm.scheduled_kickoff"
                   type="time"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
             </div>
@@ -548,12 +543,12 @@
             <!-- Round + Group -->
             <div class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Round</label
                 >
                 <select
                   v-model="mForm.tournament_round"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option value="">— none —</option>
                   <option value="group_stage">Group Stage</option>
@@ -566,13 +561,13 @@
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Group</label
                 >
                 <input
                   v-model="mForm.tournament_group"
                   type="text"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="e.g. Group A"
                 />
               </div>
@@ -581,13 +576,13 @@
             <!-- Age group + Season (hidden defaults when creating) -->
             <div v-if="!editingMatch" class="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Age Group *</label
                 >
                 <select
                   v-model="mForm.age_group_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option :value="null" disabled>— select —</option>
                   <option v-for="ag in ageGroups" :key="ag.id" :value="ag.id">
@@ -596,13 +591,13 @@
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Season *</label
                 >
                 <select
                   v-model="mForm.season_id"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option :value="null" disabled>— select —</option>
                   <option v-for="s in seasons" :key="s.id" :value="s.id">
@@ -615,36 +610,36 @@
             <!-- Score + Status -->
             <div class="grid grid-cols-3 gap-4 mb-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Home Score</label
                 >
                 <input
                   v-model.number="mForm.home_score"
                   type="number"
                   min="0"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="—"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Away Score</label
                 >
                 <input
                   v-model.number="mForm.away_score"
                   type="number"
                   min="0"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="—"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Status</label
                 >
                 <select
                   v-model="mForm.match_status"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option value="scheduled">Scheduled</option>
                   <option value="completed">Completed</option>
@@ -666,26 +661,26 @@
                 Draw after regulation — enter penalty shootout scores (optional)
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Home PK Score</label
                 >
                 <input
                   v-model.number="mForm.home_penalty_score"
                   type="number"
                   min="0"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
                   placeholder="—"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1"
+                <label class="block text-sm font-medium text-fg mb-1"
                   >Away PK Score</label
                 >
                 <input
                   v-model.number="mForm.away_penalty_score"
                   type="number"
                   min="0"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
                   placeholder="—"
                 />
               </div>
@@ -696,7 +691,7 @@
               <button
                 type="button"
                 @click="closeMatchModal"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
               >
                 Cancel
               </button>
@@ -816,12 +811,12 @@ export default {
 
     const statusClass = status => {
       const map = {
-        scheduled: 'text-gray-500',
+        scheduled: 'text-fg-muted',
         completed: 'text-green-700 font-medium',
         cancelled: 'text-red-500',
         in_progress: 'text-brand-600 font-medium',
       };
-      return map[status] || 'text-gray-500';
+      return map[status] || 'text-fg-muted';
     };
 
     const matchCountFor = id => matchCountCache.value[id] ?? 0;
@@ -1272,7 +1267,7 @@ export default {
   z-index: 1000;
 }
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 520px;
   width: 90%;

--- a/frontend/src/components/admin/AdminUsers.vue
+++ b/frontend/src/components/admin/AdminUsers.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="admin-users">
     <div class="flex justify-between items-center mb-6">
-      <h2 class="text-xl font-semibold text-gray-900">User Login Activity</h2>
+      <h2 class="text-xl font-semibold text-fg">User Login Activity</h2>
       <button
         @click="activeTab === 'users' ? fetchUsers() : fetchLoginEvents()"
         :disabled="loading"
-        class="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200 disabled:opacity-50"
+        class="px-3 py-1.5 text-sm bg-surface-alt text-fg-muted rounded hover:bg-line disabled:opacity-50"
       >
         {{ loading ? 'Loading...' : 'Refresh' }}
       </button>
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Tabs -->
-    <div class="mb-4 border-b border-gray-200">
+    <div class="mb-4 border-b border-line">
       <nav class="flex space-x-4">
         <button
           @click="
@@ -29,8 +29,8 @@
           "
           :class="[
             activeTab === 'users'
-              ? 'border-b-2 border-brand-600 text-brand-600'
-              : 'text-gray-500 hover:text-gray-700',
+              ? 'border-b-2 border-brand-600 text-brand-600 dark:border-brand-300 dark:text-brand-300'
+              : 'text-fg-muted hover:text-fg',
             'pb-2 text-sm font-medium',
           ]"
         >
@@ -43,8 +43,8 @@
           "
           :class="[
             activeTab === 'events'
-              ? 'border-b-2 border-brand-600 text-brand-600'
-              : 'text-gray-500 hover:text-gray-700',
+              ? 'border-b-2 border-brand-600 text-brand-600 dark:border-brand-300 dark:text-brand-300'
+              : 'text-fg-muted hover:text-fg',
             'pb-2 text-sm font-medium',
           ]"
         >
@@ -55,19 +55,19 @@
 
     <!-- Users Tab -->
     <div v-if="activeTab === 'users'">
-      <div v-if="loading" class="text-center py-8 text-gray-500">
+      <div v-if="loading" class="text-center py-8 text-fg-muted">
         Loading users...
       </div>
       <div
         v-else-if="users.length === 0"
-        class="text-center py-8 text-gray-500"
+        class="text-center py-8 text-fg-muted"
       >
         No users found.
       </div>
       <div v-else class="overflow-x-auto">
         <table class="min-w-full text-sm">
           <thead>
-            <tr class="text-left text-gray-500 border-b border-gray-200">
+            <tr class="text-left text-fg-muted border-b border-line">
               <th class="pb-2 pr-4 font-medium">Username</th>
               <th class="pb-2 pr-4 font-medium">Display Name</th>
               <th class="pb-2 pr-4 font-medium">Role</th>
@@ -75,12 +75,16 @@
               <th class="pb-2 font-medium">Joined</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
-            <tr v-for="user in users" :key="user.id" class="hover:bg-gray-50">
-              <td class="py-2 pr-4 font-mono text-gray-900">
+          <tbody class="divide-y divide-line">
+            <tr
+              v-for="user in users"
+              :key="user.id"
+              class="hover:bg-surface-alt"
+            >
+              <td class="py-2 pr-4 font-mono text-fg">
                 {{ user.username }}
               </td>
-              <td class="py-2 pr-4 text-gray-700">
+              <td class="py-2 pr-4 text-fg-muted">
                 {{ user.display_name || '—' }}
               </td>
               <td class="py-2 pr-4">
@@ -88,7 +92,7 @@
                   user.role || 'user'
                 }}</span>
               </td>
-              <td class="py-2 pr-4 text-gray-600">
+              <td class="py-2 pr-4 text-fg-muted">
                 <span v-if="user.last_login_at">
                   <span
                     :class="
@@ -101,9 +105,9 @@
                   >
                   {{ formatDate(user.last_login_at) }}
                 </span>
-                <span v-else class="text-gray-400 italic">Never</span>
+                <span v-else class="text-fg-muted italic">Never</span>
               </td>
-              <td class="py-2 text-gray-500">
+              <td class="py-2 text-fg-muted">
                 {{ formatDate(user.created_at) }}
               </td>
             </tr>
@@ -121,12 +125,12 @@
           @input="debouncedFetch"
           type="text"
           placeholder="Filter by username..."
-          class="px-3 py-1.5 text-sm border border-gray-300 rounded w-48 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          class="px-3 py-1.5 text-sm bg-card text-fg border border-line rounded w-48 focus:outline-none focus:ring-1 focus:ring-brand-500"
         />
         <select
           v-model="filterSuccess"
           @change="fetchLoginEvents"
-          class="px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-brand-500"
+          class="px-3 py-1.5 text-sm bg-card text-fg border border-line rounded focus:outline-none focus:ring-1 focus:ring-brand-500"
         >
           <option value="">All results</option>
           <option value="true">Success only</option>
@@ -134,12 +138,12 @@
         </select>
       </div>
 
-      <div v-if="loading" class="text-center py-8 text-gray-500">
+      <div v-if="loading" class="text-center py-8 text-fg-muted">
         Loading events...
       </div>
       <div
         v-else-if="events.length === 0"
-        class="text-center py-8 text-gray-500"
+        class="text-center py-8 text-fg-muted"
       >
         No login events found.
       </div>
@@ -147,7 +151,7 @@
         <div class="overflow-x-auto">
           <table class="min-w-full text-sm">
             <thead>
-              <tr class="text-left text-gray-500 border-b border-gray-200">
+              <tr class="text-left text-fg-muted border-b border-line">
                 <th class="pb-2 pr-4 font-medium">Time</th>
                 <th class="pb-2 pr-4 font-medium">Username</th>
                 <th class="pb-2 pr-4 font-medium">Result</th>
@@ -155,12 +159,16 @@
                 <th class="pb-2 font-medium">Role</th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-100">
-              <tr v-for="ev in events" :key="ev.id" class="hover:bg-gray-50">
-                <td class="py-2 pr-4 text-gray-600 whitespace-nowrap">
+            <tbody class="divide-y divide-line">
+              <tr
+                v-for="ev in events"
+                :key="ev.id"
+                class="hover:bg-surface-alt"
+              >
+                <td class="py-2 pr-4 text-fg-muted whitespace-nowrap">
                   {{ formatDate(ev.created_at) }}
                 </td>
-                <td class="py-2 pr-4 font-mono text-gray-900">
+                <td class="py-2 pr-4 font-mono text-fg">
                   {{ ev.username }}
                 </td>
                 <td class="py-2 pr-4">
@@ -178,10 +186,10 @@
                     }}
                   </span>
                 </td>
-                <td class="py-2 pr-4 font-mono text-gray-500 text-xs">
+                <td class="py-2 pr-4 font-mono text-fg-muted text-xs">
                   {{ ev.client_ip || '—' }}
                 </td>
-                <td class="py-2 text-gray-600 text-xs">{{ ev.role || '—' }}</td>
+                <td class="py-2 text-fg-muted text-xs">{{ ev.role || '—' }}</td>
               </tr>
             </tbody>
           </table>
@@ -189,21 +197,21 @@
 
         <!-- Pagination -->
         <div
-          class="flex items-center justify-between mt-4 text-sm text-gray-600"
+          class="flex items-center justify-between mt-4 text-sm text-fg-muted"
         >
           <span>Showing {{ events.length }} of {{ eventTotal }} events</span>
           <div class="flex gap-2">
             <button
               @click="prevPage"
               :disabled="currentPage === 0"
-              class="px-3 py-1 border border-gray-300 rounded disabled:opacity-40 hover:bg-gray-50"
+              class="px-3 py-1 border border-line rounded disabled:opacity-40 hover:bg-surface-alt"
             >
               Previous
             </button>
             <button
               @click="nextPage"
               :disabled="(currentPage + 1) * pageSize >= eventTotal"
-              class="px-3 py-1 border border-gray-300 rounded disabled:opacity-40 hover:bg-gray-50"
+              class="px-3 py-1 border border-line rounded disabled:opacity-40 hover:bg-surface-alt"
             >
               Next
             </button>

--- a/frontend/src/components/admin/BracketSlotCard.vue
+++ b/frontend/src/components/admin/BracketSlotCard.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="border rounded-lg p-3 bg-white shadow-sm"
+    class="border rounded-lg p-3 bg-card shadow-sm"
     :class="{
       'border-green-400': isCompleted,
-      'border-gray-200': !isCompleted,
+      'border-line': !isCompleted,
     }"
   >
     <!-- Home team -->
@@ -14,7 +14,7 @@
       <div class="flex items-center space-x-2">
         <span
           v-if="bracketSlot.home_seed"
-          class="text-xs text-gray-400 w-4 text-right"
+          class="text-xs text-fg-muted w-4 text-right"
         >
           {{ bracketSlot.home_seed }}
         </span>
@@ -27,7 +27,7 @@
       </span>
     </div>
 
-    <hr class="border-gray-100" />
+    <hr class="border-line" />
 
     <!-- Away team -->
     <div
@@ -37,7 +37,7 @@
       <div class="flex items-center space-x-2">
         <span
           v-if="bracketSlot.away_seed"
-          class="text-xs text-gray-400 w-4 text-right"
+          class="text-xs text-fg-muted w-4 text-right"
         >
           {{ bracketSlot.away_seed }}
         </span>
@@ -53,7 +53,7 @@
     <!-- Date/Time display (view mode) -->
     <div
       v-if="bracketSlot.match_id && !editing"
-      class="mt-1 flex items-center justify-between text-xs text-gray-500"
+      class="mt-1 flex items-center justify-between text-xs text-fg-muted"
     >
       <span>
         {{ displayDate }}
@@ -61,7 +61,7 @@
       </span>
       <button
         @click="startEditing"
-        class="ml-2 text-gray-400 hover:text-brand-600"
+        class="ml-2 text-fg-muted hover:text-brand-600 dark:hover:text-brand-300"
         title="Edit date/time"
       >
         &#9998;
@@ -74,18 +74,18 @@
         <input
           type="date"
           v-model="editDate"
-          class="flex-1 text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          class="flex-1 text-xs border border-line rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
         />
         <input
           type="time"
           v-model="editTime"
-          class="flex-1 text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          class="flex-1 text-xs border border-line rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-brand-500"
         />
       </div>
       <div class="flex justify-end space-x-2">
         <button
           @click="cancelEditing"
-          class="text-xs px-2 py-1 text-gray-600 border border-gray-300 rounded hover:bg-gray-50"
+          class="text-xs px-2 py-1 text-fg-muted border border-line rounded hover:bg-surface-alt"
         >
           Cancel
         </button>
@@ -171,7 +171,7 @@ export default {
     });
 
     const statusClass = computed(() => {
-      if (!props.bracketSlot.match_id) return 'text-gray-400';
+      if (!props.bracketSlot.match_id) return 'text-fg-muted';
       if (props.bracketSlot.match_status === 'completed')
         return 'text-green-600';
       if (props.bracketSlot.match_status === 'live')

--- a/frontend/src/components/admin/SupportInboxList.vue
+++ b/frontend/src/components/admin/SupportInboxList.vue
@@ -20,7 +20,7 @@
           :class="
             currentStatus === tab.value
               ? 'bg-brand-600 text-white border-brand-600'
-              : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              : 'bg-card text-fg border-line hover:bg-surface-alt'
           "
           @click="$emit('filter', tab.value)"
         >
@@ -38,11 +38,11 @@
           type="text"
           placeholder="MT-42"
           data-testid="support-inbox-search"
-          class="px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 w-32"
+          class="px-3 py-1.5 text-sm bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 w-32"
         />
         <button
           type="submit"
-          class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700"
+          class="px-3 py-1.5 text-sm bg-surface-alt hover:bg-line rounded-md text-fg"
           data-testid="support-inbox-search-submit"
         >
           Go
@@ -53,7 +53,7 @@
     <!-- Loading / empty / rows -->
     <div
       v-if="loading && threads.items.length === 0"
-      class="text-center text-gray-500 py-12"
+      class="text-center text-fg-muted py-12"
       data-testid="support-inbox-loading"
     >
       Loading threads…
@@ -61,7 +61,7 @@
 
     <div
       v-else-if="threads.items.length === 0"
-      class="text-center text-gray-500 py-12 bg-gray-50 rounded-lg"
+      class="text-center text-fg-muted py-12 bg-surface-alt rounded-lg"
       data-testid="support-inbox-empty"
     >
       <p class="font-medium mb-1">No threads in this view.</p>
@@ -70,20 +70,20 @@
 
     <ul
       v-else
-      class="divide-y divide-gray-200 border border-gray-200 rounded-lg bg-white"
+      class="divide-y divide-line border border-line rounded-lg bg-card"
     >
       <li
         v-for="thread in threads.items"
         :key="thread.id"
         :data-testid="`thread-row-${thread.case_number}`"
-        class="px-4 py-3 hover:bg-gray-50 cursor-pointer"
+        class="px-4 py-3 hover:bg-surface-alt cursor-pointer"
         @click="$emit('select', thread.id)"
       >
         <div class="flex items-start justify-between gap-3">
           <div class="min-w-0 flex-1">
             <div class="flex items-center gap-2 mb-1">
               <span
-                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-100 text-gray-800"
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-surface-alt text-fg"
                 :data-testid="`thread-case-${thread.case_number}`"
               >
                 MT-{{ thread.case_number }}
@@ -103,14 +103,14 @@
                 {{ thread.unread_count }}
               </span>
             </div>
-            <p class="text-sm font-medium text-gray-900 truncate">
+            <p class="text-sm font-medium text-fg truncate">
               {{ participantDisplay(thread) }}
             </p>
-            <p class="text-sm text-gray-700 truncate">
+            <p class="text-sm text-fg truncate">
               {{ thread.subject || '(no subject)' }}
             </p>
           </div>
-          <div class="text-right text-xs text-gray-500 whitespace-nowrap">
+          <div class="text-right text-xs text-fg-muted whitespace-nowrap">
             {{ relativeTime(thread.last_message_at) }}
           </div>
         </div>
@@ -121,7 +121,7 @@
     <div v-if="threads.nextCursor" class="text-center mt-4">
       <button
         type="button"
-        class="px-4 py-2 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700"
+        class="px-4 py-2 text-sm bg-surface-alt hover:bg-line rounded-md text-fg"
         data-testid="support-inbox-load-more"
         :disabled="loading"
         @click="$emit('load-more')"

--- a/frontend/src/components/admin/SupportThreadView.vue
+++ b/frontend/src/components/admin/SupportThreadView.vue
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
       <button
         type="button"
-        class="text-sm text-brand-700 hover:underline"
+        class="text-sm text-brand-700 dark:text-brand-300 hover:underline"
         data-testid="thread-back"
         @click="$emit('back')"
       >
@@ -14,7 +14,7 @@
         <button
           v-if="thread.unread_count > 0"
           type="button"
-          class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700"
+          class="px-3 py-1.5 text-sm bg-surface-alt hover:bg-line rounded-md text-fg-muted"
           data-testid="thread-mark-all-read"
           @click="$emit('mark-all-read')"
         >
@@ -23,7 +23,7 @@
         <div class="relative" v-click-outside="closeDropdown">
           <button
             type="button"
-            class="px-3 py-1.5 text-sm border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 flex items-center gap-1"
+            class="px-3 py-1.5 text-sm border border-line rounded-md text-fg-muted hover:bg-surface-alt flex items-center gap-1"
             data-testid="thread-status-dropdown"
             :aria-expanded="dropdownOpen"
             @click="dropdownOpen = !dropdownOpen"
@@ -39,13 +39,13 @@
           </button>
           <ul
             v-if="dropdownOpen"
-            class="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10 py-1"
+            class="absolute right-0 mt-1 w-48 bg-card border border-line rounded-md shadow-lg z-10 py-1"
             role="menu"
           >
             <li>
               <button
                 type="button"
-                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-surface-alt"
                 data-testid="thread-status-resolved"
                 @click="onPickStatus('resolved')"
               >
@@ -55,7 +55,7 @@
             <li>
               <button
                 type="button"
-                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-surface-alt"
                 data-testid="thread-status-spam"
                 @click="onPickStatus('spam')"
               >
@@ -65,7 +65,7 @@
             <li>
               <button
                 type="button"
-                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-surface-alt"
                 data-testid="thread-status-reopen"
                 @click="onPickStatus('awaiting_admin')"
               >
@@ -78,10 +78,10 @@
     </div>
 
     <!-- Thread metadata -->
-    <div class="mb-4 pb-4 border-b border-gray-200">
+    <div class="mb-4 pb-4 border-b border-line">
       <div class="flex items-center gap-2 mb-2">
         <span
-          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-100 text-gray-800"
+          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-surface-alt text-fg"
           data-testid="thread-case-number"
         >
           MT-{{ thread.case_number }}
@@ -95,10 +95,10 @@
           {{ statusLabel(thread.status) }}
         </span>
       </div>
-      <h3 class="text-lg font-semibold text-gray-900">
+      <h3 class="text-lg font-semibold text-fg">
         {{ thread.subject || '(no subject)' }}
       </h3>
-      <p class="text-sm text-gray-600">
+      <p class="text-sm text-fg-muted">
         {{ thread.participant_name || thread.participant_email }}
         <span v-if="thread.participant_name">
           &lt;{{ thread.participant_email }}&gt;</span
@@ -121,11 +121,11 @@
           :class="
             msg.direction === 'outbound'
               ? 'bg-brand-50 border border-brand-200'
-              : 'bg-gray-50 border border-gray-200'
+              : 'bg-surface-alt border border-line'
           "
         >
-          <div class="flex items-center gap-2 mb-1 text-xs text-gray-500">
-            <span class="font-medium text-gray-700">
+          <div class="flex items-center gap-2 mb-1 text-xs text-fg-muted">
+            <span class="font-medium text-fg-muted">
               {{
                 msg.direction === 'outbound'
                   ? msg.from_name || 'Support'
@@ -139,20 +139,20 @@
           </div>
           <div
             v-if="msg.body_html"
-            class="text-sm text-gray-800 prose prose-sm max-w-none"
+            class="text-sm text-fg prose prose-sm max-w-none"
             data-testid="message-body-html"
             v-html="msg.body_html"
           />
           <div
             v-else
-            class="text-sm text-gray-800 whitespace-pre-wrap"
+            class="text-sm text-fg whitespace-pre-wrap"
             data-testid="message-body-text"
           >
             {{ msg.body_text }}
           </div>
           <p
             v-if="msg.had_attachments"
-            class="mt-2 text-xs italic text-gray-500"
+            class="mt-2 text-xs italic text-fg-muted"
             data-testid="message-attachments-notice"
           >
             Attachments stripped. Reply via your email client to view them.
@@ -163,7 +163,7 @@
 
     <!-- Reply composer -->
     <form
-      class="border-t border-gray-200 pt-4"
+      class="border-t border-line pt-4"
       data-testid="reply-composer"
       @submit.prevent="onReply"
     >
@@ -174,7 +174,7 @@
         rows="4"
         placeholder="Write a reply…"
         data-testid="reply-textarea"
-        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 text-sm"
+        class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 text-sm"
       ></textarea>
       <div class="flex justify-end mt-2">
         <button

--- a/frontend/src/components/profiles/AdminProfile.vue
+++ b/frontend/src/components/profiles/AdminProfile.vue
@@ -460,7 +460,7 @@ export default {
 
 <style scoped>
 .admin-section {
-  background-color: #f8fafc;
+  background-color: rgb(var(--color-surface-alt));
   padding: 20px;
   border-radius: 8px;
   margin-bottom: 20px;
@@ -479,10 +479,10 @@ export default {
 }
 
 .admin-card {
-  background: white;
+  background: rgb(var(--color-card));
   padding: 20px;
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
   cursor: pointer;
   transition: all 0.2s ease;
   text-align: center;
@@ -500,20 +500,20 @@ export default {
 }
 
 .admin-card h4 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 10px 0 5px 0;
   font-size: 16px;
 }
 
 .admin-card p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 14px;
   margin: 0;
 }
 
 .user-management-section {
-  background-color: #fff;
-  border: 1px solid #e5e7eb;
+  background-color: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   margin-bottom: 20px;
 }
@@ -523,14 +523,14 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .close-btn {
   background: none;
   border: none;
   font-size: 24px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
   padding: 0;
   width: 30px;
@@ -554,9 +554,9 @@ export default {
   display: flex;
   align-items: center;
   padding: 15px;
-  background-color: #f9fafb;
+  background-color: rgb(var(--color-surface-alt));
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
 }
 
 .user-avatar {
@@ -578,7 +578,7 @@ export default {
 
 .user-details h4 {
   margin: 0 0 8px 0;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   font-size: 16px;
   font-weight: 600;
 }
@@ -593,7 +593,7 @@ export default {
 
 .info-label {
   font-weight: 600;
-  color: #4b5563;
+  color: rgb(var(--color-fg-muted));
   font-size: 12px;
 }
 
@@ -604,7 +604,7 @@ export default {
 }
 
 .user-email {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 13px;
 }
 
@@ -615,7 +615,7 @@ export default {
 }
 
 .user-created {
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   font-size: 11px;
   margin-top: 5px;
 }
@@ -631,10 +631,12 @@ export default {
 
 .role-select {
   padding: 6px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   font-size: 14px;
   min-width: 140px;
+  background-color: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .quick-stats {
@@ -712,8 +714,8 @@ export default {
 
 .edit-btn {
   padding: 6px 12px;
-  background-color: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background-color: rgb(var(--color-surface-alt));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   cursor: pointer;
   font-size: 16px;
@@ -721,8 +723,8 @@ export default {
 }
 
 .edit-btn:hover {
-  background-color: #e5e7eb;
-  border-color: #9ca3af;
+  background-color: rgb(var(--color-line));
+  border-color: rgb(var(--color-fg-muted));
 }
 
 .modal-overlay {
@@ -739,7 +741,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 500px;
   width: 90%;
@@ -755,12 +757,12 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .modal-header h3 {
   margin: 0;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   font-size: 18px;
 }
 
@@ -776,17 +778,19 @@ export default {
   display: block;
   margin-bottom: 8px;
   font-weight: 600;
-  color: #374151;
+  color: rgb(var(--color-fg));
   font-size: 14px;
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   font-size: 14px;
   box-sizing: border-box;
+  background-color: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .form-input:focus {
@@ -799,7 +803,7 @@ export default {
 .help-text {
   margin-top: 4px;
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .error-message {
@@ -814,24 +818,24 @@ export default {
   justify-content: flex-end;
   gap: 12px;
   padding: 20px;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid rgb(var(--color-line));
 }
 
 .btn-secondary {
   padding: 8px 16px;
-  background-color: white;
-  border: 1px solid #d1d5db;
+  background-color: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: rgb(var(--color-fg));
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .btn-secondary:hover {
-  background-color: #f9fafb;
-  border-color: #9ca3af;
+  background-color: rgb(var(--color-surface-alt));
+  border-color: rgb(var(--color-fg-muted));
 }
 
 .btn-primary {
@@ -859,6 +863,6 @@ export default {
 .loading {
   text-align: center;
   padding: 20px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 </style>

--- a/frontend/src/components/profiles/BaseProfile.vue
+++ b/frontend/src/components/profiles/BaseProfile.vue
@@ -359,11 +359,11 @@ export default {
   align-items: center;
   margin-bottom: 20px;
   padding-bottom: 10px;
-  border-bottom: 2px solid #e5e7eb;
+  border-bottom: 2px solid rgb(var(--color-line));
 }
 
 .profile-header h2 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0;
 }
 
@@ -384,11 +384,11 @@ export default {
 .loading {
   text-align: center;
   padding: 40px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .profile-info {
-  background-color: #f9fafb;
+  background-color: rgb(var(--color-surface-alt));
   padding: 20px;
   border-radius: 8px;
   margin-bottom: 20px;
@@ -402,7 +402,7 @@ export default {
 
 .info-group label {
   font-weight: 600;
-  color: #374151;
+  color: rgb(var(--color-fg));
   min-width: 120px;
   margin-right: 10px;
 }
@@ -410,15 +410,17 @@ export default {
 .profile-input {
   flex: 1;
   padding: 8px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   font-size: 14px;
+  background-color: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .profile-input:disabled {
   background-color: transparent;
   border: none;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .role-badge {
@@ -504,7 +506,7 @@ export default {
 .field-hint {
   display: block;
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-top: 4px;
   font-style: italic;
 }
@@ -569,8 +571,8 @@ export default {
 }
 
 .channel-platform {
-  background: white;
-  border: 1px solid #e0f2fe;
+  background: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 6px;
   padding: 14px;
   margin-bottom: 12px;
@@ -585,7 +587,7 @@ export default {
 
 .channel-platform-name {
   font-weight: 600;
-  color: #1e293b;
+  color: rgb(var(--color-fg));
   font-size: 14px;
 }
 
@@ -641,7 +643,7 @@ export default {
 
 .channel-hint {
   font-size: 12px;
-  color: #64748b;
+  color: rgb(var(--color-fg-muted));
   margin: 6px 0 0 0;
   font-style: italic;
 }

--- a/frontend/src/components/profiles/ClubManagerProfile.vue
+++ b/frontend/src/components/profiles/ClubManagerProfile.vue
@@ -499,12 +499,12 @@ export default {
 .capabilities-section h3 {
   font-size: 18px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0 0 8px 0;
 }
 
 .section-description {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 14px;
   margin: 0 0 16px 0;
   line-height: 1.5;
@@ -521,9 +521,9 @@ export default {
   align-items: flex-start;
   gap: 16px;
   padding: 20px;
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
   text-decoration: none;
   color: inherit;
   transition: all 0.2s;
@@ -556,19 +556,19 @@ export default {
   margin: 0 0 6px 0;
   font-size: 16px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .capability-content p {
   margin: 0;
   font-size: 13px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   line-height: 1.4;
 }
 
 .capability-arrow {
   font-size: 20px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   transition: transform 0.2s;
   align-self: center;
 }
@@ -593,7 +593,7 @@ export default {
 }
 
 .no-club-card p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin: 0;
 }
 
@@ -613,7 +613,7 @@ export default {
 .edit-modal {
   width: 100%;
   max-width: 440px;
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
@@ -624,27 +624,27 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .modal-header h3 {
   margin: 0;
   font-size: 18px;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .close-btn {
   background: none;
   border: none;
   font-size: 24px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
   padding: 0;
   line-height: 1;
 }
 
 .close-btn:hover {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .modal-body {
@@ -659,16 +659,18 @@ export default {
   display: block;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: rgb(var(--color-fg));
   margin-bottom: 6px;
 }
 
 .form-group input {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   font-size: 14px;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .form-group input:focus {
@@ -689,15 +691,15 @@ export default {
   justify-content: flex-end;
   gap: 12px;
   padding: 16px 20px;
-  border-top: 1px solid #e5e7eb;
-  background: #f9fafb;
+  border-top: 1px solid rgb(var(--color-line));
+  background: rgb(var(--color-surface-alt));
 }
 
 .cancel-btn {
   padding: 10px 20px;
-  background: white;
-  color: #374151;
-  border: 1px solid #d1d5db;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   font-weight: 500;
   font-size: 14px;
@@ -706,7 +708,7 @@ export default {
 }
 
 .cancel-btn:hover {
-  background: #f3f4f6;
+  background: rgb(var(--color-surface-alt));
 }
 
 .save-btn {

--- a/frontend/src/components/profiles/FanProfile.vue
+++ b/frontend/src/components/profiles/FanProfile.vue
@@ -765,7 +765,7 @@ export default {
 
 /* Club Teams Section - Grouped Layout */
 .club-teams-section {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   padding: 25px;
   margin-bottom: 25px;
@@ -773,7 +773,7 @@ export default {
 }
 
 .club-teams-section h3 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin-bottom: 20px;
   font-size: 18px;
 }
@@ -785,7 +785,7 @@ export default {
 }
 
 .league-group {
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 10px;
   overflow: hidden;
 }
@@ -814,7 +814,7 @@ export default {
 }
 
 .division-group {
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .division-group:last-child {
@@ -839,7 +839,7 @@ export default {
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid rgb(var(--color-line));
   transition: background 0.15s;
 }
 
@@ -848,12 +848,12 @@ export default {
 }
 
 .age-group-row:hover {
-  background: #f8fafc;
+  background: rgb(var(--color-surface-alt));
 }
 
 .age-group-name {
   font-weight: 500;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   font-size: 14px;
 }
 
@@ -890,7 +890,7 @@ export default {
 
 /* Quick Access */
 .quick-access-section {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   padding: 25px;
   margin-bottom: 25px;
@@ -898,7 +898,7 @@ export default {
 }
 
 .quick-access-section h3 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin-bottom: 20px;
   font-size: 18px;
 }
@@ -953,7 +953,7 @@ export default {
 
 /* Upcoming Matches */
 .upcoming-section {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   padding: 25px;
   margin-bottom: 25px;
@@ -961,7 +961,7 @@ export default {
 }
 
 .upcoming-section h3 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin-bottom: 20px;
   font-size: 18px;
 }
@@ -976,14 +976,14 @@ export default {
   grid-template-columns: 100px 1fr 80px;
   align-items: center;
   padding: 15px;
-  background: #f9fafb;
+  background: rgb(var(--color-surface-alt));
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
 }
 
 .match-date {
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-weight: 500;
 }
 
@@ -997,18 +997,18 @@ export default {
 .home-team,
 .away-team {
   font-weight: 500;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .vs {
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   font-size: 12px;
 }
 
 .match-type {
   text-align: right;
   font-size: 11px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   text-transform: uppercase;
 }
 
@@ -1040,7 +1040,7 @@ export default {
 }
 
 .feature-card {
-  background: white;
+  background: rgb(var(--color-card));
   padding: 20px;
   border-radius: 10px;
   text-align: center;
@@ -1066,7 +1066,7 @@ export default {
 
 .feature-card p {
   margin: 0;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 13px;
 }
 
@@ -1085,7 +1085,7 @@ export default {
 }
 
 .edit-modal {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   width: 90%;
   max-width: 450px;
@@ -1097,24 +1097,24 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .modal-header h3 {
   margin: 0;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .close-btn {
   background: none;
   border: none;
   font-size: 24px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
 }
 
 .close-btn:hover {
-  color: #4b5563;
+  color: rgb(var(--color-fg));
 }
 
 .modal-body {
@@ -1129,16 +1129,18 @@ export default {
   display: block;
   margin-bottom: 8px;
   font-weight: 600;
-  color: #374151;
+  color: rgb(var(--color-fg));
 }
 
 .form-group input {
   width: 100%;
   padding: 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   font-size: 14px;
   box-sizing: border-box;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .form-group input:focus {
@@ -1152,21 +1154,21 @@ export default {
   justify-content: flex-end;
   gap: 12px;
   padding: 20px;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid rgb(var(--color-line));
 }
 
 .cancel-btn {
   padding: 10px 20px;
-  background: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background: rgb(var(--color-surface-alt));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
-  color: #4b5563;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
   font-weight: 500;
 }
 
 .cancel-btn:hover {
-  background: #e5e7eb;
+  background: rgb(var(--color-line));
 }
 
 .save-btn {

--- a/frontend/src/components/profiles/LiveUpdatesSection.vue
+++ b/frontend/src/components/profiles/LiveUpdatesSection.vue
@@ -268,7 +268,7 @@ export default {
 
 .section-desc {
   font-size: 13px;
-  color: #475569;
+  color: rgb(var(--color-fg-muted));
   margin: 0 0 16px 0;
   line-height: 1.5;
 }
@@ -280,8 +280,8 @@ export default {
 }
 
 .platform-item {
-  background: white;
-  border: 1px solid #e0f2fe;
+  background: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   padding: 14px;
 }
@@ -296,7 +296,7 @@ export default {
 .platform-name {
   font-weight: 600;
   font-size: 14px;
-  color: #1e293b;
+  color: rgb(var(--color-fg));
 }
 
 .status-pill {
@@ -306,8 +306,8 @@ export default {
   border-radius: 10px;
 }
 .pill-none {
-  background: #f1f5f9;
-  color: #94a3b8;
+  background: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg-muted));
 }
 .pill-pending {
   background: #fef9c3;
@@ -331,14 +331,16 @@ export default {
 .handle-input {
   flex: 1;
   padding: 7px 10px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 6px;
   font-size: 13px;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .handle-input:disabled {
-  background: #f9fafb;
-  color: #9ca3af;
+  background: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg-muted));
 }
 
 .request-btn {
@@ -370,7 +372,7 @@ export default {
 
 .status-msg {
   font-size: 12px;
-  color: #64748b;
+  color: rgb(var(--color-fg-muted));
   margin: 6px 0 0;
   font-style: italic;
 }

--- a/frontend/src/components/profiles/PlayerCard.vue
+++ b/frontend/src/components/profiles/PlayerCard.vue
@@ -225,7 +225,7 @@ export default {
 
 <style scoped>
 .player-card {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
@@ -272,7 +272,7 @@ export default {
 .player-name {
   font-weight: 600;
   font-size: 16px;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   /* Truncate long names */
   white-space: nowrap;
   overflow: hidden;
@@ -281,7 +281,7 @@ export default {
 
 .player-secondary {
   font-size: 13px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-bottom: 8px;
 }
 
@@ -334,7 +334,7 @@ export default {
 }
 
 .social-icon.tiktok {
-  color: #000000;
+  color: rgb(var(--color-fg));
 }
 
 .social-icon.tiktok:hover {

--- a/frontend/src/components/profiles/PlayerDetailView.vue
+++ b/frontend/src/components/profiles/PlayerDetailView.vue
@@ -388,7 +388,7 @@ export default {
   align-items: center;
   justify-content: center;
   padding: 48px 16px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .loading-spinner {
@@ -432,7 +432,7 @@ export default {
 }
 
 .error-container p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-bottom: 16px;
 }
 
@@ -454,7 +454,7 @@ export default {
 
 /* Profile card */
 .profile-card {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
@@ -476,7 +476,7 @@ export default {
 .player-name {
   font-size: 24px;
   font-weight: 700;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0 0 16px 0;
 }
 
@@ -492,14 +492,14 @@ export default {
   flex-direction: column;
   align-items: center;
   padding: 12px 20px;
-  background-color: #f9fafb;
+  background-color: rgb(var(--color-surface-alt));
   border-radius: 12px;
   min-width: 100px;
 }
 
 .detail-label {
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 4px;
@@ -508,14 +508,14 @@ export default {
 .detail-value {
   font-size: 16px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 /* Section titles */
 .section-title {
   font-size: 18px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0 0 12px 0;
   padding: 0 4px;
 }
@@ -535,7 +535,7 @@ export default {
   display: flex;
   align-items: center;
   padding: 14px 16px;
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
   text-decoration: none;
@@ -596,18 +596,18 @@ export default {
 .platform {
   font-size: 14px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .handle {
   font-size: 13px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .link-arrow {
   width: 20px;
   height: 20px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
 }
 
 /* Games section */
@@ -622,7 +622,7 @@ export default {
 }
 
 .game-item {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   padding: 14px 16px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
@@ -630,7 +630,7 @@ export default {
 
 .game-date {
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-bottom: 8px;
 }
 
@@ -645,7 +645,7 @@ export default {
   flex: 1;
   font-size: 14px;
   font-weight: 500;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .game-teams .team-name:last-child {
@@ -655,12 +655,12 @@ export default {
 .game-score {
   font-size: 16px;
   font-weight: 700;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   white-space: nowrap;
 }
 
 .game-score.has-score {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .game-status {

--- a/frontend/src/components/profiles/PlayerPhotoOverlay.vue
+++ b/frontend/src/components/profiles/PlayerPhotoOverlay.vue
@@ -168,7 +168,7 @@ export default {
   aspect-ratio: 1;
   border-radius: 12px;
   overflow: hidden;
-  background-color: #f3f4f6;
+  background-color: rgb(var(--color-surface-alt));
 }
 
 .photo-container {
@@ -191,8 +191,8 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #e5e7eb;
-  color: #9ca3af;
+  background-color: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg-muted));
 }
 
 .photo-placeholder svg {

--- a/frontend/src/components/profiles/PlayerPhotoUpload.vue
+++ b/frontend/src/components/profiles/PlayerPhotoUpload.vue
@@ -411,7 +411,7 @@ export default {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .help-btn {
@@ -420,7 +420,7 @@ export default {
   gap: 4px;
   background: none;
   border: none;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
   font-size: 13px;
   padding: 4px 8px;
@@ -429,8 +429,8 @@ export default {
 }
 
 .help-btn:hover {
-  background-color: #f3f4f6;
-  color: #374151;
+  background-color: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg));
 }
 
 .help-panel {
@@ -490,14 +490,14 @@ export default {
   aspect-ratio: 1;
   border-radius: 12px;
   overflow: hidden;
-  background-color: #f3f4f6;
-  border: 2px dashed #d1d5db;
+  background-color: rgb(var(--color-surface-alt));
+  border: 2px dashed rgb(var(--color-line));
   transition: all 0.15s ease;
 }
 
 .photo-slot.has-photo {
   border-style: solid;
-  border-color: #e5e7eb;
+  border-color: rgb(var(--color-line));
 }
 
 .photo-slot.is-profile {
@@ -544,14 +544,14 @@ export default {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
 }
 
 .upload-icon {
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background-color: #e5e7eb;
+  background-color: rgb(var(--color-surface-alt));
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/profiles/PlayerProfile.vue
+++ b/frontend/src/components/profiles/PlayerProfile.vue
@@ -981,7 +981,7 @@ export default {
 .dashboard-header h1 {
   font-size: 24px;
   font-weight: 700;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0;
 }
 
@@ -1198,7 +1198,7 @@ export default {
 }
 
 .column-card {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   padding: 20px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -1207,7 +1207,7 @@ export default {
 .column-card h3 {
   font-size: 18px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0 0 16px 0;
 }
 
@@ -1252,8 +1252,8 @@ export default {
   height: 40px;
   border-radius: 50%;
   border: none;
-  background: #f3f4f6;
-  color: #374151;
+  background: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg));
   font-size: 24px;
   cursor: pointer;
   display: flex;
@@ -1264,7 +1264,7 @@ export default {
 }
 
 .carousel-btn:hover {
-  background: #e5e7eb;
+  background: rgb(var(--color-line));
 }
 
 .carousel-dots {
@@ -1277,7 +1277,7 @@ export default {
   height: 10px;
   border-radius: 50%;
   border: none;
-  background: #d1d5db;
+  background: rgb(var(--color-line));
   cursor: pointer;
   padding: 0;
   transition: all 0.2s;
@@ -1295,7 +1295,7 @@ export default {
   justify-content: center;
   padding: 40px 20px;
   text-align: center;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
 }
 
 .no-photos-icon {
@@ -1324,7 +1324,7 @@ export default {
 .no-games,
 .no-history {
   text-align: center;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   font-size: 14px;
   padding: 20px;
 }
@@ -1338,9 +1338,9 @@ export default {
 
 .history-item {
   padding: 12px;
-  background: #f9fafb;
+  background: rgb(var(--color-surface-alt));
   border-radius: 8px;
-  border-left: 3px solid #e5e7eb;
+  border-left: 3px solid rgb(var(--color-line));
 }
 
 .history-item.current {
@@ -1350,7 +1350,7 @@ export default {
 
 .history-season {
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1367,7 +1367,7 @@ export default {
 
 .history-team {
   font-size: 14px;
-  color: #4b5563;
+  color: rgb(var(--color-fg-muted));
   margin-top: 4px;
 }
 
@@ -1381,14 +1381,14 @@ export default {
 .meta-tag {
   font-size: 11px;
   padding: 2px 8px;
-  background: #e5e7eb;
+  background: rgb(var(--color-surface-alt));
   border-radius: 4px;
-  color: #4b5563;
+  color: rgb(var(--color-fg-muted));
 }
 
 /* Stats Section */
 .stats-section {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 12px;
   padding: 20px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -1398,7 +1398,7 @@ export default {
 .stats-section h3 {
   font-size: 18px;
   font-weight: 600;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0 0 16px 0;
 }
 
@@ -1411,7 +1411,7 @@ export default {
 .stat-item {
   text-align: center;
   padding: 16px;
-  background: #f9fafb;
+  background: rgb(var(--color-surface-alt));
   border-radius: 8px;
 }
 
@@ -1422,7 +1422,7 @@ export default {
 .stat-value {
   font-size: 28px;
   font-weight: 700;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .stat-item.highlight .stat-value {
@@ -1431,7 +1431,7 @@ export default {
 
 .stat-label {
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-top: 4px;
   text-transform: uppercase;
 }
@@ -1447,7 +1447,7 @@ export default {
 
 .no-stats {
   text-align: center;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   padding: 20px;
 }
 
@@ -1457,7 +1457,7 @@ export default {
 
 .no-stats .hint {
   font-size: 12px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   margin-top: 8px;
 }
 
@@ -1476,7 +1476,7 @@ export default {
 }
 
 .no-team-card p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin: 0;
 }
 
@@ -1496,14 +1496,14 @@ export default {
 .editor-modal-content {
   width: 100%;
   max-width: 1000px;
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 16px;
 }
 
 .edit-info-modal {
   width: 100%;
   max-width: 480px;
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 16px;
   overflow: hidden;
 }
@@ -1513,20 +1513,20 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .modal-header h3 {
   margin: 0;
   font-size: 18px;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .close-btn {
   background: none;
   border: none;
   font-size: 24px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
 }
 
@@ -1542,13 +1542,13 @@ export default {
   display: block;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: rgb(var(--color-fg));
   margin-bottom: 6px;
 }
 
 .form-group .hint {
   font-weight: 400;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   font-size: 12px;
 }
 
@@ -1556,9 +1556,11 @@ export default {
 .form-group select {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   font-size: 14px;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .form-group input:focus,
@@ -1569,15 +1571,15 @@ export default {
 }
 
 .readonly-input {
-  background-color: #f3f4f6;
-  color: #6b7280;
+  background-color: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg-muted));
   cursor: not-allowed;
 }
 
 .field-hint {
   display: block;
   font-size: 11px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   margin-top: 4px;
 }
 
@@ -1596,12 +1598,12 @@ export default {
   align-items: center;
   gap: 12px;
   padding: 16px 20px;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid rgb(var(--color-line));
 }
 
 .saving {
   font-size: 14px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .done-btn {
@@ -1620,7 +1622,7 @@ export default {
 
 .loading {
   text-align: center;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   padding: 20px;
 }
 
@@ -1720,8 +1722,8 @@ export default {
 }
 
 .channel-item {
-  background: white;
-  border: 1px solid #e0f2fe;
+  background: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   padding: 14px;
 }
@@ -1736,7 +1738,7 @@ export default {
 .channel-name {
   font-weight: 600;
   font-size: 14px;
-  color: #1e293b;
+  color: rgb(var(--color-fg));
 }
 
 .channel-pill {
@@ -1765,13 +1767,13 @@ export default {
 
 .channel-handle {
   font-size: 13px;
-  color: #334155;
+  color: rgb(var(--color-fg));
   margin-bottom: 8px;
 }
 
 .channel-handle-missing {
   font-size: 12px;
-  color: #94a3b8;
+  color: rgb(var(--color-fg-muted));
   font-style: italic;
   margin-bottom: 8px;
 }
@@ -1785,14 +1787,14 @@ export default {
 .channel-input {
   flex: 1;
   padding: 6px 10px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   font-size: 13px;
 }
 
 .channel-input:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
+  background: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg-muted));
 }
 
 .request-access-btn {
@@ -1816,7 +1818,7 @@ export default {
 
 .channel-status-msg {
   font-size: 12px;
-  color: #64748b;
+  color: rgb(var(--color-fg-muted));
   margin: 6px 0 0;
   font-style: italic;
 }

--- a/frontend/src/components/profiles/PlayerProfileEditor.vue
+++ b/frontend/src/components/profiles/PlayerProfileEditor.vue
@@ -520,13 +520,13 @@ export default {
   align-items: center;
   margin-bottom: 20px;
   padding-bottom: 16px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .editor-header h2 {
   margin: 0;
   font-size: 24px;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .header-actions {
@@ -545,12 +545,12 @@ export default {
 }
 
 .btn-secondary {
-  background-color: #f3f4f6;
-  color: #374151;
+  background-color: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg));
 }
 
 .btn-secondary:hover {
-  background-color: #e5e7eb;
+  background-color: rgb(var(--color-line));
 }
 
 .btn-primary {
@@ -605,8 +605,8 @@ export default {
 }
 
 .preview-card {
-  background-color: #f8fafc;
-  border: 1px solid #e5e7eb;
+  background-color: rgb(var(--color-surface-alt));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 12px;
   padding: 20px;
 }
@@ -614,7 +614,7 @@ export default {
 .preview-card h3 {
   margin: 0 0 16px 0;
   font-size: 16px;
-  color: #374151;
+  color: rgb(var(--color-fg));
 }
 
 .preview-photo {
@@ -625,7 +625,7 @@ export default {
 
 .preview-hint {
   text-align: center;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 12px;
   margin: 12px 0 0 0;
 }
@@ -637,8 +637,8 @@ export default {
 }
 
 .settings-section {
-  background-color: white;
-  border: 1px solid #e5e7eb;
+  background-color: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 12px;
   padding: 20px;
 }
@@ -646,7 +646,7 @@ export default {
 .settings-section h3 {
   margin: 0 0 16px 0;
   font-size: 16px;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   font-weight: 600;
 }
 
@@ -668,7 +668,7 @@ export default {
   align-items: center;
   gap: 8px;
   padding: 16px 12px;
-  border: 2px solid #e5e7eb;
+  border: 2px solid rgb(var(--color-line));
   border-radius: 10px;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -691,7 +691,7 @@ export default {
 .style-label {
   font-size: 13px;
   font-weight: 500;
-  color: #374151;
+  color: rgb(var(--color-fg));
 }
 
 .sr-only {
@@ -707,7 +707,7 @@ export default {
 
 .color-help-text {
   font-size: 13px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin: 0 0 16px 0;
 }
 
@@ -764,15 +764,17 @@ export default {
 .form-group label {
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: rgb(var(--color-fg));
 }
 
 .form-input,
 .form-select {
   padding: 10px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   font-size: 14px;
+  background-color: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
   transition: border-color 0.15s ease;
 }
 
@@ -784,14 +786,14 @@ export default {
 }
 
 .form-input-readonly {
-  background-color: #f3f4f6;
-  color: #6b7280;
+  background-color: rgb(var(--color-surface-alt));
+  color: rgb(var(--color-fg-muted));
   cursor: not-allowed;
 }
 
 .field-hint {
   font-size: 12px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   margin-top: 4px;
 }
 
@@ -846,7 +848,7 @@ export default {
 
 .social-help-text {
   font-size: 13px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin: 0 0 16px 0;
 }
 

--- a/frontend/src/components/profiles/TeamManagerProfile.vue
+++ b/frontend/src/components/profiles/TeamManagerProfile.vue
@@ -462,7 +462,7 @@ export default {
 }
 
 .club-location {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-weight: 400;
   font-size: 0.9em;
 }
@@ -483,30 +483,32 @@ export default {
 }
 
 .team-selection-section {
-  background-color: #f0f9ff;
+  background-color: rgb(var(--color-surface-alt));
   padding: 20px;
   border-radius: 8px;
   margin-bottom: 20px;
-  border: 1px solid #bae6fd;
+  border: 1px solid rgb(var(--color-line));
 }
 
 .team-selector label {
   display: block;
   font-weight: 600;
   margin-bottom: 10px;
-  color: #1e40af;
+  color: rgb(var(--color-fg));
 }
 
 .team-select {
   width: 100%;
   padding: 10px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 4px;
   font-size: 14px;
+  background-color: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
 }
 
 .team-management {
-  background-color: #f8fafc;
+  background-color: rgb(var(--color-surface-alt));
   padding: 20px;
   border-radius: 8px;
   margin-bottom: 20px;
@@ -519,10 +521,10 @@ export default {
 }
 
 .management-card {
-  background: white;
+  background: rgb(var(--color-card));
   padding: 20px;
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
   cursor: pointer;
   transition: all 0.2s ease;
   text-align: center;
@@ -540,13 +542,13 @@ export default {
 }
 
 .management-card h4 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 10px 0 5px 0;
   font-size: 16px;
 }
 
 .management-card p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 14px;
   margin: 0 0 10px 0;
 }
@@ -559,8 +561,8 @@ export default {
 
 .players-section,
 .games-section {
-  background-color: #fff;
-  border: 1px solid #e5e7eb;
+  background-color: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   margin-bottom: 20px;
 }
@@ -570,14 +572,14 @@ export default {
   justify-content: space-between;
   align-items: center;
   padding: 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid rgb(var(--color-line));
 }
 
 .close-btn {
   background: none;
   border: none;
   font-size: 24px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   cursor: pointer;
   padding: 0;
   width: 30px;
@@ -601,9 +603,9 @@ export default {
   display: flex;
   align-items: center;
   padding: 15px;
-  background-color: #f9fafb;
+  background-color: rgb(var(--color-surface-alt));
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
 }
 
 .player-avatar {
@@ -625,11 +627,11 @@ export default {
 
 .player-details h4 {
   margin: 0 0 5px 0;
-  color: #1f2937;
+  color: rgb(var(--color-fg));
 }
 
 .player-email {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 14px;
   margin: 0 0 5px 0;
 }
@@ -662,15 +664,15 @@ export default {
   gap: 15px;
   align-items: center;
   padding: 15px;
-  background-color: #f9fafb;
+  background-color: rgb(var(--color-surface-alt));
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgb(var(--color-line));
   margin-bottom: 10px;
 }
 
 .game-date {
   font-weight: 600;
-  color: #374151;
+  color: rgb(var(--color-fg));
   font-size: 14px;
 }
 
@@ -681,7 +683,7 @@ export default {
 }
 
 .vs {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 12px;
 }
 
@@ -698,7 +700,7 @@ export default {
 .game-type {
   text-align: center;
   font-size: 12px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .team-stats {
@@ -721,7 +723,7 @@ export default {
 
 .stat-item {
   text-align: center;
-  background: white;
+  background: rgb(var(--color-card));
   padding: 15px;
   border-radius: 6px;
 }
@@ -734,7 +736,7 @@ export default {
 }
 
 .stat-label {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 12px;
   text-transform: uppercase;
 }
@@ -753,19 +755,19 @@ export default {
 }
 
 .no-team-message p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-bottom: 20px;
 }
 
 .contact-admin {
-  background: white;
+  background: rgb(var(--color-card));
   padding: 20px;
   border-radius: 6px;
   text-align: left;
 }
 
 .contact-admin ul {
-  color: #374151;
+  color: rgb(var(--color-fg));
   margin: 10px 0 0 20px;
 }
 

--- a/frontend/src/components/profiles/TeamRosterPage.vue
+++ b/frontend/src/components/profiles/TeamRosterPage.vue
@@ -425,13 +425,13 @@ export default {
   gap: 12px;
   margin-bottom: 16px;
   padding: 12px 16px;
-  background: #f9fafb;
+  background: rgb(var(--color-surface-alt));
   border-radius: 10px;
 }
 
 .dropdown-label {
   font-size: 14px;
-  color: #374151;
+  color: rgb(var(--color-fg));
   font-weight: 600;
   white-space: nowrap;
 }
@@ -439,10 +439,11 @@ export default {
 .club-teams-dropdown {
   flex: 1;
   padding: 10px 14px;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgb(var(--color-line));
   border-radius: 8px;
   font-size: 14px;
-  background: white;
+  background: rgb(var(--color-card));
+  color: rgb(var(--color-fg));
   cursor: pointer;
   min-width: 0;
 }
@@ -455,7 +456,7 @@ export default {
 
 .dropdown-hint {
   font-size: 12px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
   white-space: nowrap;
 }
 
@@ -466,7 +467,7 @@ export default {
   align-items: center;
   justify-content: center;
   padding: 48px 16px;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .loading-spinner {
@@ -510,7 +511,7 @@ export default {
 }
 
 .error-container p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin-bottom: 16px;
 }
 
@@ -681,7 +682,7 @@ export default {
   justify-content: center;
   padding: 48px 16px;
   text-align: center;
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
 }
 
 .empty-state.small {
@@ -691,7 +692,7 @@ export default {
 .empty-icon {
   width: 64px;
   height: 64px;
-  background-color: #f3f4f6;
+  background-color: rgb(var(--color-surface-alt));
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -702,20 +703,20 @@ export default {
 .empty-icon svg {
   width: 32px;
   height: 32px;
-  color: #9ca3af;
+  color: rgb(var(--color-fg-muted));
 }
 
 .empty-state p {
   margin: 0;
   font-size: 16px;
   font-weight: 500;
-  color: #4b5563;
+  color: rgb(var(--color-fg));
 }
 
 .empty-subtext {
   font-size: 14px !important;
   font-weight: 400 !important;
-  color: #9ca3af !important;
+  color: rgb(var(--color-fg-muted)) !important;
   margin-top: 8px !important;
 }
 

--- a/frontend/src/components/profiles/TeamRosterRouter.vue
+++ b/frontend/src/components/profiles/TeamRosterRouter.vue
@@ -149,7 +149,7 @@ export default {
 }
 
 .loading-state p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   font-size: 16px;
   margin: 0;
 }
@@ -163,7 +163,7 @@ export default {
   justify-content: center;
   padding: 60px 20px;
   text-align: center;
-  background-color: #f9fafb;
+  background-color: rgb(var(--color-surface-alt));
   border-radius: 12px;
   margin: 20px;
 }
@@ -188,7 +188,7 @@ export default {
 .not-authenticated h3,
 .not-player h3,
 .no-team h3 {
-  color: #1f2937;
+  color: rgb(var(--color-fg));
   margin: 0 0 12px 0;
   font-size: 20px;
   font-weight: 600;
@@ -197,7 +197,7 @@ export default {
 .not-authenticated p,
 .not-player p,
 .no-team p {
-  color: #6b7280;
+  color: rgb(var(--color-fg-muted));
   margin: 0;
   font-size: 15px;
 }
@@ -205,7 +205,7 @@ export default {
 .sub-text {
   margin-top: 8px !important;
   font-size: 14px !important;
-  color: #9ca3af !important;
+  color: rgb(var(--color-fg-muted)) !important;
 }
 
 .router-content {

--- a/frontend/src/components/roster/RosterManager.vue
+++ b/frontend/src/components/roster/RosterManager.vue
@@ -10,15 +10,11 @@
       data-testid="roster-manager"
     >
       <!-- Header -->
-      <div
-        class="p-4 border-b border-gray-200 flex justify-between items-center"
-      >
-        <h3 class="text-lg font-semibold text-gray-900">
-          Roster: {{ teamName }}
-        </h3>
+      <div class="p-4 border-b border-line flex justify-between items-center">
+        <h3 class="text-lg font-semibold text-fg">Roster: {{ teamName }}</h3>
         <button
           @click="$emit('close')"
-          class="text-gray-400 hover:text-gray-600"
+          class="text-fg-muted hover:text-fg"
           data-testid="close-roster-button"
         >
           <svg
@@ -38,11 +34,9 @@
       </div>
 
       <!-- Action Bar -->
-      <div
-        class="p-4 border-b border-gray-200 flex justify-between items-center"
-      >
+      <div class="p-4 border-b border-line flex justify-between items-center">
         <div class="flex items-center space-x-3">
-          <div class="text-sm text-gray-600">
+          <div class="text-sm text-fg-muted">
             {{ roster.length }} player{{ roster.length !== 1 ? 's' : '' }}
           </div>
           <!-- Bulk age-group assignment (SB-69): shows when rows are selected -->
@@ -51,12 +45,12 @@
             class="flex items-center space-x-2"
             data-testid="bulk-age-group-bar"
           >
-            <span class="text-sm text-gray-600"
+            <span class="text-sm text-fg-muted"
               >{{ selectedIds.length }} selected</span
             >
             <select
               v-model.number="bulkAgeGroupId"
-              class="px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+              class="px-2 py-1 text-sm bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
               data-testid="bulk-age-group-select"
             >
               <option :value="null" disabled>Age group…</option>
@@ -77,7 +71,7 @@
         <div class="flex space-x-2">
           <button
             @click="showBulkImportModal = true"
-            class="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+            class="px-3 py-1.5 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
             data-testid="bulk-import-button"
           >
             Bulk Import
@@ -115,7 +109,7 @@
       <!-- Empty State -->
       <div
         v-else-if="roster.length === 0"
-        class="p-8 text-center text-gray-500"
+        class="p-8 text-center text-fg-muted"
         data-testid="roster-empty"
       >
         <div class="text-4xl mb-2">👤</div>
@@ -125,52 +119,52 @@
 
       <!-- Roster Table -->
       <div v-else class="overflow-x-auto" data-testid="roster-table-container">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
+        <table class="min-w-full divide-y divide-line">
+          <thead class="bg-surface-alt">
             <tr>
               <th class="px-4 py-3 text-left w-10">
                 <input
                   type="checkbox"
                   :checked="allSelected"
                   @change="toggleSelectAll"
-                  class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                  class="rounded border-line text-brand-600 focus:ring-brand-500"
                   title="Select all"
                   data-testid="select-all-checkbox"
                 />
               </th>
               <th
-                class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-16"
+                class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-16"
               >
                 #
               </th>
               <th
-                class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Name
               </th>
               <th
-                class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-28"
+                class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-28"
               >
                 Age Group
               </th>
               <th
-                class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-20"
+                class="px-4 py-3 text-center text-xs font-medium text-fg-muted uppercase tracking-wider w-20"
               >
                 Account
               </th>
               <th
-                class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                class="px-4 py-3 text-left text-xs font-medium text-fg-muted uppercase tracking-wider"
               >
                 Positions
               </th>
               <th
-                class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-40"
+                class="px-4 py-3 text-right text-xs font-medium text-fg-muted uppercase tracking-wider w-40"
               >
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
+          <tbody class="bg-card divide-y divide-line">
             <tr
               v-for="player in roster"
               :key="player.id"
@@ -181,16 +175,14 @@
                   type="checkbox"
                   :value="player.id"
                   v-model="selectedIds"
-                  class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                  class="rounded border-line text-brand-600 focus:ring-brand-500"
                   :data-testid="`select-player-${player.id}`"
                 />
               </td>
-              <td
-                class="px-4 py-3 whitespace-nowrap text-sm font-bold text-gray-900"
-              >
+              <td class="px-4 py-3 whitespace-nowrap text-sm font-bold text-fg">
                 {{ player.jersey_number }}
               </td>
-              <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-fg">
                 {{ player.display_name }}
               </td>
               <!-- Age-group badge + inline single-row quick-assign (SB-69) -->
@@ -202,7 +194,7 @@
                   class="px-2 py-1 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   :class="
                     player.age_group_id
-                      ? 'border-gray-300 text-gray-900'
+                      ? 'border-line text-fg bg-card'
                       : 'border-amber-300 text-amber-700 bg-amber-50'
                   "
                   :data-testid="`row-age-group-${player.id}`"
@@ -221,14 +213,14 @@
                 >
                   ✓
                 </span>
-                <span v-else class="text-gray-300">—</span>
+                <span v-else class="text-fg-muted">—</span>
               </td>
-              <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-fg-muted">
                 <div class="flex flex-wrap gap-1">
                   <span
                     v-for="pos in player.positions || []"
                     :key="pos"
-                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800"
+                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-alt text-fg"
                   >
                     {{ pos }}
                   </span>
@@ -239,7 +231,7 @@
               >
                 <button
                   @click="openEditModal(player)"
-                  class="text-brand-600 hover:text-brand-900"
+                  class="text-brand-600 hover:text-brand-900 dark:text-brand-300 dark:hover:text-brand-200"
                   title="Edit name/positions"
                   data-testid="edit-player-button"
                 >
@@ -247,7 +239,7 @@
                 </button>
                 <button
                   @click="openChangeNumberModal(player)"
-                  class="text-gray-600 hover:text-gray-900"
+                  class="text-fg-muted hover:text-fg"
                   title="Change jersey number"
                   data-testid="change-number-button"
                 >
@@ -289,10 +281,10 @@
           data-testid="add-player-modal"
         >
           <div class="p-6">
-            <h4 class="text-lg font-medium text-gray-900 mb-4">Add Player</h4>
+            <h4 class="text-lg font-medium text-fg mb-4">Add Player</h4>
             <form @submit.prevent="addPlayer" data-testid="add-player-form">
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2">
+                <label class="block text-sm font-medium text-fg mb-2">
                   Jersey Number <span class="text-red-500">*</span>
                 </label>
                 <input
@@ -301,39 +293,39 @@
                   min="1"
                   max="99"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="1-99"
                   data-testid="jersey-number-input"
                 />
               </div>
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >First Name</label
                 >
                 <input
                   v-model="addForm.first_name"
                   type="text"
                   maxlength="100"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="Optional"
                   data-testid="first-name-input"
                 />
               </div>
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Last Name</label
                 >
                 <input
                   v-model="addForm.last_name"
                   type="text"
                   maxlength="100"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder="Optional"
                   data-testid="last-name-input"
                 />
               </div>
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Positions</label
                 >
                 <div class="flex flex-wrap gap-2">
@@ -346,9 +338,9 @@
                       type="checkbox"
                       :value="pos"
                       v-model="addForm.positions"
-                      class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                      class="rounded border-line text-brand-600 focus:ring-brand-500"
                     />
-                    <span class="ml-1 text-sm text-gray-700">{{ pos }}</span>
+                    <span class="ml-1 text-sm text-fg">{{ pos }}</span>
                   </label>
                 </div>
               </div>
@@ -356,7 +348,7 @@
                 <button
                   type="button"
                   @click="closeInnerModals"
-                  class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                  class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
                 >
                   Cancel
                 </button>
@@ -387,36 +379,36 @@
           data-testid="edit-player-modal"
         >
           <div class="p-6">
-            <h4 class="text-lg font-medium text-gray-900 mb-4">
+            <h4 class="text-lg font-medium text-fg mb-4">
               Edit Player #{{ editingPlayer?.jersey_number }}
             </h4>
             <form @submit.prevent="updatePlayer" data-testid="edit-player-form">
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >First Name</label
                 >
                 <input
                   v-model="editForm.first_name"
                   type="text"
                   maxlength="100"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   data-testid="edit-first-name-input"
                 />
               </div>
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Last Name</label
                 >
                 <input
                   v-model="editForm.last_name"
                   type="text"
                   maxlength="100"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   data-testid="edit-last-name-input"
                 />
               </div>
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2"
+                <label class="block text-sm font-medium text-fg mb-2"
                   >Positions</label
                 >
                 <div class="flex flex-wrap gap-2">
@@ -429,9 +421,9 @@
                       type="checkbox"
                       :value="pos"
                       v-model="editForm.positions"
-                      class="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                      class="rounded border-line text-brand-600 focus:ring-brand-500"
                     />
-                    <span class="ml-1 text-sm text-gray-700">{{ pos }}</span>
+                    <span class="ml-1 text-sm text-fg">{{ pos }}</span>
                   </label>
                 </div>
               </div>
@@ -439,7 +431,7 @@
                 <button
                   type="button"
                   @click="closeInnerModals"
-                  class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                  class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
                 >
                   Cancel
                 </button>
@@ -470,10 +462,10 @@
           data-testid="change-number-modal"
         >
           <div class="p-6">
-            <h4 class="text-lg font-medium text-gray-900 mb-4">
+            <h4 class="text-lg font-medium text-fg mb-4">
               Change Jersey Number
             </h4>
-            <p class="text-sm text-gray-600 mb-4">
+            <p class="text-sm text-fg-muted mb-4">
               Current: #{{ editingPlayer?.jersey_number }} ({{
                 editingPlayer?.display_name
               }})
@@ -483,7 +475,7 @@
               data-testid="change-number-form"
             >
               <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2">
+                <label class="block text-sm font-medium text-fg mb-2">
                   New Number <span class="text-red-500">*</span>
                 </label>
                 <input
@@ -492,7 +484,7 @@
                   min="1"
                   max="99"
                   required
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500"
                   data-testid="new-jersey-number-input"
                 />
               </div>
@@ -500,7 +492,7 @@
                 <button
                   type="button"
                   @click="closeInnerModals"
-                  class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                  class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
                 >
                   Cancel
                 </button>
@@ -531,10 +523,10 @@
           data-testid="bulk-import-modal"
         >
           <div class="p-6">
-            <h4 class="text-lg font-medium text-gray-900 mb-4">
+            <h4 class="text-lg font-medium text-fg mb-4">
               Bulk Import Players
             </h4>
-            <p class="text-sm text-gray-600 mb-4">
+            <p class="text-sm text-fg-muted mb-4">
               Enter jersey numbers, one per line. Players will be created with
               just the number.
             </p>
@@ -543,7 +535,7 @@
                 <textarea
                   v-model="bulkImportText"
                   rows="8"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 font-mono"
+                  class="w-full px-3 py-2 bg-card text-fg border border-line rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 font-mono"
                   placeholder="1&#10;7&#10;10&#10;11&#10;23"
                   data-testid="bulk-import-textarea"
                 ></textarea>
@@ -552,7 +544,7 @@
                 <button
                   type="button"
                   @click="closeInnerModals"
-                  class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                  class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
                 >
                   Cancel
                 </button>
@@ -584,16 +576,15 @@
         >
           <div class="p-6 text-center">
             <div class="text-4xl mb-4">✉️</div>
-            <h4 class="text-lg font-medium text-gray-900 mb-2">
-              Invite Created!
-            </h4>
-            <p class="text-sm text-gray-600 mb-4">
+            <h4 class="text-lg font-medium text-fg mb-2">Invite Created!</h4>
+            <p class="text-sm text-fg-muted mb-4">
               Share this code with #{{ invitePlayer?.jersey_number }}:
             </p>
-            <div class="bg-gray-100 rounded-lg p-4 mb-4">
-              <code class="text-lg font-mono font-bold text-brand-600">{{
-                inviteCode
-              }}</code>
+            <div class="bg-surface-alt rounded-lg p-4 mb-4">
+              <code
+                class="text-lg font-mono font-bold text-brand-600 dark:text-brand-300"
+                >{{ inviteCode }}</code
+              >
             </div>
             <button
               @click="copyInviteCode"
@@ -603,7 +594,7 @@
             </button>
             <button
               @click="closeInnerModals"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+              class="px-4 py-2 text-sm font-medium text-fg bg-surface-alt hover:bg-line rounded-md"
             >
               Close
             </button>
@@ -1068,7 +1059,7 @@ export default {
 }
 
 .modal-content {
-  background: white;
+  background: rgb(var(--color-card));
   border-radius: 8px;
   max-width: 800px;
   width: 95%;

--- a/frontend/src/components/shared/ClubLogo.vue
+++ b/frontend/src/components/shared/ClubLogo.vue
@@ -112,6 +112,6 @@ const imgClass = computed(() => {
 });
 
 const initialsClass = computed(() => {
-  return `${sizeConfig.value.text} font-bold text-slate-400`;
+  return `${sizeConfig.value.text} font-bold text-fg-muted`;
 });
 </script>


### PR DESCRIPTION
## Summary

Batch dark-mode migration of **49 view components** — completes the Midnight Amber dark-mode rollout (SB-144). Admin (all CRUD screens), profiles, live, tournaments, post-match, roster, plus Goals/QoP/MatchForm/MatchDetail/etc. Same semantic-token recipe proven on Table (SB-147) and Matches (SB-150); covers both Tailwind utility classes and scoped-CSS hardcoded light hexes.

## How it was run

Multi-agent workflow: one migrate agent per file + a verify agent reviewing each diff. The verify pass caught and reverted several **over-tokenized semantic status badges** (AdminUsers role pills, AdminChannelRequests, SupportInboxList, QoP qualification chip) and added a dark changelog-link override in WhatsNewView.

## Left untouched (by design)

Semantic status badges (green/red/yellow-100 + dark text), `bg-brand-50/100` chips & banners, self-contained dark chips, W/L/D result circles + win/loss arrows, and fixed-design colors (FormationField pitch green, player cards, IG share graphics).

## Verification

- `npm run lint` clean, `npm run test:run` 544/544 pass
- 4 files (RosterManager, AdminProfile, TeamManagerProfile, TeamRosterPage) skipped the agent verify stage on a spend cap — manually audited: no leftover light text, no over-tokenized badges, brand-600 hits are checkbox accents (fine)
- **Authed views can't render in the logged-out local preview — please eyeball each tab (Admin, Profile, Tournaments, Leaderboard, QoP, live) in dark + light after deploy.** Color-only changes, so risk is contrast/visual, not functional.

## Minor follow-ups flagged (out of scope)

A few `bg-brand-50/100` chips (age-group pills, playoff/championship chips) keep their light tint in dark mode — readable, polish later if desired.

Part of theming sub-epic SB-144. Fixes SB-151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)