### PR TITLE
feat(theme): dark-mode polish for native form controls (SB-160)

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -21,10 +21,31 @@
     --color-fg: 232 238 247;
     --color-fg-muted: 148 163 184;
     --color-line: 35 48 71;
+    /* Render native widgets (select popups, date/time pickers, scrollbars)
+       in dark — fixes white form controls that CSS can't reach (SB-160). */
+    color-scheme: dark;
   }
   body {
     background-color: rgb(var(--color-surface));
     color: rgb(var(--color-fg));
+  }
+  /* Global dark form-control polish: any select/input/textarea without an
+     explicit token bg (e.g. native selects defaulting to white) gets the
+     card surface + readable text/border in dark mode. */
+  .dark select,
+  .dark input,
+  .dark textarea {
+    background-color: rgb(var(--color-card));
+    color: rgb(var(--color-fg));
+    border-color: rgb(var(--color-line));
+  }
+  .dark select option {
+    background-color: rgb(var(--color-card));
+    color: rgb(var(--color-fg));
+  }
+  .dark input::placeholder,
+  .dark textarea::placeholder {
+    color: rgb(var(--color-fg-muted));
   }
 }
 


### PR DESCRIPTION
## Summary

Native `<select>` and date/time `<input>` controls rendered white in dark mode — browsers draw native widgets in light regardless of CSS. Most visible as the glaring white **Season dropdown** on Matches / Add Match.

One global fix in `style.css` under `.dark`:
- `color-scheme: dark` — native select popups, date/time pickers, and scrollbars now render dark
- global `.dark select/input/textarea` → `card` bg, `fg` text, `line` border; `option` → card/fg; placeholders → fg-muted

Fixes every form control across all views in one place — no per-component work.

## Verification

Verified in local preview (dark): `color-scheme` resolves to `dark`; a `<select>` and `<input>` compute `background-color: rgb(19,26,46)` (card) with light text. Lint clean, 544/544 tests.

Part of theming sub-epic SB-144. Fixes SB-160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)